### PR TITLE
Add precomputed terrain hillshade with debug controls

### DIFF
--- a/worldgen/config.js
+++ b/worldgen/config.js
@@ -30,10 +30,7 @@ export const WORLDGEN_DEFAULTS = {
 };
 
 export const SHADING_DEFAULTS = {
-  enabled: true,
-  lightDir: [-1, -1],   // sun from NW (x,y); z inferred
-  intensity: 0.12,      // max ± brightness change (0.08–0.12 recommended)
-  ambient: 0.78,        // base light level (0..1)
-  gamma: 1.0,           // 1.0 = linear; 0.9 softens contrast
-  method: 'sobel'       // 'sobel' | 'simple'
+  mode: 'hillshade',
+  ambient: 0.78,
+  intensity: 0.22
 };


### PR DESCRIPTION
## Summary
- add exported shading helpers that proxy to runtime implementations for debug access
- precompute and cache hillshade during world generation and shade static terrain tiles using the cached values
- refine shading defaults and hillshade math while adding debug kit controls for mode and parameter adjustments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc5d973de08324b0760a5eb5a56d69