### PR TITLE
Tune water generation defaults

### DIFF
--- a/worldgen/config.js
+++ b/worldgen/config.js
@@ -2,16 +2,16 @@ export const WORLDGEN_DEFAULTS = {
   heightScale: 0.010,
   moistureScale: 0.015,
   warpScale: 0.040,
-  water: { level: 0.32, minLakeSize: 12, maxLakeSize: 220 },
+  water: { level: 0.42, minLakeSize: 18, maxLakeSize: 650 },
   rivers: {
-    count: 2,
-    sourceMin: 0.66,
-    sourceSpacing: 24,
-    accumThreshold: 15,
-    meanderJitter: 0.20,
-    smoothIterations: 2,
-    maxWidth: 5,
-    widenK: 0.45
+    count: 4,
+    sourceMin: 0.58,
+    sourceSpacing: 16,
+    accumThreshold: 2,
+    meanderJitter: 0.32,
+    smoothIterations: 4,
+    maxWidth: 6,
+    widenK: 0.55
   },
   rock: {
     targetRatio: 0.06,


### PR DESCRIPTION
## Summary
- increase default lake threshold and size limits so lakes form larger basins
- adjust river defaults to spawn more, longer rivers with extra smoothing and width

## Testing
- node --input-type=module <<'EOF'
import { generateTerrain } from './worldgen/terrain.js';
import { WORLDGEN_DEFAULTS } from './worldgen/config.js';

const cfg = structuredClone(WORLDGEN_DEFAULTS);
const dims = { w: 192, h: 192 };
const originalLog = console.log;
const stats = [];
console.log = (...args) => {
  if (args[0] === '[worldgen]' && args[1]) stats.push(args[1]);
  return originalLog(...args);
};
for (let seed = 1; seed <= 20; seed++) {
  generateTerrain(seed, cfg, dims);
}
console.log = originalLog;
const waterAvg = stats.reduce((sum, s) => sum + s.coverage.water, 0) / stats.length;
const riverMedian = stats.reduce((sum, s) => sum + s.rivers.medianLength, 0) / stats.length;
const riverCountAvg = stats.reduce((sum, s) => sum + s.rivers.count, 0) / stats.length;
console.log('Average water coverage %', waterAvg);
console.log('Average river median length', riverMedian);
console.log('Average river count', riverCountAvg);
EOF

------
https://chatgpt.com/codex/tasks/task_e_68cc0401f4688324bf35e5d7e875f950