### PR TITLE
Fix coordinate scaling in screenToWorld

### DIFF
--- a/app.js
+++ b/app.js
@@ -287,8 +287,8 @@ const setDbg = (s)=> dbg.textContent = s;
 
 function screenToWorld(px, py){
   const rect = canvas.getBoundingClientRect();
-  const sx = (px - rect.left) * DPR;
-  const sy = (py - rect.top)  * DPR;
+  const sx = (px - rect.left) * (canvas.width  / rect.width);
+  const sy = (py - rect.top)  * (canvas.height / rect.height);
   return {
     x: (sx + cam.x) / (TILE * cam.z),
     y: (sy + cam.y) / (TILE * cam.z)


### PR DESCRIPTION
## Summary
- Calculate screen-to-world scaling from canvas dimensions instead of fixed DPR.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b31330ac448324a960181edca8c664