### PR TITLE
Load DebugKit before game script

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,8 @@
   <button class="btn" id="btnHelpClose">Got it</button>
 </div>
 
+<!-- Enable the DebugKit overlay by visiting the page with ?debug=1 or setting localStorage.debug to true. -->
+<script src="debugkit.js" defer></script>
 <script src="app.js?v=3.1" defer></script>
 <script>
   setTimeout(() => {


### PR DESCRIPTION
## Summary
- load DebugKit ahead of the main game bundle so it can hook into startup
- note how to enable the debug overlay via a query parameter or localStorage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8720060b88324b0e0cc8c40dc119f