### PR TITLE
Fuse villager loops in update() and ungate item-index rebuild

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -5859,7 +5859,6 @@ function update(){
       planBuildings(gameState.bb);
       lastBuildPlanTick=tick;
     }
-    rebuildItemTileIndex();
     updateAnimals();
     updateNocturnalEntities(ambientNow);
     for(const v of villagers){
@@ -5872,8 +5871,8 @@ function update(){
           if(it){ v.inv={type:it.type,qty:it.qty}; removeItemAtIndex(itemIndex); }
         }
       }
+      villagerTick(v);
     }
-    for(const v of villagers){ villagerTick(v); }
     flushPendingBirths();
   }
   render();

--- a/src/app.js
+++ b/src/app.js
@@ -1676,16 +1676,29 @@ function zoneHasWorkNow(z, i){
 
 function toggleSheet(id, open){ const el=document.getElementById(id); if(!el) return; el.setAttribute('data-open', open?'true':'false'); }
 
-const btnSave=el('btnSave');
+const uiRefs = {
+  btnPause: el('btnPause'),
+  btnSpeed: el('btnSpeed'),
+  btnPrior: el('btnPrior'),
+  btnSave: el('btnSave'),
+  btnNew: el('btnNew'),
+  btnHelpClose: el('btnHelpClose'),
+  help: el('help'),
+  sheetPrior: el('sheetPrior'),
+  prioFood: el('prioFood'),
+  prioBuild: el('prioBuild'),
+  prioExplore: el('prioExplore')
+};
+const btnSave = uiRefs.btnSave;
 if(!Storage.available){ btnSave.disabled=true; btnSave.title='Saving unavailable in this context'; }
 
 /* Named handlers — required so removeEventListener can match the same reference */
-function onPauseClick(){ paused=!paused; el('btnPause').textContent=paused?'▶️':'⏸'; }
-function onSpeedClick(){ speedIdx=(speedIdx+1)%SPEEDS.length; el('btnSpeed').textContent=SPEEDS[speedIdx]+'×'; }
-function onPriorClick(){ const sheet=document.getElementById('sheetPrior'); const open=sheet.getAttribute('data-open')==='true'; toggleSheet('sheetPrior',!open); }
+function onPauseClick(){ paused=!paused; uiRefs.btnPause.textContent=paused?'▶️':'⏸'; }
+function onSpeedClick(){ speedIdx=(speedIdx+1)%SPEEDS.length; uiRefs.btnSpeed.textContent=SPEEDS[speedIdx]+'×'; }
+function onPriorClick(){ const open=uiRefs.sheetPrior.getAttribute('data-open')==='true'; toggleSheet('sheetPrior',!open); }
 function onSaveClick(){ if(!Storage.available){ Toast.show('Saving disabled in this context'); return; } saveGame(); Toast.show('Saved.'); }
 function onNewClick(){ newWorld(); }
-function onHelpCloseClick(){ el('help').style.display='none'; Storage.set('aiv_help_px3','1'); }
+function onHelpCloseClick(){ uiRefs.help.style.display='none'; Storage.set('aiv_help_px3','1'); }
 function onSheetPriorClick(e){ if(e.target.closest('.sheet-close')) toggleSheet('sheetPrior',false); }
 function onDocumentClick(e){
   const modeBtn = e.target.closest('[data-mode]');
@@ -1701,34 +1714,34 @@ function onPrioExploreInput(e){ policy.sliders.explore=(parseInt(e.target.value,
 let uiListenersBound = false;
 function bindUIListeners(){
   if(uiListenersBound) return;
-  el('btnPause').addEventListener('click', onPauseClick);
-  el('btnSpeed').addEventListener('click', onSpeedClick);
-  el('btnPrior').addEventListener('click', onPriorClick);
-  btnSave.addEventListener('click', onSaveClick);
-  el('btnNew').addEventListener('click', onNewClick);
-  el('btnHelpClose').addEventListener('click', onHelpCloseClick);
-  document.getElementById('sheetPrior').addEventListener('click', onSheetPriorClick);
+  uiRefs.btnPause.addEventListener('click', onPauseClick);
+  uiRefs.btnSpeed.addEventListener('click', onSpeedClick);
+  uiRefs.btnPrior.addEventListener('click', onPriorClick);
+  uiRefs.btnSave.addEventListener('click', onSaveClick);
+  uiRefs.btnNew.addEventListener('click', onNewClick);
+  uiRefs.btnHelpClose.addEventListener('click', onHelpCloseClick);
+  uiRefs.sheetPrior.addEventListener('click', onSheetPriorClick);
   document.addEventListener('click', onDocumentClick);
   window.addEventListener('keydown', onKeyDown);
-  document.getElementById('prioFood').addEventListener('input', onPrioFoodInput);
-  document.getElementById('prioBuild').addEventListener('input', onPrioBuildInput);
-  document.getElementById('prioExplore').addEventListener('input', onPrioExploreInput);
+  uiRefs.prioFood.addEventListener('input', onPrioFoodInput);
+  uiRefs.prioBuild.addEventListener('input', onPrioBuildInput);
+  uiRefs.prioExplore.addEventListener('input', onPrioExploreInput);
   uiListenersBound = true;
 }
 function unbindUIListeners(){
   if(!uiListenersBound) return;
-  el('btnPause').removeEventListener('click', onPauseClick);
-  el('btnSpeed').removeEventListener('click', onSpeedClick);
-  el('btnPrior').removeEventListener('click', onPriorClick);
-  btnSave.removeEventListener('click', onSaveClick);
-  el('btnNew').removeEventListener('click', onNewClick);
-  el('btnHelpClose').removeEventListener('click', onHelpCloseClick);
-  document.getElementById('sheetPrior').removeEventListener('click', onSheetPriorClick);
+  uiRefs.btnPause.removeEventListener('click', onPauseClick);
+  uiRefs.btnSpeed.removeEventListener('click', onSpeedClick);
+  uiRefs.btnPrior.removeEventListener('click', onPriorClick);
+  uiRefs.btnSave.removeEventListener('click', onSaveClick);
+  uiRefs.btnNew.removeEventListener('click', onNewClick);
+  uiRefs.btnHelpClose.removeEventListener('click', onHelpCloseClick);
+  uiRefs.sheetPrior.removeEventListener('click', onSheetPriorClick);
   document.removeEventListener('click', onDocumentClick);
   window.removeEventListener('keydown', onKeyDown);
-  document.getElementById('prioFood').removeEventListener('input', onPrioFoodInput);
-  document.getElementById('prioBuild').removeEventListener('input', onPrioBuildInput);
-  document.getElementById('prioExplore').removeEventListener('input', onPrioExploreInput);
+  uiRefs.prioFood.removeEventListener('input', onPrioFoodInput);
+  uiRefs.prioBuild.removeEventListener('input', onPrioBuildInput);
+  uiRefs.prioExplore.removeEventListener('input', onPrioExploreInput);
   uiListenersBound = false;
 }
 bindUIListeners();

--- a/src/app.js
+++ b/src/app.js
@@ -189,6 +189,17 @@ const villagers = units.villagers;
 const jobs = units.jobs;
 const itemsOnGround = units.itemsOnGround;
 const animals = units.animals;
+const buildingsByKind = new Map();
+function indexBuilding(b){
+  if(!b || !b.kind) return;
+  let arr=buildingsByKind.get(b.kind);
+  if(!arr){ arr=[]; buildingsByKind.set(b.kind, arr); }
+  arr.push(b);
+}
+function reindexAllBuildings(){
+  buildingsByKind.clear();
+  for(const b of buildings) indexBuilding(b);
+}
 const nocturnalEntities = new Array(28).fill(null).map(() => ({
   active: false,
   x: 0,
@@ -1066,6 +1077,7 @@ function newWorld(seed=Date.now()|0){
   rng.seed = normalizedSeed;
   rng.generator = mulberry32(normalizedSeed);
   jobs.length=0; buildings.length=0; itemsOnGround.length=0; animals.length=0; markItemsDirty();
+  buildingsByKind.clear();
   villagerNumberCounter = 1;
   storageTotals.food = 24;
   storageTotals.wood = 12;
@@ -1261,6 +1273,7 @@ function addBuilding(kind,x,y,opts={}){
     pending:{wood:0,stone:0}
   };
   buildings.push(b);
+  indexBuilding(b);
   return b;
 }
 
@@ -3858,7 +3871,7 @@ function tryEquipBow(v){
   v._nextPathTick=tick+12;
   return true;
 }
-function findNearestBuilding(x,y,kind){ let best=null,bd=Infinity; for(const b of buildings){ if(b.kind!==kind||b.built<1) continue; const d=distanceToFootprint(x,y,b); if(d<bd){bd=d; best=b;} } return best; }
+function findNearestBuilding(x,y,kind){ let best=null,bd=Infinity; const list=buildingsByKind.get(kind); if(!list) return null; for(const b of list){ if(b.built<1) continue; const d=distanceToFootprint(x,y,b); if(d<bd){bd=d; best=b;} } return best; }
 function scoreExistingJobForVillager(j, v, blackboard){
   if(!j) return -Infinity;
   let supplyStatus=null;
@@ -4588,6 +4601,7 @@ function loadGame(){ try{ const raw=Storage.get(SAVE_KEY); if(!raw) return false
     ensureBuildingData(b);
     buildings.push(b);
   });
+  reindexAllBuildings();
   const loadedTotals = Object.assign({food:0,wood:0,stone:0,bow:0}, d.storageTotals||{});
   storageTotals.food = loadedTotals.food||0;
   storageTotals.wood = loadedTotals.wood||0;

--- a/src/app.js
+++ b/src/app.js
@@ -183,7 +183,7 @@ gameState.policy = policy;
 if (!gameState.bb) {
   gameState.bb = computeBlackboard(gameState, policy);
 }
-const { units, time, rng, stocks, queue, population } = gameState;
+const { units, time, rng, stocks, queue } = gameState;
 const buildings = units.buildings;
 const villagers = units.villagers;
 const jobs = units.jobs;
@@ -1825,6 +1825,7 @@ function onPointerMove(e){
 }
 
 function endPointer(e){
+  if(!activePointers.has(e.pointerId)) return;
   activePointers.delete(e.pointerId);
   if(primaryPointer && e.pointerId===primaryPointer.id) primaryPointer=null;
   if(activePointers.size<2) pinch=null;

--- a/src/app.js
+++ b/src/app.js
@@ -200,6 +200,28 @@ function reindexAllBuildings(){
   buildingsByKind.clear();
   for(const b of buildings) indexBuilding(b);
 }
+let emittersDirty = true;
+function markEmittersDirty(){ emittersDirty = true; }
+const activeZoneJobs = { sow: new Set(), chop: new Set(), mine: new Set() };
+function clearActiveZoneJobs(){
+  activeZoneJobs.sow.clear();
+  activeZoneJobs.chop.clear();
+  activeZoneJobs.mine.clear();
+}
+function noteJobAssignmentChanged(j){
+  if(!j) return;
+  const set = activeZoneJobs[j.type];
+  if(!set) return;
+  const key = j.y * GRID_W + j.x;
+  if((j.assigned||0) > 0) set.add(key);
+  else set.delete(key);
+}
+function noteJobRemoved(j){
+  if(!j) return;
+  const set = activeZoneJobs[j.type];
+  if(!set) return;
+  set.delete(j.y * GRID_W + j.x);
+}
 const nocturnalEntities = new Array(28).fill(null).map(() => ({
   active: false,
   x: 0,
@@ -1078,6 +1100,8 @@ function newWorld(seed=Date.now()|0){
   rng.generator = mulberry32(normalizedSeed);
   jobs.length=0; buildings.length=0; itemsOnGround.length=0; animals.length=0; markItemsDirty();
   buildingsByKind.clear();
+  clearActiveZoneJobs();
+  markEmittersDirty();
   villagerNumberCounter = 1;
   storageTotals.food = 24;
   storageTotals.wood = 12;
@@ -1274,6 +1298,7 @@ function addBuilding(kind,x,y,opts={}){
   };
   buildings.push(b);
   indexBuilding(b);
+  if(b.kind==='campfire' && b.built>=1) markEmittersDirty();
   return b;
 }
 
@@ -2543,6 +2568,7 @@ function cancelHaulJobsForBuilding(b){
           villager.state='idle';
         }
       }
+      noteJobRemoved(job);
       jobs.splice(i,1);
     }
   }
@@ -2857,9 +2883,13 @@ function finishJob(v, remove=false){
   const job = v.targetJob;
   if(job){
     job.assigned = Math.max(0, (job.assigned||0)-1);
+    noteJobAssignmentChanged(job);
     if(remove){
       const ji = jobs.indexOf(job);
-      if(ji !== -1) jobs.splice(ji,1);
+      if(ji !== -1){
+        noteJobRemoved(job);
+        jobs.splice(ji,1);
+      }
     }
   }
   v.targetJob=null;
@@ -3023,7 +3053,10 @@ function generateJobs(){
     if(!status.hasAnySupply){
       if(job){
         const ji=jobs.indexOf(job);
-        if(ji!==-1) jobs.splice(ji,1);
+        if(ji!==-1){
+          noteJobRemoved(job);
+          jobs.splice(ji,1);
+        }
       }
       continue;
     }
@@ -3120,7 +3153,7 @@ function villagerTick(v){
   const nightNow = isNightAmbient(ambientNow);
   const dawnNow = isDawnAmbient(ambientNow);
   const style = policy?.style?.jobScoring || {};
-  const blackboard = ensureBlackboardSnapshot();
+  const blackboard = gameState.bb;
   const resting=v.state==='resting';
   const hydrationDecay=HYDRATION_DECAY*(resting?0.55:1);
   v.hydration=clamp(v.hydration-hydrationDecay,0,1);
@@ -3404,6 +3437,7 @@ function villagerTick(v){
       v.targetJob=j;
       v.thought=j.type==='haul'?moodThought(v,'Hauling'):moodThought(v,j.type.toUpperCase());
       j.assigned++;
+      noteJobAssignmentChanged(j);
       v._nextPathTick=tick+12;
       return;
     }
@@ -3910,7 +3944,7 @@ function scoreExistingJobForVillager(j, v, blackboard){
 function maybeInterruptJob(v, { blackboard=null, margin=0 } = {}){
   const currentJob = v.targetJob;
   if(!currentJob) return false;
-  const bb = blackboard || ensureBlackboardSnapshot();
+  const bb = blackboard || gameState.bb;
   const famineEmergency = bb?.famine === true && currentJob.type!=='harvest' && currentJob.type!=='sow' && currentJob.type!=='forage';
   const jobStyle = policy?.style?.jobScoring || {};
   const reprioritizeMargin = Number.isFinite(margin) ? margin : (Number.isFinite(jobStyle.reprioritizeMargin) ? jobStyle.reprioritizeMargin : 0);
@@ -3934,7 +3968,7 @@ function maybeInterruptJob(v, { blackboard=null, margin=0 } = {}){
 }
 // Finds an open harvest job when food is tight and a villager is free.
 function findPanicHarvestJob(v){
-  const bb = ensureBlackboardSnapshot();
+  const bb = gameState.bb;
   let best=null, bestScore=-Infinity;
   for(const j of jobs){
     if(!j || j.type!=='harvest') continue;
@@ -3951,7 +3985,7 @@ function findPanicHarvestJob(v){
 function pickJobFor(v){
   if(v.lifeStage==='child') return null;
   let best=null,bs=-Infinity;
-  const blackboard = ensureBlackboardSnapshot();
+  const blackboard = gameState.bb;
   const minScore = typeof policy?.style?.jobScoring?.minPickScore === 'number'
     ? policy.style.jobScoring.minPickScore
     : 0;
@@ -4226,6 +4260,7 @@ else if(v.state==='build'){
         spent.wood=def.wood||0;
         spent.stone=def.stone||0;
         b.progress=cost;
+        if(b.kind==='campfire') markEmittersDirty();
         cancelHaulJobsForBuilding(b);
         markStaticDirty();
         v.thought=moodThought(v,'Built');
@@ -4602,6 +4637,7 @@ function loadGame(){ try{ const raw=Storage.get(SAVE_KEY); if(!raw) return false
     buildings.push(b);
   });
   reindexAllBuildings();
+  markEmittersDirty();
   const loadedTotals = Object.assign({food:0,wood:0,stone:0,bow:0}, d.storageTotals||{});
   storageTotals.food = loadedTotals.food||0;
   storageTotals.wood = loadedTotals.wood||0;
@@ -5224,17 +5260,31 @@ function render(){
   villagerLabels.length = 0;
 
   if (!Array.isArray(world.emitters)) world.emitters = [];
-  world.emitters.length = 0;
-  if (shadingMode !== 'off'){
-    for (const b of buildings){
-      if(b && b.kind==='campfire' && (b.built||0) >= 1){
-        const fp=getFootprint(b.kind);
-        const emitterX=b.x + (fp?.w||1)*0.5;
-        const emitterY=b.y + (fp?.h||1)*0.5;
-        const emitterIntensity = nightActive ? 0.55 : 0.4;
-        world.emitters.push({ x:emitterX, y:emitterY, radius:7.5, intensity:emitterIntensity, falloff:2.0, flicker:true });
+  if (emittersDirty
+      || world._emittersShadingMode !== shadingMode
+      || world._emittersNightActive !== nightActive) {
+    world.emitters.length = 0;
+    if (shadingMode !== 'off') {
+      const campfires = buildingsByKind.get('campfire');
+      if (campfires){
+        const intensity = nightActive ? 0.55 : 0.4;
+        for (const b of campfires){
+          if((b.built||0) < 1) continue;
+          const fp = getFootprint(b.kind);
+          world.emitters.push({
+            x: b.x + (fp?.w||1)*0.5,
+            y: b.y + (fp?.h||1)*0.5,
+            radius: 7.5,
+            intensity,
+            falloff: 2.0,
+            flicker: true
+          });
+        }
       }
     }
+    world._emittersShadingMode = shadingMode;
+    world._emittersNightActive = nightActive;
+    emittersDirty = false;
   }
 
   const useMultiply = shadingMode !== 'off' && LIGHTING.useMultiplyComposite;
@@ -5272,14 +5322,6 @@ function render(){
   if(frames.length){
     const frame = Math.floor((tick/10)%frames.length);
     drawWaterOverlay(frames, frame, vis);
-  }
-
-  const activeZoneJobs={ sow:new Set(), chop:new Set(), mine:new Set() };
-  for(const job of jobs){
-    const type=job.type;
-    if((job.assigned||0)>0 && activeZoneJobs[type]){
-      activeZoneJobs[type].add(job.y*GRID_W + job.x);
-    }
   }
 
   drawZoneOverlay(activeZoneJobs, cam, baseDx, baseDy);


### PR DESCRIPTION
The per-tick block ran two consecutive `for (const v of villagers)`
loops: one for auto-pickup, one for `villagerTick`. Items dropped or
picked up by villager N during the tick weren't visible to villager N+1
because the second loop didn't re-check `itemTileIndexDirty` (AUDIT.md:
"Item tile index rebuild gated incorrectly").

Fuse the loops so each iteration: rebuilds the index if dirty,
auto-picks-up, then runs `villagerTick`. The previously-unconditional
outer rebuild call before the loop is removed — `rebuildItemTileIndex`
is internally gated on `itemTileIndexDirty`, so the per-iteration check
covers both the entry case and intra-loop dirtying.