### PR TITLE
Ensure shading globals exist before boot

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,13 @@ export function setShadingParams(params = {}) {
   return setShadingParamsImpl(params);
 }
 
+if (typeof globalThis !== 'undefined') {
+  // Provide provisional globals so the debug overlay can bind immediately.
+  globalThis.setShadingMode = setShadingMode;
+  globalThis.setShadingParams = setShadingParams;
+  globalThis.SHADING_DEFAULTS = SHADING_DEFAULTS;
+}
+
 export function makeAltitudeShade(height, w, h, cfg = SHADING_DEFAULTS) {
   const size = w * h;
   const shade = new Float32Array(size);
@@ -475,10 +482,10 @@ function applyShadingParams({ ambient, intensity } = {}) {
 setShadingModeImpl = applyShadingMode;
 setShadingParamsImpl = applyShadingParams;
 
-if (typeof window !== 'undefined') {
-  window.setShadingMode = setShadingMode;
-  window.setShadingParams = setShadingParams;
-  window.SHADING_DEFAULTS = SHADING_DEFAULTS;
+if (typeof globalThis !== 'undefined') {
+  globalThis.setShadingMode = applyShadingMode;
+  globalThis.setShadingParams = applyShadingParams;
+  globalThis.SHADING_DEFAULTS = SHADING_DEFAULTS;
 }
 const BUILDINGS = {
   campfire: { label: 'Campfire', cost: 0, wood: 0, stone: 0 },


### PR DESCRIPTION
## Summary
- expose provisional shading functions and defaults on `globalThis` so the debug overlay can bind immediately
- replace the provisional globals with the real shading helpers once the world state is ready

## Testing
- Loaded `index.html?debug=1` locally and confirmed the debug overlay reports the shade mode and reacts to slider changes

------
https://chatgpt.com/codex/tasks/task_e_68cc77c182808324873c1e5bef0d23aa