### PR TITLE
Defer saveGame lookup in createUISystem to fix TDZ black screen

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1330,7 +1330,7 @@ function zoneHasWorkNow(z, i){
 const _uiSystem = createUISystem({
   policy,
   time,
-  saveGame,
+  saveGame: (...args) => saveGame(...args),
   newWorld
 });
 const Toast = _uiSystem.Toast;


### PR DESCRIPTION
createUISystem is called at app.js:1330 with `saveGame` as a shorthand
property, but `const saveGame = _saveSystem.saveGame` is initialized
~2,600 lines later at app.js:3934. Module-top-level evaluation hits the
TDZ and throws ReferenceError; main.js's dynamic import catches it,
sets __AIV_BOOT_FAILED__, and bootstrap.js's "JS NOT RUNNING" banner
is suppressed. The page renders the HUD over a black canvas with no
error visible to the user.

Replace the shorthand with `saveGame: (...args) => saveGame(...args)`
so the binding is read at call time (when the user clicks Save), well
after line 3934 has executed. Verified by reproducing the original
ReferenceError against the deployed bundle in jsdom and confirming the
patched bundle boots cleanly with world tiles, buildings, and villagers
populated.

https://claude.ai/code/session_01VPkom2CSqUEVgQqM4UkuuX