### PR TITLE
Allow sow jobs on empty farmland

### DIFF
--- a/app.js
+++ b/app.js
@@ -957,7 +957,7 @@ function pickJobFor(v){
     const i=idx(j.x,j.y);
     if(j.type==='chop'&&world.trees[i]===0) continue;
     if(j.type==='mine'&&world.rocks[i]===0) continue;
-    if(j.type==='sow'&&world.tiles[i]===TILES.FARMLAND) continue;
+    if(j.type==='sow'&&world.growth[i]>0) continue;
     const d=Math.abs((v.x|0)-j.x)+Math.abs((v.y|0)-j.y);
     let prio=(j.prio||0.5);
     if(j.type==='build' && supplyStatus && !supplyStatus.fullyDelivered){


### PR DESCRIPTION
## Summary
- allow villagers to accept sow jobs whenever the farmland tile has no active crop growth

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68caa77d183c8324a4cad084a8fbe2ae