### PR TITLE
Load DebugKit dynamically with CDN fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,77 @@
 </div>
 
 <!-- Enable the DebugKit overlay by visiting the page with ?debug=1 or setting localStorage.debug to true. -->
-<script src="debugkit.js" defer></script>
+<script>
+  (function () {
+    'use strict';
+    const params = new URLSearchParams(window.location.search || '');
+    let storageFlag = false;
+    try {
+      storageFlag = window.localStorage && window.localStorage.getItem('debug') === 'true';
+    } catch (err) {
+      storageFlag = false;
+    }
+    if (!(params.get('debug') === '1' || storageFlag)) {
+      return;
+    }
+    const sources = [
+      { url: 'debugkit.js', label: 'debugkit.js' },
+      { url: 'https://cdn.jsdelivr.net/gh/CigThePig/AI_Village@main/debugkit.js', label: 'debugkit.js?cdn' }
+    ];
+    const head = document.head || document.getElementsByTagName('head')[0] || document.body;
+
+    function fetchText(url) {
+      if (window.fetch) {
+        return fetch(url, { cache: 'no-store' }).then(function (resp) {
+          if (!resp.ok) {
+            throw new Error('HTTP ' + resp.status);
+          }
+          return resp.text();
+        });
+      }
+      return new Promise(function (resolve, reject) {
+        try {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', url, true);
+          xhr.overrideMimeType && xhr.overrideMimeType('text/plain');
+          xhr.onreadystatechange = function () {
+            if (xhr.readyState === 4) {
+              if (xhr.status >= 200 && xhr.status < 300) {
+                resolve(xhr.responseText);
+              } else {
+                reject(new Error('HTTP ' + xhr.status));
+              }
+            }
+          };
+          xhr.onerror = function () { reject(new Error('Network error')); };
+          xhr.send();
+        } catch (xhrErr) {
+          reject(xhrErr);
+        }
+      });
+    }
+
+    function loadFrom(index) {
+      if (index >= sources.length) {
+        return Promise.reject(new Error('All sources failed'));
+      }
+      const source = sources[index];
+      return fetchText(source.url).then(function (code) {
+        const script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.textContent = code + '\n//# sourceURL=' + source.label;
+        head.appendChild(script);
+      }).catch(function (err) {
+        console.warn('DebugKit load failed from', source.url, err);
+        return loadFrom(index + 1);
+      });
+    }
+
+    loadFrom(0).catch(function (err) {
+      console.warn('DebugKit overlay unavailable:', err);
+    });
+  })();
+</script>
 <script src="app.js?v=3.1" defer></script>
 <script>
   setTimeout(() => {


### PR DESCRIPTION
## Summary
- detect when the debug overlay should be enabled and programmatically fetch `debugkit.js`
- fall back to loading the script from jsDelivr when the GitHub Pages asset is missing, logging helpful warnings when both attempts fail

## Testing
- python - <<'PY'
import asyncio
from playwright.async_api import async_playwright

async def run():
    async with async_playwright() as p:
        browser = await p.chromium.launch()
        page = await browser.new_page()
        page.on('console', lambda msg: print('console:', msg.type, msg.text))
        page.on('pageerror', lambda exc: print('pageerror:', exc))
        await page.goto('http://127.0.0.1:8000/index.html?debug=1', wait_until='networkidle')
        await page.wait_for_timeout(3000)
        tray = await page.evaluate("!!document.querySelector('#dbgTray')")
        print('tray_present', tray)
        await browser.close()

asyncio.run(run())
PY
- python - <<'PY'
import asyncio
from playwright.async_api import async_playwright

async def run():
    async with async_playwright() as p:
        browser = await p.chromium.launch()
        page = await browser.new_page(ignore_https_errors=True)
        page.on('console', lambda msg: print('console:', msg.type, msg.text))
        page.on('pageerror', lambda exc: print('pageerror:', exc))
        await page.goto('http://127.0.0.1:8000/index.html?debug=1', wait_until='networkidle')
        await page.wait_for_timeout(4000)
        tray = await page.evaluate("!!document.querySelector('#dbgTray')")
        print('tray_present', tray)
        await browser.close()

asyncio.run(run())
PY

------
https://chatgpt.com/codex/tasks/task_e_68c888c6ff648324bdd47379ba68cfa4