### PR TITLE
Remove unused locals/imports flagged by lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,7 +34,7 @@ export default [
       }
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrors: 'none' }],
       'no-empty': ['warn', { allowEmptyCatch: true }],
       'no-prototype-builtins': 'off',
       'no-constant-condition': ['warn', { checkLoops: false }],

--- a/public/debugkit.js
+++ b/public/debugkit.js
@@ -882,12 +882,12 @@
     if (!shadingHooksInstalled) {
       const originalMode = win.setShadingMode;
       const originalParams = win.setShadingParams;
-      win.setShadingMode = function (mode) {
+      win.setShadingMode = function () {
         const result = originalMode.apply(this, arguments);
         syncShadingControls();
         return result;
       };
-      win.setShadingParams = function (params) {
+      win.setShadingParams = function () {
         const result = originalParams.apply(this, arguments);
         syncShadingControls();
         return result;

--- a/public/worldgen/terrain.js
+++ b/public/worldgen/terrain.js
@@ -38,10 +38,8 @@
   let GH = 0;
   let GS = 0;
   let baseSeed = 0;
-  let RNG_RIVER = null;
   let RNG_RESOURCE = null;
   let heightField = null;
-  let moistureField = null;
   let riverMeta = [];
   let riverConfig = null;
 
@@ -72,7 +70,6 @@ function generateTerrain(seed, cfg, dims) {
   GW = dims.w | 0;
   GH = dims.h | 0;
   GS = GW * GH;
-  RNG_RIVER = mulberry32((baseSeed ^ 0xA341316C) >>> 0);
   RNG_RESOURCE = mulberry32((baseSeed ^ 0xAD90777D) >>> 0);
   riverConfig = cfg.rivers;
   riverMeta = [];
@@ -87,7 +84,6 @@ function generateTerrain(seed, cfg, dims) {
 
   const { height, moisture } = makeHeightMoisture(baseSeed, GW, GH, cfg);
   heightField = height;
-  moistureField = moisture;
 
   const lakeMask = floodFillBasins(height, cfg.water.level, cfg.water.minLakeSize, cfg.water.maxLakeSize, GW, GH);
   boostMoistureRing(moisture, lakeMask, GW, GH, 0.07);
@@ -538,7 +534,7 @@ function rasterizeRivers(polylines, accum, tiles, cfg, w, h) {
   const riverMask = new Uint8Array(w * h);
   const widthCache = new Uint8Array(w * h);
 
-  const paint = (x, y, idx) => {
+  const paint = (x, y) => {
     if (x < 0 || y < 0 || x >= w || y >= h) return;
     const centerIdx = y * w + x;
     const width = getWidth(centerIdx, accum, cfg, widthCache);
@@ -564,7 +560,7 @@ function rasterizeRivers(polylines, accum, tiles, cfg, w, h) {
   for (const poly of polylines) {
     if (!poly || poly.length === 0) continue;
     let prev = poly[0];
-    paint(Math.round(prev[0]), Math.round(prev[1]), idx(Math.round(prev[0]), Math.round(prev[1])));
+    paint(Math.round(prev[0]), Math.round(prev[1]));
     for (let i = 1; i < poly.length; i++) {
       const cur = poly[i];
       const dx = cur[0] - prev[0];
@@ -574,7 +570,7 @@ function rasterizeRivers(polylines, accum, tiles, cfg, w, h) {
         const t = s / steps;
         const sx = prev[0] + dx * t;
         const sy = prev[1] + dy * t;
-        paint(Math.round(sx), Math.round(sy), idx(Math.round(sx), Math.round(sy)));
+        paint(Math.round(sx), Math.round(sy));
       }
       prev = cur;
     }
@@ -1143,12 +1139,6 @@ function largestClearingArea(tiles, w, h) {
   return best;
 }
 
-function countOnes(mask) {
-  let total = 0;
-  for (let i = 0; i < mask.length; i++) if (mask[i]) total++;
-  return total;
-}
-
 function makeHillshade(height, w, h, cfg = SHADING_DEFAULTS) {
   const size = w * h;
   const shade = new Float32Array(size);
@@ -1233,7 +1223,7 @@ function makeHillshade(height, w, h, cfg = SHADING_DEFAULTS) {
 }
 
 function logGenerationStats(ctx) {
-  const { tiles, rocks, berries, masks, stoneDeposits, berryTiles, fertileStats, duration, config } = ctx;
+  const { tiles, stoneDeposits, berryTiles, fertileStats, duration, config } = ctx;
   const size = tiles.length;
   const counts = new Array(10).fill(0);
   for (let i = 0; i < size; i++) counts[tiles[i]]++;

--- a/src/app.js
+++ b/src/app.js
@@ -844,7 +844,7 @@ function removeAnimal(animal){
   return false;
 }
 
-function resolveHuntYield({ animal, lodge }){
+function resolveHuntYield({ animal: _animal, lodge }){
   const effects=lodge?.effects || {};
   const gameBonus=Number.isFinite(effects.gameYieldBonus)?effects.gameYieldBonus:0;
   const hideBonus=Number.isFinite(effects.hideYieldBonus)?effects.hideYieldBonus:0;
@@ -1028,8 +1028,6 @@ function newWorld(seed=Date.now()|0){
   storageReserved.bow = 0;
   time.tick = 0;
   time.dayTime = 0;
-  tick = time.tick;
-  dayTime = time.dayTime;
   const terrain = generateTerrain(seed, WORLDGEN_DEFAULTS, { w: GRID_W, h: GRID_H });
   const aux = terrain.aux || {};
   const mode = normalizeShadingMode(SHADING_DEFAULTS.mode);
@@ -2068,7 +2066,6 @@ function cancelHaulJobsForBuilding(b){
   }
 }
 function idx(x,y){ if(x<0||y<0||x>=GRID_W||y>=GRID_H) return -1; return baseIdx(x,y); }
-function getTile(x,y){ const i=idx(x,y); if(i<0) return null; return { t:world.tiles[i], i }; }
 const _pathfinder = createPathfinder({
   idx,
   tileOccupiedByBuilding,
@@ -3874,7 +3871,7 @@ function seasonTick(){
   }
   const hasFarmBoosters=buildings.some(b=>b.built>=1 && (b.kind==='farmplot'||b.kind==='well'));
   const creationCfg = getJobCreationConfig();
-  const bb = ensureBlackboardSnapshot();
+  ensureBlackboardSnapshot();
   for(let i=0;i<world.growth.length;i++){
     if(world.tiles[i]!==TILES.FARMLAND) continue;
     const prev=world.growth[i];

--- a/src/app/lighting.js
+++ b/src/app/lighting.js
@@ -1,4 +1,4 @@
-import { SHADING_DEFAULTS, AIV_SCOPE } from './environment.js';
+import { SHADING_DEFAULTS } from './environment.js';
 
 const LIGHTING = {
   mode: 'hillshade',


### PR DESCRIPTION
- Drop redundant `tick = time.tick; dayTime = time.dayTime;` no-ops in
  newWorld(); the defineProperty mirrors already keep them in sync.
- Drop unused `getTile` helper and unused `bb` assignment in src/app.js.
- Mark unused `animal` arg in resolveHuntYield() as `_animal`.
- Drop unused `RNG_RIVER`, `moistureField`, `countOnes`, and unused
  destructured fields in worldgen/terrain.js; the corresponding `idx`
  arg in `paint()` is also unused so it is removed from helper and callers.
- Drop unused `mode`/`params` formal args from debugkit shading hooks
  (the wrappers forward via `arguments`).
- Drop unused `AIV_SCOPE` import in src/app/lighting.js.
- Configure eslint `no-unused-vars` with `caughtErrors: 'none'` so
  intentionally-named-but-unused catch params do not warn.

`npm run lint` now reports 0 problems and `npm run build` succeeds.