### PR TITLE
fix: use DPR for pointer scaling

### DIFF
--- a/app.js
+++ b/app.js
@@ -287,9 +287,8 @@ const setDbg = (s)=> dbg.textContent = s;
 
 function screenToWorld(px, py){
   const rect = canvas.getBoundingClientRect();
-  // Use the canvas's real backing scale to be robust to any CSS/DPR quirks
-  const sx = (px - rect.left) * (canvas.width  / rect.width);
-  const sy = (py - rect.top)  * (canvas.height / rect.height);
+  const sx = (px - rect.left) * DPR;
+  const sy = (py - rect.top)  * DPR;
   return {
     x: (sx + cam.x) / (TILE * cam.z),
     y: (sy + cam.y) / (TILE * cam.z)


### PR DESCRIPTION
## Summary
- use device pixel ratio in `screenToWorld` to map pointer coords

## Testing
- `node --check app.js`
- `node - <<'NODE'
const TILE=32;
let DPR=2;
const cam={x:1000,y:500,z:2};
const canvas={ getBoundingClientRect: () => ({ left:10, top:20}) };
function screenToWorld(px, py){
  const rect = canvas.getBoundingClientRect();
  const sx = (px - rect.left) * DPR;
  const sy = (py - rect.top) * DPR;
  return { x: (sx + cam.x) / (TILE * cam.z),
           y: (sy + cam.y) / (TILE * cam.z) };
}
console.log('top-left', screenToWorld(10,20));
console.log('far', screenToWorld(810,620));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b30bcebe688324afca7fdf968c826a