### PR TITLE
Adjust screen-to-world conversion for canvas offset

### DIFF
--- a/app.js
+++ b/app.js
@@ -277,7 +277,12 @@ document.addEventListener('click', (e)=>{
 let drag={active:false,sx:0,sy:0,camx:0,camy:0};
 let pinch={active:false,startDist:0,startZ:0,midx:0,midy:0};
 
-function screenToWorld(px,py){ return { x: ((px*DPR) - cam.x) / (TILE*cam.z), y: ((py*DPR) - cam.y) / (TILE*cam.z) }; }
+function screenToWorld(px,py){
+  const rect = canvas.getBoundingClientRect();
+  const x = (((px - rect.left) * DPR) - cam.x) / (TILE*cam.z);
+  const y = (((py - rect.top) * DPR) - cam.y) / (TILE*cam.z);
+  return { x, y };
+}
 
 canvas.addEventListener('mousedown', (e)=>{
   drag.active=true; drag.sx=e.clientX; drag.sy=e.clientY; drag.camx=cam.x; drag.camy=cam.y;


### PR DESCRIPTION
## Summary
- account for canvas position when converting screen taps to world coordinates

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2e09b58008324ae3784871b4e1f40