### PR TITLE
Add feature-flagged micro ground rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,31 @@ This repository hosts the static build of the AI Village pixel edition experienc
 * Visit the site with `?debug=1` appended to the URL (for example, <https://cigthepig.github.io/AI_Village/?debug=1>) or set `localStorage.debug` to `true` to enable the DebugKit overlay.
 * The overlay loads the `debugkit.js` script directly from the repository root. Any changes merged into `main` are automatically deployed with the workflow below, so the latest script is always available at <https://cigthepig.github.io/AI_Village/debugkit.js>.
 
+## Sub-tile ground helpers (feature flag via `?sub=`)
+
+Added constants:
+
+* `GROUND_SUBDIV`
+* `MICRO_W`
+* `MICRO_H`
+* `MICRO_PX`
+* `WATER_BLOCK_THRESHOLD`
+* `SHOW_MICRO_OVERLAY`
+
+Added functions:
+
+* `getQueryParam(name)`
+* `microIdx(tx, ty, sx, sy)`
+* `fillMicroTile(tx, ty, type)`
+* `syncMicroTileAt(tx, ty)`
+* `waterFractionAtTile(tx, ty)`
+* `rebuildMicroFromTiles()`
+* `carveRiversMicro(seed)`
+* `encodeGroundMicro(arr)`
+* `decodeGroundMicro(str)`
+* `groundImageForType(t)`
+* `drawMicroDebugOverlay(bounds)`
+
 ## GitHub Pages deployment
 
 A GitHub Actions workflow (`.github/workflows/deploy-pages.yml`) deploys the site automatically whenever changes land on `main`:


### PR DESCRIPTION
## Summary
- add query-parameter gated constants and helpers to manage micro-tile ground data alongside the existing coarse grid
- bake static ground and animated water using micro cells, including a debug overlay and partial-water handling for zoning and pathing
- persist micro ground arrays in save data while rebuilding from coarse tiles for legacy saves

## Testing
- No automated tests (not available)

------
https://chatgpt.com/codex/tasks/task_e_68caac62a0f48324a97c7eed52f9f9a4