### PR TITLE
Fix RNG generator redeclaration preventing game boot

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -679,7 +679,7 @@ Object.defineProperties(time, {
 let lastBlackboardTick = tick;
 let lastBlackboardLogTick = tick;
 
-let R = typeof rng.generator === 'function' ? rng.generator : Math.random;
+R = typeof rng.generator === 'function' ? rng.generator : Math.random;
 Object.defineProperty(rng, 'generator', {
   configurable: true,
   enumerable: true,


### PR DESCRIPTION
## Summary
- reuse the existing RNG helper instead of redeclaring it so module evaluation succeeds and the game boots again

## Testing
- Playwright smoke test loading http://127.0.0.1:8000/index.html

------
https://chatgpt.com/codex/tasks/task_e_68cf0b635b4083249e8025c6faa6fb31