### PR TITLE
Fix black screen by removing ESM dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
 <link rel="stylesheet" href="styles.css">
 <!-- Enable the DebugKit overlay by visiting the page with ?debug=1 or setting localStorage.debug to true. -->
 <script src="bootstrap.js" defer></script>
+<script src="worldgen/noise.js" defer></script>
+<script src="worldgen/config.js" defer></script>
+<script src="worldgen/terrain.js" defer></script>
 </head>
 <body>
 <canvas id="game"></canvas>
@@ -85,6 +88,6 @@
   <button class="btn" id="btnHelpClose">Got it</button>
 </div>
 
-<script type="module" src="app.js?v=3.1"></script>
+<script src="app.js?v=3.1" defer></script>
 </body>
 </html>

--- a/worldgen/config.js
+++ b/worldgen/config.js
@@ -1,37 +1,45 @@
-export const WORLDGEN_DEFAULTS = {
-  heightScale: 0.010,
-  moistureScale: 0.015,
-  warpScale: 0.040,
-  water: { level: 0.42, minLakeSize: 18, maxLakeSize: 650 },
-  rivers: {
-    count: 4,
-    sourceMin: 0.58,
-    sourceSpacing: 16,
-    accumThreshold: 2,
-    meanderJitter: 0.32,
-    smoothIterations: 4,
-    maxWidth: 6,
-    widenK: 0.55
-  },
-  rock: {
-    targetRatio: 0.06,
-    pOnRock: 0.70,
-    blobChance: 0.30,
-    ensureMinDeposits: 120
-  },
-  fertile: {
-    areaMin: 4,
-    areaMax: 50,
-    edgeFeather: 1,
-    berryBaseP: 0.06,
-    clusterCentersPer1k: 2.0,
-    clusterRadius: 4
-  }
-};
+;(function (global) {
+  'use strict';
 
-export const SHADING_DEFAULTS = {
-  mode: 'hillshade',
-  ambient: 0.78,
-  intensity: 0.22,
-  slopeScale: 4
-};
+  const WORLDGEN_DEFAULTS = {
+    heightScale: 0.010,
+    moistureScale: 0.015,
+    warpScale: 0.040,
+    water: { level: 0.42, minLakeSize: 18, maxLakeSize: 650 },
+    rivers: {
+      count: 4,
+      sourceMin: 0.58,
+      sourceSpacing: 16,
+      accumThreshold: 2,
+      meanderJitter: 0.32,
+      smoothIterations: 4,
+      maxWidth: 6,
+      widenK: 0.55
+    },
+    rock: {
+      targetRatio: 0.06,
+      pOnRock: 0.70,
+      blobChance: 0.30,
+      ensureMinDeposits: 120
+    },
+    fertile: {
+      areaMin: 4,
+      areaMax: 50,
+      edgeFeather: 1,
+      berryBaseP: 0.06,
+      clusterCentersPer1k: 2.0,
+      clusterRadius: 4
+    }
+  };
+
+  const SHADING_DEFAULTS = {
+    mode: 'hillshade',
+    ambient: 0.78,
+    intensity: 0.22,
+    slopeScale: 4
+  };
+
+  if (global && typeof global === 'object') {
+    global.AIV_CONFIG = { WORLDGEN_DEFAULTS, SHADING_DEFAULTS };
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : (typeof window !== 'undefined' ? window : this));

--- a/worldgen/noise.js
+++ b/worldgen/noise.js
@@ -1,92 +1,101 @@
-const TAU = Math.PI * 2;
+;(function (global) {
+  'use strict';
 
-export function mulberry32(seed) {
-  return function () {
-    let t = seed += 0x6D2B79F5;
-    t = Math.imul(t ^ t >>> 15, t | 1);
-    t ^= t + Math.imul(t ^ t >>> 7, t | 61);
-    return ((t ^ t >>> 14) >>> 0) / 4294967296;
-  };
-}
+  const TAU = Math.PI * 2;
 
-function buildTables(seed) {
-  const rng = mulberry32(seed >>> 0);
-  const permBase = new Uint8Array(256);
-  const gradients = new Float32Array(512);
-  for (let i = 0; i < 256; i++) {
-    permBase[i] = i;
-    const angle = rng() * TAU;
-    gradients[i * 2] = Math.cos(angle);
-    gradients[i * 2 + 1] = Math.sin(angle);
-  }
-  for (let i = 255; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
-    const tmp = permBase[i];
-    permBase[i] = permBase[j];
-    permBase[j] = tmp;
-  }
-  const perm = new Uint8Array(512);
-  for (let i = 0; i < 512; i++) {
-    perm[i] = permBase[i & 255];
-  }
-  return { perm, gradients };
-}
-
-function fade(t) {
-  return t * t * t * (t * (t * 6 - 15) + 10);
-}
-
-function lerp(a, b, t) {
-  return a + (b - a) * t;
-}
-
-function grad(hash, x, y, gradients) {
-  const idx = (hash & 255) << 1;
-  return gradients[idx] * x + gradients[idx + 1] * y;
-}
-
-export function makeNoise2D(seed) {
-  const { perm, gradients } = buildTables(seed >>> 0);
-
-  function noise2D(x, y) {
-    const X = Math.floor(x) & 255;
-    const Y = Math.floor(y) & 255;
-
-    const xf = x - Math.floor(x);
-    const yf = y - Math.floor(y);
-
-    const u = fade(xf);
-    const v = fade(yf);
-
-    const aa = perm[X] + Y;
-    const ab = aa + 1;
-    const ba = perm[X + 1] + Y;
-    const bb = ba + 1;
-
-    const gradAA = grad(perm[aa], xf, yf, gradients);
-    const gradBA = grad(perm[ba], xf - 1, yf, gradients);
-    const gradAB = grad(perm[ab], xf, yf - 1, gradients);
-    const gradBB = grad(perm[bb], xf - 1, yf - 1, gradients);
-
-    const x1 = lerp(gradAA, gradBA, u);
-    const x2 = lerp(gradAB, gradBB, u);
-    return lerp(x1, x2, v);
+  function mulberry32(seed) {
+    return function () {
+      let t = seed += 0x6D2B79F5;
+      t = Math.imul(t ^ t >>> 15, t | 1);
+      t ^= t + Math.imul(t ^ t >>> 7, t | 61);
+      return ((t ^ t >>> 14) >>> 0) / 4294967296;
+    };
   }
 
-  function fbm2D(x, y, scale, octaves, lacunarity, gain) {
-    let frequency = scale;
-    let amplitude = 1;
-    let sum = 0;
-    let norm = 0;
-    for (let i = 0; i < octaves; i++) {
-      sum += amplitude * noise2D(x * frequency, y * frequency);
-      norm += amplitude;
-      frequency *= lacunarity;
-      amplitude *= gain;
+  function buildTables(seed) {
+    const rng = mulberry32(seed >>> 0);
+    const permBase = new Uint8Array(256);
+    const gradients = new Float32Array(512);
+    for (let i = 0; i < 256; i++) {
+      permBase[i] = i;
+      const angle = rng() * TAU;
+      gradients[i * 2] = Math.cos(angle);
+      gradients[i * 2 + 1] = Math.sin(angle);
     }
-    if (norm === 0) return 0;
-    return sum / norm;
+    for (let i = 255; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      const tmp = permBase[i];
+      permBase[i] = permBase[j];
+      permBase[j] = tmp;
+    }
+    const perm = new Uint8Array(512);
+    for (let i = 0; i < 512; i++) {
+      perm[i] = permBase[i & 255];
+    }
+    return { perm, gradients };
   }
 
-  return { noise2D, fbm2D };
-}
+  function fade(t) {
+    return t * t * t * (t * (t * 6 - 15) + 10);
+  }
+
+  function lerp(a, b, t) {
+    return a + (b - a) * t;
+  }
+
+  function grad(hash, x, y, gradients) {
+    const idx = (hash & 255) << 1;
+    return gradients[idx] * x + gradients[idx + 1] * y;
+  }
+
+  function makeNoise2D(seed) {
+    const { perm, gradients } = buildTables(seed >>> 0);
+
+    function noise2D(x, y) {
+      const X = Math.floor(x) & 255;
+      const Y = Math.floor(y) & 255;
+
+      const xf = x - Math.floor(x);
+      const yf = y - Math.floor(y);
+
+      const u = fade(xf);
+      const v = fade(yf);
+
+      const aa = perm[X] + Y;
+      const ab = aa + 1;
+      const ba = perm[X + 1] + Y;
+      const bb = ba + 1;
+
+      const gradAA = grad(perm[aa], xf, yf, gradients);
+      const gradBA = grad(perm[ba], xf - 1, yf, gradients);
+      const gradAB = grad(perm[ab], xf, yf - 1, gradients);
+      const gradBB = grad(perm[bb], xf - 1, yf - 1, gradients);
+
+      const x1 = lerp(gradAA, gradBA, u);
+      const x2 = lerp(gradAB, gradBB, u);
+      return lerp(x1, x2, v);
+    }
+
+    function fbm2D(x, y, scale, octaves, lacunarity, gain) {
+      let frequency = scale;
+      let amplitude = 1;
+      let sum = 0;
+      let norm = 0;
+      for (let i = 0; i < octaves; i++) {
+        sum += amplitude * noise2D(x * frequency, y * frequency);
+        norm += amplitude;
+        frequency *= lacunarity;
+        amplitude *= gain;
+      }
+      if (norm === 0) return 0;
+      return sum / norm;
+    }
+
+    return { noise2D, fbm2D };
+  }
+
+  const api = { mulberry32, makeNoise2D };
+  if (global && typeof global === 'object') {
+    global.AIV_NOISE = api;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : (typeof window !== 'undefined' ? window : this));


### PR DESCRIPTION
## Summary
- replace ES module imports/exports with global bridges so the app can run in environments that refuse to parse `export` syntax
- expose the terrain, noise, and config helpers on `window` and update the app to consume them via a shared AIV scope
- adjust the HTML boot sequence to load the helper scripts before the main app and keep DebugKit integrations intact

## Testing
- python -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68cdd8a4bb908324a02f7a1406c6e265