### PR TITLE
Fix touch handling and zone painting efficiency

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,9 @@
   .bar { pointer-events:auto; background: rgba(27,35,48,0.9); border:1px solid rgba(255,255,255,0.1); border-radius:14px; padding:10px; display:grid; grid-template-columns: repeat(4, 1fr); gap:8px; }
   .chip { text-align:center; font-weight:700; font-size:13px; background: rgba(255,255,255,0.06); border:1px solid rgba(255,255,255,0.12); color:var(--fg); border-radius:10px; padding:8px 10px; user-select:none; }
   .chip[data-active="true"] { background: rgba(124,196,255,0.18); border-color: rgba(124,196,255,0.55); }
-  .sheet { position:fixed; left:0; right:0; bottom:0; transform: translateY(100%); transition: transform .2s ease; background: var(--panel-2); border-top:1px solid rgba(255,255,255,0.08); border-radius: 16px 16px 0 0; padding: 12px 12px calc(env(safe-area-inset-bottom) + 12px); max-height: 65vh; overflow:auto; box-shadow: 0 -12px 30px rgba(0,0,0,0.5); z-index:4000; }
-  .sheet[data-open="true"] { transform: translateY(0) }
+  /* Sheets shouldn’t intercept the map when closed */
+  .sheet { pointer-events:none; position:fixed; left:0; right:0; bottom:0; transform: translateY(100%); transition: transform .2s ease; background: var(--panel-2); border-top:1px solid rgba(255,255,255,0.08); border-radius: 16px 16px 0 0; padding: 12px 12px calc(env(safe-area-inset-bottom) + 12px); max-height: 65vh; overflow:auto; box-shadow: 0 -12px 30px rgba(0,0,0,0.5); z-index:4000; }
+  .sheet[data-open="true"] { pointer-events:auto; transform: translateY(0) }
   .sheet h3 { margin: 6px 2px 10px; font-size: 16px; color: var(--muted); display:flex; justify-content:space-between; align-items:center; }
   .sheet-close { border:1px solid rgba(255,255,255,0.12); background:rgba(255,255,255,0.06); color:var(--fg); border-radius:8px; padding:4px 8px; font-weight:700; }
   .grid { display:grid; grid-template-columns: repeat(4, 1fr); gap:8px }


### PR DESCRIPTION
## Summary
- Prevent hidden sheets from intercepting canvas touches
- Improve screen-to-world math for reliable interaction scaling
- Regenerate jobs only once per stroke while painting zones

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e9bb1ed483248b376c10b2dd0130