### PR TITLE
Use canvas bounding rect for resize

### DIFF
--- a/app.js
+++ b/app.js
@@ -91,10 +91,11 @@ const MIN_Z=1.2, MAX_Z=4.5;
 
 function resize(){
   DPR = Math.max(1, Math.min(3, window.devicePixelRatio || 1));
-  W = Math.floor(window.innerWidth * DPR);
-  H = Math.floor(window.innerHeight * DPR);
-  canvas.width = W; canvas.height = H;
-  canvas.style.width = '100vw'; canvas.style.height = '100vh';
+  const rect = canvas.getBoundingClientRect();
+  W = Math.floor(rect.width * DPR);
+  H = Math.floor(rect.height * DPR);
+  canvas.width = W;
+  canvas.height = H;
 }
 resize(); window.addEventListener('resize', resize);
 function clampCam(){


### PR DESCRIPTION
## Summary
- calculate drawing buffer size from canvas bounding rect for proper pointer scaling

## Testing
- `node --check app.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68b32090bc348324803611d47ed5c4b0