### PR TITLE
Use DPR for precise screen-to-world mapping

### DIFF
--- a/app.js
+++ b/app.js
@@ -287,9 +287,9 @@ document.body.appendChild(dbg);
 const setDbg = (s)=> dbg.textContent = s;
 
 function screenToWorld(px, py){
-  const rect = canvas.getBoundingClientRect();
-  const sx = (px - rect.left) * (canvas.width  / rect.width);
-  const sy = (py - rect.top)  * (canvas.height / rect.height);
+  const rect = canvas.getBoundingClientRect();       // CSS pixels
+  const sx = (px - rect.left) * DPR;                 // device pixels
+  const sy = (py - rect.top)  * DPR;
   return {
     x: (sx + cam.x) / (TILE * cam.z),
     y: (sy + cam.y) / (TILE * cam.z)


### PR DESCRIPTION
## Summary
- Convert pointer coordinates to device pixels using global DPR in `screenToWorld`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b338b78d5c83249ff4e0596fffb774