### PR TITLE
Switch to ES module bootstrap with centralized state

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,6 @@
   <button class="btn" id="btnHelpClose">Got it</button>
 </div>
 
-<script src="app.js?v=3.1" defer></script>
+<script type="module" src="/src/main.js"></script>
 </body>
 </html>

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,9 @@
+export const TILE_SIZE = 16;
+export const ENTITY_TILE_SIZE = 32;
+export const GRID_WIDTH = 192;
+export const GRID_HEIGHT = 192;
+export const SPEED_OPTIONS = [0.5, 1, 2, 4];
+export const CAMERA_MIN_Z = 1.2;
+export const CAMERA_MAX_Z = 4.5;
+export const DAY_LENGTH = 60 * 40;
+export const LAYER_ORDER = Object.freeze(['terrain', 'water', 'entities', 'ui']);

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,60 @@
+const GLOBAL_SCOPE = typeof globalThis !== 'undefined' ? globalThis : (typeof window !== 'undefined' ? window : this);
+
+function hasWorldgenDependencies() {
+  return Boolean(
+    GLOBAL_SCOPE &&
+    GLOBAL_SCOPE.AIV_TERRAIN &&
+    GLOBAL_SCOPE.AIV_CONFIG &&
+    typeof GLOBAL_SCOPE.AIV_TERRAIN.generateTerrain === 'function' &&
+    typeof GLOBAL_SCOPE.AIV_TERRAIN.makeHillshade === 'function'
+  );
+}
+
+function waitForDocumentReady() {
+  if (typeof document === 'undefined') {
+    return Promise.resolve();
+  }
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    document.addEventListener('DOMContentLoaded', resolve, { once: true });
+  });
+}
+
+async function waitForDependencies() {
+  await waitForDocumentReady();
+  if (hasWorldgenDependencies()) {
+    return;
+  }
+  await new Promise((resolve) => {
+    const maxAttempts = 300;
+    let attempts = 0;
+    const interval = setInterval(() => {
+      attempts++;
+      if (hasWorldgenDependencies() || attempts >= maxAttempts) {
+        clearInterval(interval);
+        resolve();
+      }
+    }, 10);
+  });
+}
+
+(async function bootstrap() {
+  try {
+    await waitForDependencies();
+    const module = await import('./app.js');
+    if (module && typeof module.bootGame === 'function') {
+      module.bootGame();
+    }
+  } catch (err) {
+    console.error('AI Village failed to start', err);
+    if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE.reportFatal === 'function') {
+      try {
+        GLOBAL_SCOPE.reportFatal(err);
+      } catch (reportErr) {
+        console.error('AI Village fallback fatal reporter failed', reportErr);
+      }
+    }
+  }
+})();

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,54 @@
+export function createInitialState({ seed, cfg } = {}) {
+  const baseSeed = Number.isFinite(seed) ? seed >>> 0 : (Date.now() | 0);
+  const config = cfg && typeof cfg === 'object' ? cfg : {};
+
+  const unitsConfig = config.units && typeof config.units === 'object' ? config.units : {};
+  const stocksConfig = config.stocks && typeof config.stocks === 'object' ? config.stocks : {};
+  const queueConfig = config.queue && typeof config.queue === 'object' ? config.queue : {};
+  const populationConfig = config.population && typeof config.population === 'object' ? config.population : {};
+
+  const units = {
+    buildings: Array.isArray(unitsConfig.buildings) ? unitsConfig.buildings.slice() : [],
+    villagers: Array.isArray(unitsConfig.villagers) ? unitsConfig.villagers.slice() : [],
+    jobs: Array.isArray(unitsConfig.jobs) ? unitsConfig.jobs.slice() : [],
+    itemsOnGround: Array.isArray(unitsConfig.itemsOnGround) ? unitsConfig.itemsOnGround.slice() : []
+  };
+
+  const timeDefaults = {
+    tick: 0,
+    paused: false,
+    speedIdx: 1,
+    dayTime: 0
+  };
+  const time = Object.assign({}, timeDefaults, config.time && typeof config.time === 'object' ? config.time : {});
+
+  const rng = {
+    seed: baseSeed,
+    generator: typeof (config.rng && config.rng.generator) === 'function' ? config.rng.generator : Math.random
+  };
+
+  const stocks = {
+    totals: Object.assign({ food: 0, wood: 0, stone: 0 }, stocksConfig.totals),
+    reserved: Object.assign({ food: 0, wood: 0, stone: 0 }, stocksConfig.reserved)
+  };
+
+  const queue = {
+    villagerLabels: Array.isArray(queueConfig.villagerLabels) ? queueConfig.villagerLabels.slice() : []
+  };
+
+  const population = {
+    priorities: Object.assign({ food: 0.7, build: 0.5, explore: 0.3 }, populationConfig.priorities)
+  };
+
+  const initialWorld = config.world && typeof config.world === 'object' ? config.world : null;
+
+  return {
+    world: initialWorld,
+    units,
+    time,
+    rng,
+    stocks,
+    queue,
+    population
+  };
+}


### PR DESCRIPTION
## Summary
- convert the game bootstrap to ES modules by loading `src/main.js` from the page
- add `createInitialState` so world, unit, and timing data live in one exported state object
- pull core tuning constants into `src/config.js`, including the layer ordering metadata

## Testing
- node --check src/app.js
- node --check src/main.js
- node --check src/state.js
- node --check src/config.js

------
https://chatgpt.com/codex/tasks/task_e_68cebb5824a08324ba8d50643e554dea