### PR TITLE
UI polish: responsive HUD, queued toasts, closable sheets, visible zone painting

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,9 @@
   :root { --bg:#0d0f13; --fg:#e9f1ff; --muted:#9cb2cc; --panel:#141821; --panel-2:#1b2230; --accent:#7cc4ff; }
   html, body { margin:0; padding:0; height:100%; background:var(--bg); color:var(--fg); font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial; overflow:hidden; -webkit-tap-highlight-color: transparent; }
   #game { position:fixed; inset:0; width:100vw; height:100vh; background:#0a0c10; image-rendering:pixelated; image-rendering:crisp-edges; touch-action:none; display:block; }
-  .hud-top { position: fixed; left: 10px; right: 10px; top: 10px; display:flex; justify-content:space-between; align-items:center; gap:10px; pointer-events:none; }
+  .hud-top { position: fixed; left: 10px; right: 10px; top: max(10px, env(safe-area-inset-top)); display:flex; flex-wrap:wrap; justify-content:space-between; align-items:center; gap:10px; pointer-events:none; z-index:3000; }
+  .hud-top > * { pointer-events:auto; }
+  .hud-top .pill { max-width:100%; overflow:hidden; }
   .pill { pointer-events:auto; background: rgba(20,24,33,0.9); border:1px solid rgba(255,255,255,0.1); border-radius: 12px; padding: 8px 10px; display:flex; gap:12px; align-items:center; box-shadow: 0 4px 18px rgba(0,0,0,0.35); backdrop-filter: blur(6px); }
   .stat { font-weight:700; font-size:14px } .stat small { color: var(--muted); font-weight:600; margin-left:4px }
   .btn { pointer-events:auto; border:1px solid rgba(255,255,255,0.1); background: rgba(27,35,48,0.95); color:var(--fg); border-radius:10px; padding:8px 10px; font-weight:700; font-size:14px; }
@@ -17,16 +19,22 @@
   .bar { pointer-events:auto; background: rgba(27,35,48,0.9); border:1px solid rgba(255,255,255,0.1); border-radius:14px; padding:10px; display:grid; grid-template-columns: repeat(4, 1fr); gap:8px; }
   .chip { text-align:center; font-weight:700; font-size:13px; background: rgba(255,255,255,0.06); border:1px solid rgba(255,255,255,0.12); color:var(--fg); border-radius:10px; padding:8px 10px; user-select:none; }
   .chip[data-active="true"] { background: rgba(124,196,255,0.18); border-color: rgba(124,196,255,0.55); }
-  .sheet { position:fixed; left:0; right:0; bottom:0; transform: translateY(100%); transition: transform .2s ease; background: var(--panel-2); border-top:1px solid rgba(255,255,255,0.08); border-radius: 16px 16px 0 0; padding: 12px 12px calc(env(safe-area-inset-bottom) + 12px); max-height: 65vh; overflow:auto; box-shadow: 0 -12px 30px rgba(0,0,0,0.5); }
-  .sheet[data-open="true"] { transform: translateY(0) } .sheet h3 { margin: 6px 2px 10px; font-size: 16px; color: var(--muted); }
+  .sheet { position:fixed; left:0; right:0; bottom:0; transform: translateY(100%); transition: transform .2s ease; background: var(--panel-2); border-top:1px solid rgba(255,255,255,0.08); border-radius: 16px 16px 0 0; padding: 12px 12px calc(env(safe-area-inset-bottom) + 12px); max-height: 65vh; overflow:auto; box-shadow: 0 -12px 30px rgba(0,0,0,0.5); z-index:4000; }
+  .sheet[data-open="true"] { transform: translateY(0) }
+  .sheet h3 { margin: 6px 2px 10px; font-size: 16px; color: var(--muted); display:flex; justify-content:space-between; align-items:center; }
+  .sheet-close { border:1px solid rgba(255,255,255,0.12); background:rgba(255,255,255,0.06); color:var(--fg); border-radius:8px; padding:4px 8px; font-weight:700; }
   .grid { display:grid; grid-template-columns: repeat(4, 1fr); gap:8px }
   .tile { text-align:center; font-size:12px; padding:10px; background: rgba(255,255,255,0.06); border:1px solid rgba(255,255,255,0.12); border-radius:10px; user-select:none; }
   .slider { appearance:none; width:100%; height:8px; border-radius:999px; background:#2b3544; outline:none; }
   .slider::-webkit-slider-thumb { appearance:none; width:22px; height:22px; border-radius:50%; background: var(--accent); border: 2px solid rgba(255,255,255,0.35); box-shadow: 0 2px 6px rgba(0,0,0,0.45); }
-  .toast { position: fixed; left:50%; bottom:86px; transform: translateX(-50%) translateY(200%); transition: transform .25s ease; background: rgba(20,24,33,0.95); border:1px solid rgba(255,255,255,0.1); border-radius: 12px; padding: 10px 14px; pointer-events:none; font-weight:700; font-size:14px; }
-  .toast[data-show="true"] { transform: translateX(-50%) translateY(0) }
   #help { position: fixed; left: 12px; right: 12px; top: 12px; background: rgba(20,24,33,0.95); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; padding: 12px; font-size: 14px; line-height: 1.4; box-shadow: 0 10px 30px rgba(0,0,0,0.6); display: none; }
   #help button { margin-top: 8px }
+
+  @media (max-width: 480px) {
+    .hud-top { gap:8px; }
+    .pill { padding: 6px 8px; }
+    .hud-top .pill:nth-child(2) { margin-left:auto; }
+  }
 </style>
 </head>
 <body>
@@ -61,7 +69,7 @@
 </div>
 
 <div class="sheet" id="sheetZones">
-  <h3>Zones (pixel markers)</h3>
+  <h3>Zones (pixel markers) <button class="sheet-close" aria-label="Close">✕</button></h3>
   <div class="grid">
     <div class="tile" data-zone="farm">🌾 Farm</div>
     <div class="tile" data-zone="cut">🪓 Cut Trees</div>
@@ -73,7 +81,7 @@
 </div>
 
 <div class="sheet" id="sheetBuild">
-  <h3>Build</h3>
+  <h3>Build <button class="sheet-close" aria-label="Close">✕</button></h3>
   <div class="grid">
     <div class="tile" data-build="hut">🏚️ Hut (10 wood)</div>
     <div class="tile" data-build="storage">📦 Storage (8 wood)</div>
@@ -83,7 +91,7 @@
 </div>
 
 <div class="sheet" id="sheetPrior">
-  <h3>Village Priorities</h3>
+  <h3>Village Priorities <button class="sheet-close" aria-label="Close">✕</button></h3>
   <div style="display:flex; gap:10px">
     <div style="flex:1"><div style="font-weight:700;margin-bottom:4px">Food</div><input type="range" id="prioFood" class="slider" min="0" max="100" value="70"></div>
     <div style="flex:1"><div style="font-weight:700;margin-bottom:4px">Build</div><input type="range" id="prioBuild" class="slider" min="0" max="100" value="50"></div>
@@ -97,8 +105,6 @@
   - If you saw a blank screen previously, this build fixes camera scaling.<br/>
   <button class="btn" id="btnHelpClose">Got it</button>
 </div>
-
-<div class="toast" id="toast"></div>
 
 <script src="app.js?v=3.1" defer></script>
 <script>


### PR DESCRIPTION
## Summary
- Ensure top HUD pills wrap and respect safe areas on small screens
- Queue system messages at top with auto-dismiss toasts
- Make all bottom sheets closable and switchable without reload
- Add zone paint washes and live brush preview for immediate feedback

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2d1484f9c83249a10ed16316a45c5