### PR TITLE
Resolve two low-severity AUDIT.md items in src/app.js

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -93,22 +93,6 @@ have since been merged.
 
 ## Open — Low
 
-### `src/app.js:70` ships a diagnostic `console.log`
-- `console.log("AIV Phase1 perf build")` runs on every page load.
-  Intentional — it confirms the bundle ran — but it's noise in prod
-  consoles. Consider gating on `import.meta.env.DEV` or removing.
-
-### Unused exports retained as a debug surface
-- **Where**: `src/app.js:4924` exports `setShadingMode`,
-  `setShadingParams`, `makeAltitudeShade`, `ambientAt`,
-  `buildHillshadeQ`, `buildLightmap`, `sampleLightAt`,
-  `shadeFillColorLit`, `applySpriteShadeLit`. No internal module imports
-  them; they're also installed onto `AIV_APP` for DebugKit (`src/app.js:4900`).
-- **Suggested**: The intent is documented in a code comment but the
-  contract isn't pinned anywhere user-facing. Either drop the ES exports
-  (leaving only the `AIV_APP` global) or document them in a public-API
-  README so external tools know what they can rely on.
-
 ### No automated tests
 - The repo has lint and build but no test runner. A smoke test (e.g.
   `vitest` plus a single "boot the world headless" assertion) would
@@ -200,3 +184,13 @@ prior audit; the linked file/line is where the fix lives.
 - **Bootstrap helper cleanup** — `__AIV_WORLDGEN_RESOLVE__`/`REJECT__`
   null themselves after the first call so the closure can GC and
   double-calls are no-ops (`public/bootstrap.js:14-39`).
+- **Diagnostic `console.log` on every load** — the
+  `"AIV Phase1 perf build"` log is now gated on
+  `import.meta.env?.DEV` (`src/app.js:72-74`) so prod consoles stay
+  clean while local dev still gets the bundle-ran confirmation.
+- **Unused ES exports retained as a debug surface** — the duplicate
+  `export { setShadingMode, ... }` at the bottom of `src/app.js` has
+  been dropped. The helpers remain reachable through the
+  `window.AIV_APP` global installed at `src/app.js:3988-4005`, which
+  is what DebugKit already uses; the comment at `src/app.js:4012-4017`
+  pins that contract.

--- a/src/app.js
+++ b/src/app.js
@@ -69,7 +69,9 @@ import {
   normalizeExperienceLedger
 } from './app/simulation.js';
 
-console.log("AIV Phase1 perf build"); // shows up so we know this file ran
+if (import.meta.env?.DEV) {
+  console.log("AIV Phase1 perf build"); // shows up so we know this file ran
+}
 const PERF = { log:false }; // flip to true to log basic timings
 
 let waterRowMask = new Uint8Array(GRID_H);
@@ -4007,7 +4009,9 @@ if (AIV_SCOPE && typeof AIV_SCOPE === 'object') {
 export { boot as bootGame };
 export { gameState as state };
 export { LIGHTING };
-// Public debug surface: also installed onto window.AIV_APP above for DebugKit.
-// No internal modules import these — kept as an ES export so external tools
-// that prefer module imports over globals can still reach them.
-export { setShadingMode, setShadingParams, makeAltitudeShade, ambientAt, buildHillshadeQ, buildLightmap, sampleLightAt, shadeFillColorLit, applySpriteShadeLit };
+// Debug helpers (setShadingMode, setShadingParams, makeAltitudeShade,
+// ambientAt, buildHillshadeQ, buildLightmap, sampleLightAt,
+// shadeFillColorLit, applySpriteShadeLit) are exposed only via the
+// `window.AIV_APP` global installed above. They are not re-exported as
+// ES bindings because no internal module imports them and DebugKit
+// reaches them through `window`.


### PR DESCRIPTION
- Gate the "AIV Phase1 perf build" diagnostic log on
  import.meta.env?.DEV so prod consoles stay clean while local dev
  still gets the bundle-ran confirmation.
- Drop the duplicate ES exports for the nine debug-surface helpers
  (setShadingMode, setShadingParams, makeAltitudeShade, ambientAt,
  buildHillshadeQ, buildLightmap, sampleLightAt, shadeFillColorLit,
  applySpriteShadeLit). They remain reachable via the window.AIV_APP
  global, which is the contract DebugKit already relies on.

Move both entries from "Open — Low" to "Resolved" in AUDIT.md.