### PR TITLE
Fix hillshade build for new worlds

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1044,8 +1044,9 @@ function newWorld(seed=Date.now()|0){
     staticAlbedoCtx: null,
     emitters: []
   };
+  buildHillshadeQ(nextWorld);
+  world = nextWorld;
   gameState.world = nextWorld;
-  buildHillshadeQ(world);
   waterRowMask = new Uint8Array(GRID_H);
   zoneRowMask = new Uint8Array(GRID_H);
   world.zone.fill(0);


### PR DESCRIPTION
## Summary
- build the hillshade queue for the freshly constructed world object
- update the module-scoped world reference before continuing game initialization

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ced5acff7c8324979f995d6d021f29