### PR TITLE
Adjust hillshade shading slope scaling

### DIFF
--- a/app.js
+++ b/app.js
@@ -467,12 +467,15 @@ function applyShadingMode(mode) {
   markStaticDirty();
 }
 
-function applyShadingParams({ ambient, intensity } = {}) {
+function applyShadingParams({ ambient, intensity, slopeScale } = {}) {
   if (typeof ambient === 'number' && Number.isFinite(ambient)) {
     SHADING_DEFAULTS.ambient = clamp(ambient, 0, 1);
   }
   if (typeof intensity === 'number' && Number.isFinite(intensity)) {
     SHADING_DEFAULTS.intensity = clamp(intensity, 0, 1);
+  }
+  if (typeof slopeScale === 'number' && Number.isFinite(slopeScale)) {
+    SHADING_DEFAULTS.slopeScale = clamp(slopeScale, 0.1, 16);
   }
   if (!world || !world.aux || !world.aux.height) return;
   if (SHADING_DEFAULTS.mode === 'off') return;

--- a/worldgen/config.js
+++ b/worldgen/config.js
@@ -32,5 +32,6 @@ export const WORLDGEN_DEFAULTS = {
 export const SHADING_DEFAULTS = {
   mode: 'hillshade',
   ambient: 0.78,
-  intensity: 0.22
+  intensity: 0.22,
+  slopeScale: 4
 };

--- a/worldgen/terrain.js
+++ b/worldgen/terrain.js
@@ -1141,6 +1141,9 @@ export function makeHillshade(height, w, h, cfg = SHADING_DEFAULTS) {
 
   const ambient = clamp(typeof cfg?.ambient === 'number' ? cfg.ambient : SHADING_DEFAULTS.ambient, 0, 1);
   const intensity = clamp(typeof cfg?.intensity === 'number' ? cfg.intensity : SHADING_DEFAULTS.intensity, 0, 1);
+  let slopeScale = Number.isFinite(cfg?.slopeScale) ? cfg.slopeScale : SHADING_DEFAULTS.slopeScale;
+  if (!Number.isFinite(slopeScale)) slopeScale = 1;
+  if (slopeScale < 0.1) slopeScale = 0.1;
   shade.fill(ambient);
 
   if (w < 3 || h < 3) {
@@ -1155,7 +1158,7 @@ export function makeHillshade(height, w, h, cfg = SHADING_DEFAULTS) {
   ly /= ln;
   lz /= ln;
 
-  const normalZ = 4;
+  const normalZ = 1;
 
   for (let y = 1; y < h - 1; y++) {
     for (let x = 1; x < w - 1; x++) {
@@ -1171,8 +1174,8 @@ export function makeHillshade(height, w, h, cfg = SHADING_DEFAULTS) {
       const h21 = height[south];
       const h22 = height[south + 1];
 
-      const gx = (h02 + 2 * h12 + h22) - (h00 + 2 * h10 + h20);
-      const gy = (h20 + 2 * h21 + h22) - (h00 + 2 * h01 + h02);
+      const gx = ((h02 + 2 * h12 + h22) - (h00 + 2 * h10 + h20)) * slopeScale;
+      const gy = ((h20 + 2 * h21 + h22) - (h00 + 2 * h01 + h02)) * slopeScale;
 
       let nx = -gx;
       let ny = -gy;


### PR DESCRIPTION
## Summary
- reduce the implicit hillshade normal Z component and scale Sobel gradients by a configurable slope factor for better Lambert variation
- expose the new `slopeScale` control through `SHADING_DEFAULTS` and the debug kit so hillshade strength can be tuned live
- reuse the existing shading update flow so world hillshade is regenerated whenever shading parameters change

## Testing
- node --input-type=module <<'EOF'\nimport { generateTerrain, makeHillshade } from './worldgen/terrain.js';\nimport { WORLDGEN_DEFAULTS, SHADING_DEFAULTS } from './worldgen/config.js';\nconst dims = { w: 64, h: 64 };\nconst terrain = generateTerrain(12345, WORLDGEN_DEFAULTS, dims);\nconst shade = makeHillshade(terrain.aux.height, dims.w, dims.h, SHADING_DEFAULTS);\nlet min = Infinity, max = -Infinity;\nfor (const v of shade) {\n  if (v < min) min = v;\n  if (v > max) max = v;\n}\nconsole.log('range', min, max);\nEOF
- node --input-type=module <<'EOF'\nimport { generateTerrain, makeHillshade } from './worldgen/terrain.js';\nimport { WORLDGEN_DEFAULTS, SHADING_DEFAULTS } from './worldgen/config.js';\nconst dims = { w: 64, h: 64 };\nconst terrain = generateTerrain(2468, WORLDGEN_DEFAULTS, dims);\nconst shadeDefault = makeHillshade(terrain.aux.height, dims.w, dims.h, SHADING_DEFAULTS);\nconst customCfg = { ...SHADING_DEFAULTS, slopeScale: 2 };\nconst shadeCustom = makeHillshade(terrain.aux.height, dims.w, dims.h, customCfg);\nfunction range(arr) {\n  let min = Infinity, max = -Infinity;\n  for (const v of arr) {\n    if (v < min) min = v;\n    if (v > max) max = v;\n  }\n  return { min, max };\n}\nconsole.log('default', range(shadeDefault));\nconsole.log('custom', range(shadeCustom));\nEOF

------
https://chatgpt.com/codex/tasks/task_e_68cc87ffa5b08324bf2278b036b21539