### PR TITLE
Preserve XMLHttpRequest static properties in debugkit wrapper

### DIFF
--- a/debugkit.js
+++ b/debugkit.js
@@ -1308,6 +1308,23 @@
       return xhr;
     }
     WrappedXHR.prototype = OriginalXHR.prototype;
+    try {
+      Object.getOwnPropertyNames(OriginalXHR).forEach(name => {
+        if (name === 'prototype' || name === 'name' || name === 'length') return;
+        const descriptor = Object.getOwnPropertyDescriptor(OriginalXHR, name);
+        if (descriptor) {
+          Object.defineProperty(WrappedXHR, name, descriptor);
+        }
+      });
+      if (Object.getOwnPropertySymbols) {
+        Object.getOwnPropertySymbols(OriginalXHR).forEach(symbol => {
+          const descriptor = Object.getOwnPropertyDescriptor(OriginalXHR, symbol);
+          if (descriptor) {
+            Object.defineProperty(WrappedXHR, symbol, descriptor);
+          }
+        });
+      }
+    } catch (err) {}
     win.XMLHttpRequest = WrappedXHR;
   }
 


### PR DESCRIPTION
## Summary
- copy static XMLHttpRequest properties from the original constructor to the debugkit wrapper to keep constants like DONE and OPENED available

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c86bbc4060832484f20998fe83f4c2