### PR TITLE
Resolve three AUDIT.md items: experience consts, build cap, CI lint

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -30,6 +30,8 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Lint
+        run: npm run lint
       - name: Build site
         run: npm run build
       - name: Setup Pages

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -52,25 +52,6 @@ have since been merged.
 
 ## Open — Medium
 
-### `inspectJobs` in `src/ai/blackboard.js` overlaps with `policy.caps.buildWaiting`
-- **Where**: `src/ai/blackboard.js:85-99` checks
-  `job.waitingForMaterials !== true` to set `buildPush`; the same concept is
-  encoded in `policy.caps.buildWaiting` (`src/policy/policy.js:151`).
-- **Suggested**: Pick one source of truth — either feed `buildPush` from
-  `caps.buildWaiting`, or remove the cap and rely on the blackboard signal.
-
-### Duplicated experience constants
-- **Where**: `JOB_EXPERIENCE_MAP` and `EXPERIENCE_THRESHOLDS` are defined in
-  both `src/ai/scoring.js:6-18` and `src/app/simulation.js:9-22`. The
-  `simulation.js` copy includes `socialize: 'social'`; the `scoring.js`
-  copy does not.
-- **Why it matters**: Adding a new job type means editing both. The
-  divergence (`socialize`) is currently benign because it's tracked as a
-  villager state, not a scored job, but a future change could drift them
-  silently.
-- **Suggested**: Hoist both constants to a shared module (probably
-  `src/app/simulation.js`) and import from `scoring.js`.
-
 ### Canvas/lightmap context release on world swap
 - **Where**: `src/app.js` `newWorld()` reassigns `world.lightmapCanvas`/
   `world.lightmapCtx`. `src/app/canvas.js:63` keeps a module-level `ctx`
@@ -103,12 +84,6 @@ have since been merged.
   `vitest` plus a single "boot the world headless" assertion) would
   catch a lot of the closure-over-stale-state regressions the items
   above worry about.
-
-### Lint not gated in CI
-- `npm run lint` is wired in `package.json`, but the `deploy-pages`
-  workflow only runs `npm ci && npm run build`. Lint regressions can
-  land on `main` undetected. Add a `lint` step to the workflow (or a
-  separate `ci.yml`).
 
 ---
 
@@ -209,3 +184,18 @@ prior audit; the linked file/line is where the fix lives.
   `tickRunner.runFrame()` (commit `507b686`). The remaining
   `villagerTick` closure inside `src/app.js` is tracked under the
   high-severity `src/app.js` entry above.
+- **Duplicated experience constants** — `JOB_EXPERIENCE_MAP` and
+  `EXPERIENCE_THRESHOLDS` now live only in `src/app/simulation.js:9-22`.
+  `src/ai/scoring.js:1` imports them from there, eliminating the
+  `socialize` divergence between the two copies.
+- **`inspectJobs` / `policy.caps.buildWaiting` overlap** — dropped the
+  cap entirely. Both encoded the same formula (`0.5 + buildSlider * 0.35`)
+  that the planner already pre-applies as `waitingPrio` in
+  `src/app/planner.js:991`, so the cap was dead code: it could never
+  fire because `effectivePriority === cap`. Blackboard's `buildPush`
+  bonus continues to drive the "ready vs. waiting" preference.
+  `policy.caps` and the `getCaps()` helper in `scoring.js` were also
+  removed since `buildWaiting` was their only entry.
+- **Lint not gated in CI** — `.github/workflows/deploy-pages.yml` now
+  runs `npm run lint` between `npm ci` and `npm run build`, so lint
+  regressions block the deploy job before it ever uploads `dist/`.

--- a/src/ai/scoring.js
+++ b/src/ai/scoring.js
@@ -1,21 +1,9 @@
+import { JOB_EXPERIENCE_MAP, EXPERIENCE_THRESHOLDS } from '../app/simulation.js';
+
 const HEAVY_JOB_TYPES = new Set(['chop', 'mine', 'build', 'haul', 'craft_bow', 'hunt']);
 const NURTURE_JOB_TYPES = new Set(['sow', 'harvest', 'forage']);
 const FARM_JOB_TYPES = new Set(['sow', 'harvest', 'forage']);
 const ADVANCED_JOB_TYPES = new Set(['build', 'craft_bow']);
-
-const JOB_EXPERIENCE_MAP = Object.freeze({
-  sow: 'farming',
-  harvest: 'farming',
-  forage: 'farming',
-  chop: 'construction',
-  mine: 'construction',
-  build: 'construction',
-  haul: 'hauling',
-  hunt: 'hunting',
-  craft_bow: 'crafting'
-});
-
-const EXPERIENCE_THRESHOLDS = [0, 10, 30, 60];
 
 function clamp(value, min, max) {
   if (!Number.isFinite(value)) return min;
@@ -26,10 +14,6 @@ function clamp(value, min, max) {
 
 function getStyle(policy) {
   return policy?.style?.jobScoring || {};
-}
-
-function getCaps(policy) {
-  return policy?.caps || {};
 }
 
 function resolveSkill(value, fallback = 0.5) {
@@ -78,7 +62,6 @@ export function score(job, villager, policy, blackboard) {
   }
 
   const style = getStyle(policy);
-  const caps = getCaps(policy);
 
   const defaultPriority = Number.isFinite(style.defaultPriority) ? style.defaultPriority : 0.5;
   const distanceFalloff = Number.isFinite(style.distanceFalloff) ? style.distanceFalloff : 0;
@@ -118,17 +101,7 @@ export function score(job, villager, policy, blackboard) {
   const advancedTaskAffinity = Number.isFinite(style.advancedTaskAffinity) ? style.advancedTaskAffinity : 0.12;
   const leveledTaskBias = Number.isFinite(style.leveledTaskBias) ? style.leveledTaskBias : 0.05;
 
-  const rawPriority = Number.isFinite(job.prio) ? job.prio : defaultPriority;
-  let effectivePriority = rawPriority;
-
-  if (job.type === 'build' && job.supply && job.supply.fullyDelivered === false) {
-    const cap = typeof caps.buildWaiting === 'function'
-      ? caps.buildWaiting(policy, job, villager, blackboard)
-      : null;
-    if (Number.isFinite(cap) && cap < effectivePriority) {
-      effectivePriority = cap;
-    }
-  }
+  const effectivePriority = Number.isFinite(job.prio) ? job.prio : defaultPriority;
 
   const distance = Number.isFinite(job.distance) ? job.distance : 0;
   let value = effectivePriority - distance * distanceFalloff;

--- a/src/policy/policy.js
+++ b/src/policy/policy.js
@@ -147,13 +147,6 @@ export const policy = {
     }
     return this;
   },
-  caps: {
-    buildWaiting(policyRef = null, _job = null, _villager = null, _blackboard = null) {
-      const source = (policyRef || policy).sliders;
-      const buildValue = typeof source?.build === 'number' ? source.build : DEFAULT_SLIDERS.build;
-      return 0.5 + buildValue * 0.35;
-    }
-  },
   routine: {
     jobGenerationTickInterval: 20,
     seasonTickInterval: 10,


### PR DESCRIPTION
- Hoist JOB_EXPERIENCE_MAP/EXPERIENCE_THRESHOLDS to src/app/simulation.js
  and import from src/ai/scoring.js, eliminating the 'socialize' divergence.
- Drop policy.caps.buildWaiting (and the now-unused getCaps/caps wrapper
  in scoring.js): the cap formula was identical to waitingPrio in the
  planner, so it was dead code. Blackboard's buildPush bonus continues
  to drive the ready-vs-waiting preference.
- Add 'npm run lint' step to deploy-pages.yml between 'npm ci' and
  'npm run build' so lint regressions block the deploy job.
- Refresh AUDIT.md to move the three items to Resolved.