### PR TITLE
Audit fixes: security, AI scoring correctness, save/load hardening

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,228 @@
+# AI_Village Repo Audit — Deferred Work
+
+This document captures issues identified during a repository-wide audit (April 2026)
+that were **not** fixed in the same change. Each entry has a file:line pointer and
+a brief description of the problem and a suggested fix direction.
+
+The companion change in this commit landed targeted, surgical fixes for the highest-
+impact, lowest-risk items: the jsdelivr CDN fallback in `public/bootstrap.js`,
+a `clamp()` correctness bug in `src/ai/scoring.js`, a `FARM_JOB_TYPES` mismatch
+between `src/ai/blackboard.js` and `src/ai/scoring.js`, a signature mismatch in
+`policy.caps.buildWaiting`, hardening of `loadGame()` array normalization in
+`src/app.js`, and a strict-equality cleanup in `public/debugkit.js`.
+
+Severity is the auditor's estimate of impact, not user-reported priority.
+
+---
+
+## Critical — boot, runtime, lifecycle
+
+### `src/app.js` is a 5,840-line monolith
+- **Where**: `src/app.js` (entire file)
+- **Problem**: One module contains terrain rendering, simulation, pathfinding,
+  AI tick, job system, save/load, UI event handlers, lighting, and boot. ~220
+  function definitions inline; module-local convenience bindings (`buildings`,
+  `villagers`, `jobs`, `animals`, `world`, …) at lines 185–252 lock a particular
+  layout in place.
+- **Why it matters**: Almost every other item in this document (lifecycle,
+  state sync, listener leaks) is a symptom of this. Until the file is split,
+  every change risks unintended cross-cutting effects.
+- **Suggested**: Carve out `src/app/render.js`, `src/app/simulation.js`,
+  `src/app/save.js`, `src/app/ui.js`, `src/app/pathfinding.js` first — each
+  with explicit imports/exports against `gameState`. No behavior change in the
+  first pass; just relocations and module boundaries.
+
+### No teardown for `newWorld()` — listener leak
+- **Where**:
+  - `src/app.js:1634-1761` (UI buttons, document-level click, canvas pointer/wheel,
+    window keydown, slider inputs)
+  - `src/app/canvas.js:79` (`window.addEventListener('resize', resize)`)
+  - `src/app/storage.js:178,182` (`window` `error` and `unhandledrejection`)
+- **Problem**: Listeners are registered at module-load time and never removed.
+  `newWorld()` (`src/app.js:1061`) replaces world state but does not unsubscribe
+  anything; repeated `🗺️ New` clicks accumulate references through closures over
+  the previous world.
+- **Suggested**: Centralize listener registration in a `bind()` / `unbind()` pair;
+  call `unbind()` at the start of `newWorld()`. For listeners that are truly
+  module-lifetime (e.g. `resize`), keep them but document the intent.
+
+### State mutation interleaved with render
+- **Where**: `update()` in `src/app.js` (around line 5733) calls
+  `villagerTick()`, which mutates `storageTotals`, `storageReserved`,
+  `villagers`, etc., during the same RAF callback that calls `render()`.
+  `saveGame()` (`src/app.js:4475`) reads these fields without any
+  synchronization.
+- **Problem**: A save triggered mid-tick (button or auto-save) snapshots
+  inconsistent state — e.g. resource debited from `storageReserved` but the
+  receiving job not yet updated. Subtle, intermittent corruption on reload.
+- **Suggested**: Split simulation tick from render. Either run simulation in a
+  fixed-timestep loop with a frozen snapshot for save, or queue saves to fire
+  between ticks.
+
+### Stale module-local bindings after `newWorld()`
+- **Where**: `src/app.js:185-252`. Lines 186-189 capture references to
+  `units.buildings`, `units.villagers`, etc. Line 252 captures `world`.
+- **Problem**: `newWorld()` reassigns `gameState.world` (around line 1110 the
+  audit traced) and rebuilds the `units.*` arrays, but the module-local `let`s
+  go on referencing the prior objects. Anything outside `newWorld()` that uses
+  these locals is operating on stale data after the swap.
+- **Suggested**: Either freeze these as `gameState.world.tiles` accessors at
+  call sites, or have `newWorld()` mutate the existing arrays in place
+  (`array.length = 0; array.push(...newItems)`) instead of replacing them.
+  Auditing every callsite is a prerequisite to either path.
+
+---
+
+## High — data integrity
+
+### Save schema migration framework absent
+- **Where**: `src/app.js:4476` (`SAVE_VERSION` exists; only one branch:
+  coarse-vs-full tile data)
+- **Problem**: When saved fields are added, removed, or renamed, the load path
+  silently degrades — added fields default to `0`/`''`, removed fields are
+  dropped, renames lose data entirely.
+- **Suggested**: Introduce a `migrations: Map<number, (data)=>data>` table; run
+  migrations sequentially when `data.saveVersion < SAVE_VERSION`. Even an empty
+  table establishes the pattern.
+
+### Lazy villager Maps not hydrated on load
+- **Where**: `src/app.js` references `v._wanderFailures` and `v._forageFailures`
+  (created on demand around lines 3616 and 3702). `loadGame()` (line 4516)
+  rebuilds villagers without these fields.
+- **Problem**: First access path checks `if (!v._wanderFailures) v._wanderFailures = new Map()`,
+  so it works — but if a future code path does `v._wanderFailures.get(...)`
+  without the guard, loaded villagers throw.
+- **Suggested**: Initialize both as `new Map()` in the load path and at villager
+  spawn, then drop the lazy-init guards.
+
+### Item tile index rebuild gated incorrectly
+- **Where**: `src/app.js:208` (`itemTileIndexDirty`); rebuild gate inside
+  `villagerTick()` near line 5781.
+- **Problem**: The audit observed the rebuild only triggers when a villager has
+  no inventory. Items dropped or picked up by a villager *with* inventory leave
+  the index stale until somebody else hits the empty-inventory branch.
+- **Suggested**: Move the rebuild check to the beginning of the tick loop and
+  trigger it whenever `itemTileIndexDirty` is true, independent of villager
+  inventory state. Verify no callers rely on the current ordering.
+
+---
+
+## High — boot / integration
+
+### Race between `<script defer>` worldgen and ES-module boot
+- **Where**: `index.html:9-12` loads `bootstrap.js` and `worldgen/*.js` as
+  classic deferred scripts; line 63 loads `./src/main.js` as a module.
+  `src/main.js:25-46` polls every 10 ms for up to 3 s for
+  `window.AIV_TERRAIN`/`AIV_CONFIG` to appear.
+- **Problem**: Polling masks the fact that there is no causal ordering guarantee
+  between deferred scripts and module evaluation. On slow devices the timeout
+  fires and boot dies silently.
+- **Suggested**: Have `worldgen/terrain.js` resolve a `window.AIV_TERRAIN_READY`
+  promise (created up-front in `bootstrap.js`); have `main.js` `await` that
+  promise rather than polling.
+
+### Two independent boot timeouts
+- **Where**: `public/bootstrap.js:87-95` (4 s "JS NOT RUNNING" timer) and
+  `src/main.js:25-46` (3 s dependency timeout).
+- **Problem**: The 3 s timeout in `main.js` can reject before the 4 s message in
+  `bootstrap.js` fires; the user sees nothing for 3 s, then "JS NOT RUNNING"
+  one second later — confusing if the actual failure was a missed module load.
+- **Suggested**: Single source of truth: have `main.js` flip a flag; the
+  bootstrap timer should only show its message if neither boot success nor
+  boot failure has been recorded.
+
+### `index.html` `<script>` tags depend on Vite `base` accidentally
+- **Where**: `index.html:9-12` references `bootstrap.js` and `worldgen/*.js`
+  with relative URLs that happen to resolve correctly in both `dev` (`base=/`)
+  and prod (`base=/AI_Village/`).
+- **Problem**: This works today because the scripts have no internal asset
+  references. As soon as one tries to `fetch()` or `<img src="">` something
+  relative, the path breaks in one of the two contexts.
+- **Suggested**: Document the constraint at the top of each `public/`
+  script, or move the bootstrap into a module so Vite handles base rewrites.
+
+---
+
+## Medium
+
+### Pointer state race in `endPointer()`
+- **Where**: `src/app.js:1735-1738` (approx). `endPointer` clears
+  `primaryPointer` without verifying `activePointers.size` first; a
+  `pointerleave` followed by `pointerup` for the same pointer can desync state.
+- **Suggested**: Only clear `primaryPointer` when the leaving pointer matches.
+
+### Canvas / lightmap context leak on world swap
+- **Where**: `src/app/canvas.js:63` (`ctx` is a module-level singleton);
+  `src/app.js:632` reassigns `world.lightmapCtx` on `newWorld()`.
+- **Problem**: The previous offscreen canvas + context can be GCed only after
+  every closure that captured them releases its reference. Listener leaks
+  (above) keep them pinned.
+- **Suggested**: Tied to the `newWorld()` teardown work above; explicitly
+  detach old contexts and release sources.
+
+### `dayTime` shadowed
+- **Where**: `src/app.js:264-267` extracts `dayTime` from `time.dayTime`; line
+  ~451 overwrites it without ever reading the prior value.
+- **Suggested**: Drop the line 264-267 extraction.
+
+### `policy.attach()` fails silently
+- **Where**: `src/policy/policy.js:137-144`.
+- **Problem**: When `state.population.priorities` is malformed (non-object), it
+  silently falls back to `DEFAULT_SLIDERS` — debugging a missing slider becomes
+  a guessing game.
+- **Suggested**: `console.warn` on the fallback.
+
+### Redundant `computeFamineSeverity()`
+- **Where**: `src/ai/scoring.js:208,236` (computes the same value twice within
+  the same `score()` call).
+- **Suggested**: Compute once and reuse.
+
+### `inspectJobs` overlaps with policy
+- **Where**: `src/ai/blackboard.js:85-99` checks `job.waitingForMaterials`,
+  duplicating logic that `policy.caps.buildWaiting` exists to encode.
+- **Suggested**: Unify the two; either feed `buildPush` from the cap or remove
+  the cap.
+
+### Unused exports in `src/app.js`
+- **Where**: Trailing exports `shadeFillColorLit`, `applySpriteShadeLit`,
+  `ambientAt`, `buildHillshadeQ`, `buildLightmap`, `sampleLightAt` (around
+  line 5840).
+- **Problem**: No internal caller; only `AIV_APP` global exposes them.
+- **Suggested**: Either drop the exports or document they are part of an
+  intended public debug surface.
+
+---
+
+## Low
+
+### No lint / format / typecheck pipeline
+- `package.json` has only `dev`, `build`, `preview`. No `eslint`, `prettier`,
+  `tsc --noEmit`. Many of the issues above (loose equality, dead variables,
+  unused exports) would have been caught.
+- **Suggested**: Add `eslint` with the recommended JS config and a `lint`
+  script.
+
+### `.gpagesignore` is unused
+- The deploy workflow uploads `dist/`, not the repo root, so `.gpagesignore`
+  has no consumer. The file lists `node_modules/`, `.gitignore`, `.github/`,
+  `README.md`.
+- **Suggested**: Delete the file, or rewrite the workflow to use it
+  (probably not worth it given Vite already produces `dist/`).
+
+### `README.md` describes the deploy inaccurately
+- The README says the workflow "uploads the repository contents (excluding
+  files listed in `.gpagesignore`)" — but the workflow runs `npm run build` and
+  uploads `dist/`. Update the README to match reality.
+
+### Loose typing of seed in `loadGame`
+- `newWorld(d.seed)` is called without validating `d.seed` is a finite number;
+  a corrupt save with `seed: "abc"` would propagate. Worth a `Number.isFinite`
+  guard.
+
+---
+
+## Notes
+
+The audit did not run automated tests because none exist. Adding even a
+smoke-test (`vitest` + a single "boot the world headless" assertion) would
+remove a lot of risk from the deferred items above.

--- a/public/bootstrap.js
+++ b/public/bootstrap.js
@@ -13,8 +13,7 @@ console.log('AIV: HTML parsed v3.1');
     return;
   }
   const sources = [
-    { url: 'debugkit.js', label: 'debugkit.js' },
-    { url: 'https://cdn.jsdelivr.net/gh/CigThePig/AI_Village@main/public/debugkit.js', label: 'debugkit.js?cdn' }
+    { url: 'debugkit.js', label: 'debugkit.js' }
   ];
   const head = document.head || document.getElementsByTagName('head')[0] || document.body;
 

--- a/public/debugkit.js
+++ b/public/debugkit.js
@@ -1,8 +1,8 @@
 (function () {
   const DEBUG = (() => {
-    const qsDebug = new URLSearchParams(location.search).get('debug') == '1';
+    const qsDebug = new URLSearchParams(location.search).get('debug') === '1';
     try {
-      return qsDebug || localStorage.getItem('debug') == 'true';
+      return qsDebug || localStorage.getItem('debug') === 'true';
     } catch (err) {
       return qsDebug;
     }

--- a/src/ai/blackboard.js
+++ b/src/ai/blackboard.js
@@ -7,7 +7,7 @@ const DEFAULT_HUNGER_THRESHOLDS = Object.freeze({
   coldSeasonTightening: 0.05
 });
 
-const FARM_JOB_TYPES = new Set(['sow', 'harvest']);
+const FARM_JOB_TYPES = new Set(['sow', 'harvest', 'forage']);
 const BUILD_JOB_TYPES = new Set(['build']);
 const DEFAULT_FATIGUE_THRESHOLD = 0.32;
 

--- a/src/ai/scoring.js
+++ b/src/ai/scoring.js
@@ -18,9 +18,7 @@ const JOB_EXPERIENCE_MAP = Object.freeze({
 const EXPERIENCE_THRESHOLDS = [0, 10, 30, 60];
 
 function clamp(value, min, max) {
-  if (!Number.isFinite(value)) {
-    return value > max ? max : min;
-  }
+  if (!Number.isFinite(value)) return min;
   if (value < min) return min;
   if (value > max) return max;
   return value;

--- a/src/app.js
+++ b/src/app.js
@@ -4473,13 +4473,40 @@ function seasonTick(){
 
 /* ==================== Save/Load ==================== */
 function saveGame(){ const data={ saveVersion:SAVE_VERSION, seed:world.seed, tiles:Array.from(world.tiles), zone:Array.from(world.zone), trees:Array.from(world.trees), rocks:Array.from(world.rocks), berries:Array.from(world.berries), growth:Array.from(world.growth), season:world.season, tSeason:world.tSeason, buildings, storageTotals, storageReserved, villagers: villagers.map(v=>({id:v.id,x:v.x,y:v.y,h:v.hunger,e:v.energy,ha:v.happy,hy:v.hydration||0, hb:v.hydrationBuffTicks||0,nhy:v.nextHydrateTick||0,hs:v.socialTimer||0,nso:v.nextSocialTick||0,role:v.role,cond:v.condition||'normal',ss:v.starveStage||0,ns:v.nextStarveWarning||0,sk:v.sickTimer||0,rc:v.recoveryTimer||0,fs:v.farmingSkill||0,cs:v.constructionSkill||0,age:v.ageTicks||0,stage:v.lifeStage||'adult',preg:v.pregnancyTimer||0,ct:v.childhoodTimer||0,par:Array.isArray(v.parents)?v.parents:[],mate:v.pregnancyMateId||null,sit:v.storageIdleTimer||0,nsi:v.nextStorageIdleTick||0,ab:v.activeBuildingId||null,bw:v.equippedBow?1:0,num:ensureVillagerNumber(v),xp:normalizeExperienceLedger(v.experience)})), animals: animals.map(a=>({id:a.id,type:a.type,x:a.x,y:a.y,dir:a.dir||'right',state:a.state||'idle',na:a.nextActionTick||0,phase:a.idlePhase||0,nv:a.nextVillageTick||0,ng:a.nextGrazeTick||0,flee:a.fleeTicks||0})) }; Storage.set(SAVE_KEY, JSON.stringify(data)); }
-function loadGame(){ try{ const raw=Storage.get(SAVE_KEY); if(!raw) return false; const d=JSON.parse(raw); const version=typeof d.saveVersion==='number'?d.saveVersion|0:0; const tileData=normalizeArraySource(d.tiles); const isCoarseSave=version < SAVE_VERSION && tileData.length===COARSE_SAVE_SIZE*COARSE_SAVE_SIZE; const factorCandidate=isCoarseSave?Math.floor(GRID_W/COARSE_SAVE_SIZE):1; const factorY=isCoarseSave?Math.floor(GRID_H/COARSE_SAVE_SIZE):1; const upscaleFactor=(factorCandidate>1&&factorCandidate===factorY)?factorCandidate:1; newWorld(d.seed);
-  applyArrayScaled(world.tiles, d.tiles, upscaleFactor, 0);
-  applyArrayScaled(world.zone, d.zone, upscaleFactor, ZONES.NONE);
-  applyArrayScaled(world.trees, d.trees, upscaleFactor, 0);
-  applyArrayScaled(world.rocks, d.rocks, upscaleFactor, 0);
-  applyArrayScaled(world.berries, d.berries, upscaleFactor, 0);
-  applyArrayScaled(world.growth, d.growth, upscaleFactor, 0);
+function loadGame(){ try{ const raw=Storage.get(SAVE_KEY); if(!raw) return false; const d=JSON.parse(raw); const version=typeof d.saveVersion==='number'?d.saveVersion|0:0;
+  const tileData=normalizeArraySource(d.tiles);
+  const zoneData=normalizeArraySource(d.zone);
+  const treeData=normalizeArraySource(d.trees);
+  const rockData=normalizeArraySource(d.rocks);
+  const berryData=normalizeArraySource(d.berries);
+  const growthData=normalizeArraySource(d.growth);
+  const coarseLen=COARSE_SAVE_SIZE*COARSE_SAVE_SIZE;
+  const fullLen=GRID_W*GRID_H;
+  const isCoarseSave=version < SAVE_VERSION && tileData.length===coarseLen;
+  const factorCandidate=isCoarseSave?Math.floor(GRID_W/COARSE_SAVE_SIZE):1;
+  const factorY=isCoarseSave?Math.floor(GRID_H/COARSE_SAVE_SIZE):1;
+  const upscaleFactor=(factorCandidate>1&&factorCandidate===factorY)?factorCandidate:1;
+  const expectedLen=upscaleFactor>1?coarseLen:fullLen;
+  const layerSources=[
+    ['tiles', tileData],
+    ['zone', zoneData],
+    ['trees', treeData],
+    ['rocks', rockData],
+    ['berries', berryData],
+    ['growth', growthData]
+  ];
+  for(const [name, arr] of layerSources){
+    if(arr.length!==0 && arr.length!==expectedLen){
+      console.warn('AIV loadGame: '+name+' layer length '+arr.length+' does not match expected '+expectedLen+' (upscaleFactor='+upscaleFactor+')');
+    }
+  }
+  newWorld(d.seed);
+  applyArrayScaled(world.tiles, tileData, upscaleFactor, 0);
+  applyArrayScaled(world.zone, zoneData, upscaleFactor, ZONES.NONE);
+  applyArrayScaled(world.trees, treeData, upscaleFactor, 0);
+  applyArrayScaled(world.rocks, rockData, upscaleFactor, 0);
+  applyArrayScaled(world.berries, berryData, upscaleFactor, 0);
+  applyArrayScaled(world.growth, growthData, upscaleFactor, 0);
   if(typeof d.season==='number') world.season=d.season;
   if(typeof d.tSeason==='number') world.tSeason=d.tSeason;
   refreshWaterRowMaskFromTiles();

--- a/src/policy/policy.js
+++ b/src/policy/policy.js
@@ -145,7 +145,7 @@ export const policy = {
     return this;
   },
   caps: {
-    buildWaiting(policyRef = null) {
+    buildWaiting(policyRef = null, _job = null, _villager = null, _blackboard = null) {
       const source = (policyRef || policy).sliders;
       const buildValue = typeof source?.build === 'number' ? source.build : DEFAULT_SLIDERS.build;
       return 0.5 + buildValue * 0.35;


### PR DESCRIPTION
Surgical fixes from a repo-wide audit. Larger structural items (app.js
monolith, listener lifecycle, save migration framework, etc.) are
documented in the new AUDIT.md.

- public/bootstrap.js: drop the jsdelivr CDN fallback for debugkit so
  enabling debug mode can no longer pull arbitrary remote code into the
  page.
- src/ai/scoring.js: fix clamp() so non-finite values (NaN/Infinity)
  return min instead of always falling through the broken
  value > max comparison; matches the existing blackboard.js helper.
- src/ai/blackboard.js: add 'forage' to FARM_JOB_TYPES so growthPush
  triggers when foragers are working, matching scoring.js' set.
- src/policy/policy.js: align caps.buildWaiting() signature with the
  call site in scoring.js (4 args), so reviewers see the contract.
- src/app.js: in loadGame(), normalize all six terrain layer arrays up
  front, validate each against the chosen upscale factor, and pass the
  normalized references through to applyArrayScaled to prevent silent
  scale-mismatch corruption.
- public/debugkit.js: use === for the debug-flag checks instead of ==.
- AUDIT.md: enumerate deferred issues with file:line pointers and
  severity (monolith refactor, listener teardown, save migrations,
  boot-time race, pointer state race, etc.).

https://claude.ai/code/session_01MAJ7Q1UUcoq2B48SsdzMV7