### PR TITLE
Introduce policy, blackboard, and centralized job scoring

### DIFF
--- a/src/ai/blackboard.js
+++ b/src/ai/blackboard.js
@@ -1,0 +1,73 @@
+const HUNGER_THRESHOLDS = Object.freeze({
+  hungry: 0.78,
+  starving: 1.02
+});
+
+const FARM_JOB_TYPES = new Set(['sow', 'harvest']);
+const BUILD_JOB_TYPES = new Set(['build']);
+
+function coalesceNumber(value, fallback = 0) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function countVillagerNeeds(villagers) {
+  let hungry = 0;
+  let starving = 0;
+  for (const villager of villagers) {
+    if (!villager) continue;
+    const hunger = coalesceNumber(villager.hunger, 0);
+    const condition = villager.condition;
+    if (hunger > HUNGER_THRESHOLDS.starving || condition === 'starving' || condition === 'sick') {
+      starving++;
+    } else if (hunger > HUNGER_THRESHOLDS.hungry || condition === 'hungry') {
+      hungry++;
+    }
+  }
+  return { hungry, starving };
+}
+
+function availableResource(totals, reserved, key) {
+  const total = coalesceNumber(totals?.[key], 0);
+  const res = coalesceNumber(reserved?.[key], 0);
+  return Math.max(0, total - res);
+}
+
+function inspectJobs(jobs) {
+  let buildPush = false;
+  let growthPush = false;
+  for (const job of jobs) {
+    if (!job || typeof job.type !== 'string') continue;
+    if (!buildPush && BUILD_JOB_TYPES.has(job.type) && job.waitingForMaterials !== true) {
+      buildPush = true;
+    }
+    if (!growthPush && FARM_JOB_TYPES.has(job.type)) {
+      growthPush = true;
+    }
+    if (buildPush && growthPush) break;
+  }
+  return { buildPush, growthPush };
+}
+
+export function computeBlackboard(state) {
+  const villagers = Array.isArray(state?.units?.villagers) ? state.units.villagers : [];
+  const jobs = Array.isArray(state?.units?.jobs) ? state.units.jobs : [];
+  const totals = state?.stocks?.totals || null;
+  const reserved = state?.stocks?.reserved || null;
+  const tick = coalesceNumber(state?.time?.tick, 0);
+
+  const { hungry, starving } = countVillagerNeeds(villagers);
+  const availableFood = availableResource(totals, reserved, 'food');
+  const famine = starving > 0 || availableFood <= Math.max(0, villagers.length - hungry);
+  const { buildPush, growthPush } = inspectJobs(jobs);
+
+  return {
+    tick,
+    villagers: villagers.length,
+    availableFood,
+    hungryVillagers: hungry,
+    starvingVillagers: starving,
+    famine,
+    buildPush,
+    growthPush
+  };
+}

--- a/src/ai/scoring.js
+++ b/src/ai/scoring.js
@@ -1,0 +1,88 @@
+const HEAVY_JOB_TYPES = new Set(['chop', 'mine', 'build', 'haul']);
+const NURTURE_JOB_TYPES = new Set(['sow', 'harvest']);
+const FARM_JOB_TYPES = new Set(['sow', 'harvest']);
+
+function clamp(value, min, max) {
+  if (!Number.isFinite(value)) {
+    return value > max ? max : min;
+  }
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function getStyle(policy) {
+  return policy?.style?.jobScoring || {};
+}
+
+function getCaps(policy) {
+  return policy?.caps || {};
+}
+
+export function score(job, villager, policy, blackboard) {
+  if (!job || !villager || !policy) {
+    return -Infinity;
+  }
+
+  const style = getStyle(policy);
+  const caps = getCaps(policy);
+
+  const defaultPriority = Number.isFinite(style.defaultPriority) ? style.defaultPriority : 0.5;
+  const distanceFalloff = Number.isFinite(style.distanceFalloff) ? style.distanceFalloff : 0;
+  const baseMoodWeight = Number.isFinite(style.baseMoodWeight) ? style.baseMoodWeight : 0;
+  const heavyRoleMoodWeight = Number.isFinite(style.heavyRoleMoodWeight) ? style.heavyRoleMoodWeight : 0;
+  const nurtureRoleMoodWeight = Number.isFinite(style.nurtureRoleMoodWeight) ? style.nurtureRoleMoodWeight : 0;
+  const priorityMoodWeight = Number.isFinite(style.priorityMoodWeight) ? style.priorityMoodWeight : 0;
+  const lowPriorityBaseline = Number.isFinite(style.lowPriorityBaseline) ? style.lowPriorityBaseline : 0.7;
+  const farmerRoleBonus = Number.isFinite(style.farmerRoleBonus) ? style.farmerRoleBonus : 0;
+  const workerRoleBonus = Number.isFinite(style.workerRoleBonus) ? style.workerRoleBonus : 0;
+  const hungerFarmThreshold = Number.isFinite(style.hungerFarmThreshold) ? style.hungerFarmThreshold : Infinity;
+  const hungerFarmBonus = Number.isFinite(style.hungerFarmBonus) ? style.hungerFarmBonus : 0;
+
+  const rawPriority = Number.isFinite(job.prio) ? job.prio : defaultPriority;
+  let effectivePriority = rawPriority;
+
+  if (job.type === 'build' && job.supply && job.supply.fullyDelivered === false) {
+    const cap = typeof caps.buildWaiting === 'function'
+      ? caps.buildWaiting(policy, job, villager, blackboard)
+      : null;
+    if (Number.isFinite(cap) && cap < effectivePriority) {
+      effectivePriority = cap;
+    }
+  }
+
+  const distance = Number.isFinite(job.distance) ? job.distance : 0;
+  let value = effectivePriority - distance * distanceFalloff;
+
+  const happy = Number.isFinite(villager.happy) ? villager.happy : 0.5;
+  const mood = clamp((happy - 0.5) * 2, -1, 1);
+
+  value += mood * baseMoodWeight;
+  if (HEAVY_JOB_TYPES.has(job.type)) {
+    value += mood * heavyRoleMoodWeight;
+  } else if (NURTURE_JOB_TYPES.has(job.type)) {
+    value += mood * nurtureRoleMoodWeight;
+  }
+
+  if (priorityMoodWeight !== 0) {
+    if (mood >= 0) {
+      value += mood * (effectivePriority * priorityMoodWeight);
+    } else {
+      value += mood * ((lowPriorityBaseline - effectivePriority) * priorityMoodWeight);
+    }
+  }
+
+  if (villager.role === 'farmer' && FARM_JOB_TYPES.has(job.type)) {
+    value += farmerRoleBonus;
+  }
+  if (villager.role === 'worker' && HEAVY_JOB_TYPES.has(job.type)) {
+    value += workerRoleBonus;
+  }
+
+  const hunger = Number.isFinite(villager.hunger) ? villager.hunger : 0;
+  if (hunger > hungerFarmThreshold && FARM_JOB_TYPES.has(job.type)) {
+    value += hungerFarmBonus;
+  }
+
+  return value;
+}

--- a/src/policy/policy.js
+++ b/src/policy/policy.js
@@ -1,0 +1,66 @@
+const DEFAULT_SLIDERS = Object.freeze({
+  food: 0.7,
+  build: 0.5,
+  explore: 0.3
+});
+
+const DEFAULT_MOOD_TARGETS = Object.freeze({
+  upbeat: 0.8,
+  cheerful: 0.65,
+  lowSpirits: 0.35,
+  miserable: 0.2
+});
+
+const TICKS_PER_SECOND = 6;
+const DEFAULT_MINUTES = 60;
+
+const DEFAULT_JOB_STYLE = Object.freeze({
+  defaultPriority: 0.5,
+  distanceFalloff: 0.01,
+  baseMoodWeight: 0.04,
+  heavyRoleMoodWeight: 0.04,
+  nurtureRoleMoodWeight: 0.02,
+  priorityMoodWeight: 0.03,
+  lowPriorityBaseline: 0.7,
+  farmerRoleBonus: 0.08,
+  workerRoleBonus: 0.06,
+  hungerFarmThreshold: 0.6,
+  hungerFarmBonus: 0.03,
+  minPickScore: 0
+});
+
+export const policy = {
+  state: null,
+  sliders: { ...DEFAULT_SLIDERS },
+  attach(state) {
+    this.state = state || null;
+    const fromState = state?.population?.priorities;
+    if (fromState && typeof fromState === 'object') {
+      this.sliders = fromState;
+    } else {
+      this.sliders = { ...DEFAULT_SLIDERS };
+    }
+    return this;
+  },
+  caps: {
+    buildWaiting(policyRef = null) {
+      const source = (policyRef || policy).sliders;
+      const buildValue = typeof source?.build === 'number' ? source.build : DEFAULT_SLIDERS.build;
+      return 0.5 + buildValue * 0.35;
+    }
+  },
+  routine: {
+    jobGenerationTickInterval: 20,
+    seasonTickInterval: 10,
+    blackboardCadenceTicks: 30,
+    ticksPerSecond: TICKS_PER_SECOND,
+    blackboardLogging: {
+      enabled: false,
+      intervalTicks: TICKS_PER_SECOND * DEFAULT_MINUTES
+    }
+  },
+  moodTargets: { ...DEFAULT_MOOD_TARGETS },
+  style: {
+    jobScoring: { ...DEFAULT_JOB_STYLE }
+  }
+};

--- a/src/state.js
+++ b/src/state.js
@@ -49,6 +49,7 @@ export function createInitialState({ seed, cfg } = {}) {
     rng,
     stocks,
     queue,
-    population
+    population,
+    bb: null
   };
 }


### PR DESCRIPTION
## Summary
- add a dedicated policy module for sliders, caps, routines, mood targets, and job style weights
- centralize derived state in a reusable blackboard and refresh it on a regular cadence with optional logging
- refactor job generation and selection to rely on policy data and a pure scoring helper while keeping behavior unchanged

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cec248e8848324814e704e95d88322