### PR TITLE
Extract villagerTick into src/app/villagerTick.js

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -12,33 +12,42 @@ have since been merged.
 
 ## Open — High
 
-### `src/app.js` is still a single ~4,000-line module
+### `src/app.js` is still a single ~3,700-line module
 - **Where**: `src/app.js`
 - **Status**: Significant progress. Pathfinding, save/load, UI/pointer input,
   rendering helpers, world/building data, time-of-day/experience helpers,
-  the planner, and per-frame tick orchestration have been carved out into
-  `src/app/{pathfinding,save,ui,render,world,simulation,planner,tick}.js`.
-  What remains is `villagerTick` (still a module-local closure at
-  `src/app.js:1599`), the job system, building-specific behavior, boot
-  wiring, and the module-local `gameState`-array mirrors that those bits
-  still read.
+  the planner, per-frame tick orchestration, and now `villagerTick` have
+  all been carved out into
+  `src/app/{pathfinding,save,ui,render,world,simulation,planner,tick,villagerTick}.js`.
+  The file is down to ~3,706 lines (from ~4,017 before the
+  `villagerTick` extraction). What remains in-file is the job lifecycle,
+  the material-reservation/haul layer, `onArrive` (the per-job arrival
+  branch), the villager-AI helper bundle (`pickJobFor`,
+  `maybeInterruptJob`, `foragingJob`, `goRest`, `seekEmergencyFood`,
+  `consumeFood`, `tryEquipBow`, `tryHydrateAtWell`, `tryCampfireSocial`,
+  `tryStorageIdle`, `handleIdleRoam`, `nearestFoodTarget`,
+  `collectFoodHubs`, `pickWeightedRandom`, `selectReachableWanderTarget`),
+  the animal system (~350 lines), the render body
+  (`render`/`drawBuildingAt`/`drawAnimal`/`drawVillager` plus overlay
+  helpers, ~600 lines), the population/birth helpers, the DebugKit
+  bridge, and boot wiring.
 - **Why it matters**: The remaining file still owns module-local mirrors of
   `gameState` arrays (`buildings`, `villagers`, `jobs`, `animals`,
   `itemsOnGround`) and a property-getter/setter for `world`. Most of the
   trickier remaining items below trace back to that coupling.
-- **Suggested next pass**: Convert `villagerTick` (currently invoked via
-  `tickRunner.runFrame()` in `src/app/tick.js:122`) into an explicit-deps
-  function in `src/app/tick.js`, the way `createPlanner` and
-  `createTickRunner` already work. That removes the last large consumer
-  of the module-local arrays and unblocks the snapshot-for-save work
-  below.
+- **Suggested next pass**: Track follow-on extraction targets under the
+  new "src/app.js follow-on extractions" entry below. The villager-AI
+  helper bundle is the highest-leverage next target because every
+  helper there is also a dep that `createVillagerTick` currently has
+  to be handed via the deps bag — extracting them next will collapse
+  the bag and let `villagerTick` import its callees directly.
 
 ### Simulation tick interleaved with render
-- **Where**: `src/app.js:3963` (`update()`) calls `tickRunner.runFrame()`
-  (from `src/app/tick.js`, which fans out to `villagerTick`,
-  `updateAnimals`, `seasonTick`, etc.) inside the same RAF callback that
-  ends with `render()`. `saveGame()` (in `src/app/save.js:41`) reads
-  `gameState` directly when invoked.
+- **Where**: `src/app.js` `update()` calls `tickRunner.runFrame()`
+  (from `src/app/tick.js`, which fans out to `villagerTick` in
+  `src/app/villagerTick.js`, `updateAnimals`, `seasonTick`, etc.)
+  inside the same RAF callback that ends with `render()`. `saveGame()`
+  (in `src/app/save.js:41`) reads `gameState` directly when invoked.
 - **Why it matters**: Today the manual save button is the only save path so
   the practical risk is bounded — JS is single-threaded and save fires
   between RAF frames. But anything we add that triggers saves from a hook,
@@ -51,6 +60,86 @@ have since been merged.
 ---
 
 ## Open — Medium
+
+### `src/app.js` follow-on extractions
+- **Where**: `src/app.js`
+- **Status**: Track-list of the next-best extraction targets, in priority
+  order, now that `villagerTick` has moved to its own module. Each item
+  is sized so that a single PR can land it without rewriting unrelated
+  systems.
+  1. **Villager-AI helper bundle** — `pickJobFor`, `maybeInterruptJob`,
+     `scoreExistingJobForVillager`, `findPanicHarvestJob`, `foragingJob`,
+     `goRest`, `tryEquipBow`, `tryHydrateAtWell`, `tryCampfireSocial`,
+     `tryStorageIdle`, `consumeFood`, `seekEmergencyFood`,
+     `nearestFoodTarget`, `collectFoodHubs`, `pickWeightedRandom`,
+     `selectReachableWanderTarget`, `handleIdleRoam`, `findNearestBuilding`,
+     plus the starve-cycle trio (`issueStarveToast`, `enterSickState`,
+     `handleVillagerFed`) at `src/app.js:~1596-2538`. Extract into
+     `src/app/villagerAI.js` using the `createVillagerAI(deps)` factory
+     pattern. **High leverage**: `createVillagerTick`'s ~30-entry deps
+     bag mostly points at this bundle, so once it lands the bag
+     collapses to a handful of cross-module entries (`pathfind`,
+     `ambientAt`, building/job helpers).
+  2. **`onArrive`** (`src/app.js:~2540-2950`, ~400 lines branching on
+     every job type — `chop`, `mine`, `sow`, `harvest`, `forage`,
+     `build`, `haul`, `craft_bow`, `hunt`, `rest`, `hydrate`,
+     `socialize`, `storage_*`). Reads `world`, `buildings`, `jobs`,
+     `itemsOnGround`, `storageTotals`, `storageReserved` directly.
+     Extract into `src/app/onArrive.js` (or fold into `villagerAI.js`).
+  3. **Job lifecycle** — `addJob`, `finishJob`, `noteJobAssignmentChanged`,
+     `noteJobRemoved`, `suppressJob`, `isJobSuppressed`, `hasSimilarJob`,
+     `jobKey`, `getJobCreationConfig`, plus the `jobSuppression` /
+     `activeZoneJobs` indices at `src/app.js:~1482-1556`. Extract into
+     `src/app/jobs.js`.
+  4. **Material reservation / haul scheduling** — `availableToReserve`,
+     `canReserveMaterials`, `reserveMaterials`, `releaseReservedMaterials`,
+     `spendCraftMaterials`, `scheduleHaul`, `requestBuildHauls`,
+     `cancelHaulJobsForBuilding` at `src/app.js:~1347-1465`. Extract
+     into `src/app/materials.js`.
+  5. **Render body** — `render` and its draw helpers
+     (`drawBuildingAt`, `drawAnimal`, `drawVillager`,
+     `drawQueuedVillagerLabels`, `drawShadow`, `drawZoneOverlay`,
+     `drawWaterOverlay`, `drawNocturnalEntities`, `drawStaticAlbedo`)
+     at `src/app.js:~3037-3650`. Fattens `src/app/render.js` (which
+     today only owns lower-level helpers).
+  6. **Animal system** — `spawnAnimalsForWorld`, `behaviorForAnimal`,
+     `ensureAnimalDefaults`, `animalTileBlocked`, `pickRoamTarget`,
+     `attemptGraze`, `chooseFleeTarget`, `findAnimalById`,
+     `removeAnimal`, `resolveHuntYield`, `findHuntApproachPath`,
+     `interactWithVillage`, `stepAnimal`, `animalTick`, `updateAnimals`
+     at `src/app.js:~658-1010`. Extract into `src/app/animals.js`.
+  7. **Population/birth helpers** — `housingCapacity`,
+     `populationLimit`, `canSupportBirth`, `findBirthMate`,
+     `tryStartPregnancy`, `spawnChildNearParents`, `flushPendingBirths`,
+     `completePregnancy`, `promoteChildToAdult`, plus
+     `assignAdultTraits`/`rollAdultRole`/`newVillager`/`newChildVillager`
+     at `src/app.js:~1174-2148`. Extract into `src/app/population.js`.
+  8. **DebugKit bridge** — `debugKitGetPipeline`, `describeCanvasContext`,
+     `debugKitGetLightingProbe`, `debugKitEnterSafeMode`,
+     `debugKitGetState`, `configureDebugKitBridge`,
+     `installDebugKitWatcher`, `ensureDebugKitConfigured` at
+     `src/app.js:~373-598`. Extract into `src/app/debugkit.js`.
+  9. **Nocturnal entities** — `nocturnalAmbientStrength`,
+     `spawnNocturnalEntity`, `updateNocturnalEntities`,
+     `drawNocturnalEntities`, plus the `nocturnalEntities` array and
+     `nocturnalSpawnCooldown` at `src/app.js:~235-247, 3807-3900`.
+     Bundle with the render extraction.
+- **Why it matters**: Each leaves `src/app.js` smaller and
+  `gameState`-coupling more localized; combined, they take the file
+  below ~1,000 lines (mostly boot wiring + the module-local mirrors
+  themselves), at which point the mirrors can finally collapse.
+- **Cross-cutting cleanup**: A handful of villager-tuning constants
+  (`STARVE_THRESH`, `CHILDHOOD_TICKS`, `HYDRATION_BUFF_TICKS`,
+  `HYDRATION_DEHYDRATED_PENALTY`, `HYDRATION_MOOD_TICK`,
+  `REST_BASE_TICKS`, `REST_EXTRA_PER_ENERGY`, `SOCIAL_BASE_TICKS`,
+  `SOCIAL_COOLDOWN_TICKS`, `STORAGE_IDLE_BASE`, `STORAGE_IDLE_COOLDOWN`)
+  are duplicated between `src/app.js:1567-1591` and
+  `src/app/villagerTick.js:11-43` because the helpers that read them
+  in `src/app.js` haven't moved yet. The cleanup falls out for free
+  once the villager-AI helper bundle (#1) lands — both files start
+  importing from a single source. Until then, treat the duplication
+  as a bug magnet and keep the two blocks in sync if any value
+  changes.
 
 ### Canvas/lightmap context release on world swap
 - **Where**: `src/app.js` `newWorld()` reassigns `world.lightmapCanvas`/
@@ -180,10 +269,23 @@ prior audit; the linked file/line is where the fix lives.
   than closing over `src/app.js` module-locals (commit `9da2aa4`).
 - **Simulation tick orchestration extracted** — `createTickRunner(deps)`
   in `src/app/tick.js` (line 6) owns the per-frame tick fan-out and is
-  invoked from `update()` at `src/app.js:3963` via
-  `tickRunner.runFrame()` (commit `507b686`). The remaining
-  `villagerTick` closure inside `src/app.js` is tracked under the
-  high-severity `src/app.js` entry above.
+  invoked from `update()` in `src/app.js` via
+  `tickRunner.runFrame()` (commit `507b686`).
+- **`villagerTick` extracted** — `createVillagerTick(deps)` in
+  `src/app/villagerTick.js` (line 47) takes `state`, `policy`,
+  `pathfind`, the building/job helpers, and the per-villager AI
+  callbacks (`pickJobFor`, `goRest`, `consumeFood`, etc.) as explicit
+  dependencies rather than closing over `src/app.js` module-locals.
+  `createTickRunner` still receives the function as a dep at the
+  `src/app.js` wiring site, so the per-frame fan-out is unchanged.
+  The decay/mood/buff knobs that only `villagerTick` reads
+  (`HUNGER_RATE`, `ENERGY_DRAIN_BASE`, the `REST_*` recovery numbers,
+  `HYDRATION_DECAY`/`LOW`/`HUNGER_MULT`/`FATIGUE_BONUS`,
+  `SOCIAL_MOOD_TICK`/`SOCIAL_ENERGY_TICK`, `NIGHT_CAMPFIRE_*`) moved
+  with it; the constants that other still-in-`src/app.js` helpers
+  also read are tracked as a follow-on cleanup under the new
+  "src/app.js follow-on extractions" entry. Net `src/app.js` line
+  delta: -311 (~4,017 → 3,706).
 - **Duplicated experience constants** — `JOB_EXPERIENCE_MAP` and
   `EXPERIENCE_THRESHOLDS` now live only in `src/app/simulation.js:9-22`.
   `src/ai/scoring.js:1` imports them from there, eliminating the

--- a/src/app.js
+++ b/src/app.js
@@ -40,6 +40,7 @@ import { createUISystem } from './app/ui.js';
 import { createRenderSystem } from './app/render.js';
 import { createPlanner } from './app/planner.js';
 import { createTickRunner } from './app/tick.js';
+import { createVillagerTick } from './app/villagerTick.js';
 import {
   BUILDINGS,
   CAMPFIRE_EFFECT_RADIUS,
@@ -64,7 +65,6 @@ import {
   effectiveSkillFromExperience,
   isDawnAmbient,
   isNightAmbient,
-  moodMotivation,
   moodThought,
   normalizeExperienceLedger
 } from './app/simulation.js';
@@ -1555,15 +1555,22 @@ function finishJob(v, remove=false){
   v.targetJob=null;
 }
 
+// Shared villager-tuning constants. The decay/mood/buff knobs that live
+// only inside `villagerTick` (HUNGER_RATE, ENERGY_DRAIN_BASE, the REST_*
+// recovery numbers, HYDRATION_DECAY/LOW/HUNGER_MULT/FATIGUE_BONUS,
+// SOCIAL_MOOD_TICK / SOCIAL_ENERGY_TICK, NIGHT_CAMPFIRE_*) now live next
+// to that function in `src/app/villagerTick.js`. Anything that is also
+// read by helpers still in this file (foragingJob, goRest,
+// tryHydrateAtWell, tryCampfireSocial, tryStorageIdle, onArrive, the
+// pregnancy/birth helpers, etc.) stays here for now and will collapse
+// into a single source of truth when the villager-AI helper bundle
+// extracts in a follow-on pass.
 const STARVE_THRESH={ hungry:0.82, starving:1.08, sick:1.22 };
 const STARVE_COLLAPSE_TICKS=140;
 const STARVE_RECOVERY_TICKS=280;
 const STARVE_TOAST_COOLDOWN=420;
-// Hunger tuning knob: soften the rate a bit so farms can keep pace once established.
-const HUNGER_RATE=0.00095;
 // Balance knob: how much a bite of food reduces hunger.
 const FOOD_HUNGER_RECOVERY=0.65;
-const ENERGY_DRAIN_BASE=0.0011;
 const PREGNANCY_TICKS=DAY_LEN*2;
 const CHILDHOOD_TICKS=DAY_LEN*5;
 const PREGNANCY_ATTEMPT_COOLDOWN_TICKS=Math.floor(DAY_LEN*1.1);
@@ -1573,373 +1580,15 @@ const POPULATION_HARD_CAP=80;
 const FOOD_HEADROOM_PER_VILLAGER=1.25;
 const REST_BASE_TICKS=90;
 const REST_EXTRA_PER_ENERGY=110;
-const REST_ENERGY_RECOVERY=0.0024;
-const REST_MOOD_TICK=0.0009;
-const REST_FINISH_MOOD=0.05;
-const REST_HUNGER_MULT=0.42;
-const HYDRATION_DECAY=0.00018;
 const HYDRATION_VISIT_THRESHOLD=0.46;
-const HYDRATION_LOW=0.28;
 const HYDRATION_BUFF_TICKS=320;
-const HYDRATION_HUNGER_MULT=0.9;
-const HYDRATION_FATIGUE_BONUS=0.8;
-const HYDRATION_DEHYDRATED_PENALTY=1.12;
-const HYDRATION_MOOD_TICK=0.00035;
 const SOCIAL_BASE_TICKS=88;
 const SOCIAL_COOLDOWN_TICKS=DAY_LEN*0.2;
-const SOCIAL_MOOD_TICK=0.0013;
-const SOCIAL_ENERGY_TICK=0.00055;
-const NIGHT_CAMPFIRE_MOOD_TICK=0.0012;
-const NIGHT_CAMPFIRE_XP_TICK=0.15;
 const STORAGE_IDLE_BASE=70;
 const STORAGE_IDLE_COOLDOWN=DAY_LEN*0.12;
 function issueStarveToast(v,text,force=false){ const ready=(v.nextStarveWarning||0)<=tick; if(force||ready){ Toast.show(text); v.nextStarveWarning=tick+STARVE_TOAST_COOLDOWN; } }
 function enterSickState(v){ if(v.condition==='sick') return; v.condition='sick'; v.sickTimer=STARVE_COLLAPSE_TICKS; v.starveStage=Math.max(3,v.starveStage||0); finishJob(v); if(v.path) v.path.length=0; v.state='sick'; v.thought=moodThought(v,'Collapsed'); issueStarveToast(v,'A villager collapsed from hunger! They need food now.',true); }
 function handleVillagerFed(v,source='food'){ const wasCritical=(v.condition==='sick')||((v.starveStage||0)>=2); v.sickTimer=0; v.starveStage=0; if(wasCritical){ v.condition='recovering'; v.recoveryTimer=STARVE_RECOVERY_TICKS; } else { v.condition='normal'; v.recoveryTimer=Math.max(v.recoveryTimer, Math.floor(STARVE_RECOVERY_TICKS/3)); } v.nextStarveWarning=tick+Math.floor(STARVE_TOAST_COOLDOWN*0.6); if(v.state==='sick') v.state='idle'; v.thought=moodThought(v,wasCritical?'Recovering':'Content'); v.happy=clamp(v.happy+0.05,0,1); if(wasCritical){ const detail=source==='camp'?'camp stores':source==='pack'?'their pack':source==='berries'?'wild berries':source; issueStarveToast(v,`Villager recovered after eating ${detail}.`,true); } }
-function villagerTick(v){
-  if(v.condition===undefined) v.condition='normal';
-  if(v.starveStage===undefined) v.starveStage=0;
-  if(v.nextStarveWarning===undefined) v.nextStarveWarning=0;
-  if(v.sickTimer===undefined) v.sickTimer=0;
-  if(v.recoveryTimer===undefined) v.recoveryTimer=0;
-  if(v.restTimer===undefined) v.restTimer=0;
-  if(!Number.isFinite(v.hydration)) v.hydration=0.7;
-  if(!Number.isFinite(v.hydrationBuffTicks)) v.hydrationBuffTicks=0;
-  if(!Number.isFinite(v.nextHydrateTick)) v.nextHydrateTick=0;
-  if(!Number.isFinite(v.hydrationTimer)) v.hydrationTimer=0;
-  if(!Number.isFinite(v.socialTimer)) v.socialTimer=0;
-  if(!Number.isFinite(v.nextSocialTick)) v.nextSocialTick=0;
-  if(!Number.isFinite(v.storageIdleTimer)) v.storageIdleTimer=0;
-  if(!Number.isFinite(v.nextStorageIdleTick)) v.nextStorageIdleTick=0;
-  if(v.activeBuildingId===undefined) v.activeBuildingId=null;
-  if(!Number.isFinite(v.ageTicks)) v.ageTicks=0;
-  if(!v.lifeStage) v.lifeStage='adult';
-  if(!Number.isFinite(v.pregnancyTimer)) v.pregnancyTimer=0;
-  if(!Number.isFinite(v.childhoodTimer)) v.childhoodTimer=v.lifeStage==='child'?CHILDHOOD_TICKS:0;
-  if(!Array.isArray(v.parents)) v.parents=[];
-  if(v.pregnancyMateId===undefined) v.pregnancyMateId=null;
-  if(!Number.isFinite(v.nextPregnancyTick)) v.nextPregnancyTick=0;
-  v.ageTicks++;
-  if(v.lifeStage==='child'){
-    if(v.childhoodTimer>0) v.childhoodTimer--;
-    if(v.childhoodTimer<=0) promoteChildToAdult(v);
-  }
-  if(v.lifeStage==='adult'){
-    if(v.pregnancyTimer>0){
-      v.pregnancyTimer--;
-      if(v.pregnancyTimer<=0) completePregnancy(v);
-    } else {
-      tryStartPregnancy(v);
-    }
-  }
-  const ambientNow = ambientAt(dayTime);
-  const nightNow = isNightAmbient(ambientNow);
-  const dawnNow = isDawnAmbient(ambientNow);
-  const style = policy?.style?.jobScoring || {};
-  const blackboard = gameState.bb;
-  const resting=v.state==='resting';
-  const hydrationDecay=HYDRATION_DECAY*(resting?0.55:1);
-  v.hydration=clamp(v.hydration-hydrationDecay,0,1);
-  if(v.hydrationBuffTicks>0) v.hydrationBuffTicks--;
-  const hydratedBuff=(v.hydrationBuffTicks||0)>0;
-  const dehydrated=v.hydration<HYDRATION_LOW;
-  const hungerRate=(resting?HUNGER_RATE*REST_HUNGER_MULT:HUNGER_RATE)*(hydratedBuff?HYDRATION_HUNGER_MULT:(dehydrated?HYDRATION_DEHYDRATED_PENALTY:1));
-  v.hunger += hungerRate;
-  const tileX=v.x|0, tileY=v.y|0;
-  const warm=nearbyWarmth(tileX,tileY);
-  let energyDelta=-ENERGY_DRAIN_BASE;
-  const moodEnergyBoost=moodMotivation(v)*0.00045;
-  let happyDelta=warm?0.001:-0.0002;
-  const { moodBonus } = agricultureBonusesAt(tileX, tileY);
-  if(moodBonus){ happyDelta+=moodBonus; }
-  if(warm && nightNow){
-    happyDelta+=NIGHT_CAMPFIRE_MOOD_TICK;
-    addJobExperience(v, 'socialize', NIGHT_CAMPFIRE_XP_TICK);
-  }
-  const wellFed=v.hunger<STARVE_THRESH.hungry*0.55;
-  const wellRested=v.energy>0.55;
-  if(wellFed&&wellRested){
-    happyDelta+=0.0008+Math.max(0,v.energy-0.55)*0.0006;
-  }
-  energyDelta+=moodEnergyBoost;
-  if(hydratedBuff){
-    energyDelta*=HYDRATION_FATIGUE_BONUS;
-    happyDelta+=HYDRATION_MOOD_TICK*0.5;
-  } else if(dehydrated){
-    energyDelta*=HYDRATION_DEHYDRATED_PENALTY;
-    happyDelta-=HYDRATION_MOOD_TICK;
-  }
-  if(resting){
-    energyDelta+=REST_ENERGY_RECOVERY;
-    happyDelta+=REST_MOOD_TICK;
-  }
-  const prevStage=v.starveStage||0;
-  let stage=0;
-  if(v.hunger>STARVE_THRESH.hungry) stage=1;
-  if(v.hunger>STARVE_THRESH.starving) stage=2;
-  if(v.hunger>STARVE_THRESH.sick) stage=3;
-  if(v.recoveryTimer>0){
-    v.recoveryTimer--;
-    energyDelta*=0.6;
-    happyDelta+=0.0006;
-    if(v.recoveryTimer===0 && stage===0) v.condition='normal';
-  } else if(v.condition==='recovering' && stage===0){
-    v.condition='normal';
-  }
-  if(stage>=1) energyDelta-=0.00025;
-  if(stage>=2){ energyDelta-=0.00045; happyDelta-=0.00045; }
-  if(stage>=3){ energyDelta-=0.0006; happyDelta-=0.0009; }
-  if(stage>prevStage){
-    if(stage===1){ if(v.condition!=='sick') v.condition='hungry'; }
-    else if(stage===2){ if(v.condition!=='sick') v.condition='starving'; issueStarveToast(v,'A villager is starving! Set up food or gather berries.'); }
-    else if(stage>=3){ enterSickState(v); }
-  } else if(stage<prevStage){
-    if(prevStage>=2 && stage<=1 && v.condition!=='recovering') issueStarveToast(v,'Villager ate and is stabilizing.',true);
-    if(stage===0 && v.recoveryTimer<=0) v.condition='normal';
-    else if(stage===1 && v.condition!=='sick' && v.recoveryTimer<=0) v.condition='hungry';
-  } else if(stage===0 && v.recoveryTimer<=0 && v.condition!=='normal' && v.condition!=='recovering'){
-    v.condition='normal';
-  }
-  if(v.condition==='sick' && v.sickTimer<=0 && stage<3){
-    v.condition=stage>=2?'starving':stage===1?'hungry':'normal';
-  }
-  v.starveStage=stage;
-  if(v.condition==='sick' && v.sickTimer>0){
-    v.sickTimer--;
-    energyDelta-=0.0006;
-    happyDelta-=0.0008;
-    if(v.path) v.path.length=0;
-    finishJob(v);
-    v.state='sick';
-    v.thought=moodThought(v,'Collapsed');
-  }
-  v.hunger=clamp(v.hunger,0,1.2);
-  v.energy=clamp(v.energy+energyDelta,0,1);
-  v.happy=clamp(v.happy+happyDelta,0,1);
-  if(v.condition==='sick' && v.sickTimer>0){ return; }
-  const urgentFood = stage>=2 || v.condition==='sick';
-  const needsFood = stage>=1;
-  let panicHarvestJob=null;
-  if(v.state==='socializing' && dawnNow){
-    endBuildingStay(v);
-    v.state='idle';
-    v.socialTimer=0;
-    v.thought=moodThought(v,'Greeting the dawn');
-  }
-  // If daylight has clearly arrived, break out of lingering campfire gatherings.
-  if(!nightNow && (v.state==='socialize' || v.state==='socializing')){
-    endBuildingStay(v);
-    v.state='idle';
-    v.socialTimer=0;
-    v.nextSocialTick = Math.max(v.nextSocialTick || 0, tick + Math.floor(SOCIAL_COOLDOWN_TICKS * 0.4));
-    v.thought=moodThought(v,'Back to work');
-  }
-  if(v.state==='resting'){
-    if(urgentFood){
-      endBuildingStay(v);
-      v.state='idle';
-    } else {
-      const minRest=REST_BASE_TICKS+Math.round(Math.max(0,1-v.energy)*REST_EXTRA_PER_ENERGY*0.35);
-      if(v.restTimer<minRest) v.restTimer=minRest;
-      v.restTimer=Math.max(0,v.restTimer-1);
-      if(v.restTimer<=0 || v.energy>=0.995){
-        endBuildingStay(v);
-        v.state='idle';
-        v.restTimer=0;
-        v.happy=clamp(v.happy+REST_FINISH_MOOD,0,1);
-        v.thought=moodThought(v,'Rested');
-      } else {
-        const active=getBuildingById(v.activeBuildingId);
-        if(active) noteBuildingActivity(active,'rest');
-        v.thought=moodThought(v,'Resting');
-        return;
-      }
-    }
-  }
-  if(v.state==='hydrating'){
-    if(urgentFood){ endBuildingStay(v); v.state='idle'; }
-    else {
-      const active=getBuildingById(v.activeBuildingId);
-      v.hydration=1;
-      v.hydrationBuffTicks=Math.max(v.hydrationBuffTicks, HYDRATION_BUFF_TICKS);
-      v.hydrationTimer=Math.max(v.hydrationTimer||0, Math.round(HYDRATION_BUFF_TICKS*0.2));
-      v.hydrationTimer=Math.max(0, v.hydrationTimer-1);
-      if(active) noteBuildingActivity(active,'hydrate');
-      v.happy=clamp(v.happy+HYDRATION_MOOD_TICK,0,1);
-      v.thought=moodThought(v,'Drinking');
-      if(v.hydrationTimer<=0){
-        endBuildingStay(v);
-        v.state='idle';
-        v.hydrationTimer=0;
-        v.nextHydrateTick=tick+Math.floor(DAY_LEN*0.16);
-        v.thought=moodThought(v,'Hydrated');
-      } else {
-        return;
-      }
-    }
-  }
-  if(v.state==='socializing'){
-    if(urgentFood){ endBuildingStay(v); v.state='idle'; }
-    else {
-      v.socialTimer=Math.max(v.socialTimer||0, SOCIAL_BASE_TICKS);
-      v.socialTimer=Math.max(0, v.socialTimer-1);
-      v.happy=clamp(v.happy+SOCIAL_MOOD_TICK,0,1);
-      v.energy=clamp(v.energy+SOCIAL_ENERGY_TICK,0,1);
-      const active=getBuildingById(v.activeBuildingId);
-      if(active) noteBuildingActivity(active,'social');
-      v.thought=moodThought(v,'Sharing stories');
-      if(v.socialTimer<=0){
-        endBuildingStay(v);
-        v.state='idle';
-        v.nextSocialTick=tick+SOCIAL_COOLDOWN_TICKS;
-        v.thought=moodThought(v,'Refreshed');
-      } else {
-        return;
-      }
-    }
-  }
-  if(v.state==='storage_linger'){
-    if(urgentFood){ endBuildingStay(v); v.state='idle'; }
-    else {
-      v.storageIdleTimer=Math.max(v.storageIdleTimer||0, STORAGE_IDLE_BASE);
-      v.storageIdleTimer=Math.max(0, v.storageIdleTimer-1);
-      v.happy=clamp(v.happy+0.00045,0,1);
-      const active=getBuildingById(v.activeBuildingId);
-      if(active) noteBuildingActivity(active,'use');
-      v.thought=moodThought(v,'Tidying storage');
-      if(v.storageIdleTimer<=0){
-        endBuildingStay(v);
-        v.state='idle';
-        v.nextStorageIdleTick=tick+STORAGE_IDLE_COOLDOWN;
-        v.thought=moodThought(v,'Organized');
-      } else {
-        return;
-      }
-    }
-  }
-  if(urgentFood){
-    if(consumeFood(v)){ v.thought=moodThought(v,'Eating'); return; }
-    if(foragingJob(v)) return;
-    if(seekEmergencyFood(v, { pathLimit: 240, radius: 16 })) return;
-  } else if(needsFood){
-    if(consumeFood(v)){ v.thought=moodThought(v,'Eating'); return; }
-    if(foragingJob(v)) return;
-  }
-  // Panic harvest behavior when hungry: grab ripe crops if idle and food is tight.
-  if((urgentFood||needsFood) && v.state==='idle' && !v.targetJob){
-    panicHarvestJob = findPanicHarvestJob(v);
-  }
-  if(v.state==='idle' && !urgentFood && !needsFood && !v.targetJob){
-    if(tryEquipBow(v)) return;
-  }
-  const restThreshold = Number.isFinite(style.restEnergyThreshold) ? style.restEnergyThreshold : 0.22;
-  const fatigueThreshold = Number.isFinite(style.energyFatigueThreshold) ? style.energyFatigueThreshold : 0.32;
-  const restFatigueBoost = Number.isFinite(style.restFatigueBoost) ? style.restFatigueBoost : 0.08;
-  const fatigueFlag = !!blackboard?.energy?.fatigue;
-  const shouldRest = v.energy < restThreshold || (fatigueFlag && v.energy < restThreshold + restFatigueBoost) || v.energy < (fatigueThreshold * 0.8);
-  if(shouldRest){ if(goRest(v)) return; }
-  if(v.state==='idle' && !urgentFood){
-    if(tryHydrateAtWell(v)) return;
-  }
-  if(nightNow && v.state==='idle' && !needsFood && !urgentFood && !v.targetJob){
-    if(tryCampfireSocial(v, { ambientNow, forceNight: true })) return;
-  }
-  const reprioritizeMargin = Number.isFinite(style.reprioritizeMargin) ? style.reprioritizeMargin : 0.06;
-  if(maybeInterruptJob(v, { blackboard, margin: reprioritizeMargin })) return;
-  if(v.path && v.path.length>0){ stepAlong(v); return; }
-  if(v.inv){ const s=findNearestBuilding(v.x|0,v.y|0,'storage'); if(s && tick>=v._nextPathTick){ const entry=findEntryTileNear(s, v.x|0, v.y|0) || {x:Math.round(buildingCenter(s).x), y:Math.round(buildingCenter(s).y)}; const p=pathfind(v.x|0,v.y|0,entry.x,entry.y); if(p){ v.path=p; v.state='to_storage'; v.thought=moodThought(v,'Storing'); v._nextPathTick=tick+12; return; } } }
-    if(v.lifeStage==='child'){
-      v.targetJob=null;
-    }
-    const j=(panicHarvestJob || pickJobFor(v)); if(j && tick>=v._nextPathTick){
-    let dest={x:j.x,y:j.y};
-    let plannedPath=null;
-    if(j.type==='build'){
-      const b=buildings.find(bb=>bb.id===j.bid);
-      if(b){
-        const entry=findEntryTileNear(b, v.x|0, v.y|0);
-        if(entry){ dest=entry; }
-        else {
-          const center=buildingCenter(b);
-          dest={x:Math.round(center.x), y:Math.round(center.y)};
-        }
-      }
-    } else if(j.type==='haul'){
-      if(j.src){
-        const srcBuilding=buildingAt(j.src.x, j.src.y);
-        if(srcBuilding){
-          const entry=findEntryTileNear(srcBuilding, v.x|0, v.y|0);
-          if(entry){ dest=entry; }
-          else { dest={x:j.src.x,y:j.src.y}; }
-        } else { dest={x:j.src.x,y:j.src.y}; }
-      }
-      else {
-        const b=buildings.find(bb=>bb.id===j.bid);
-        if(b){
-          const entry=findEntryTileNear(b, v.x|0, v.y|0);
-          if(entry){ dest=entry; }
-          else {
-            const center=buildingCenter(b);
-            dest={x:Math.round(center.x), y:Math.round(center.y)};
-          }
-        }
-      }
-    } else if(j.type==='craft_bow'){
-      const lodge=buildings.find(bb=>bb.id===j.bid && bb.kind==='hunterLodge');
-      if(lodge){
-        const entry=findEntryTileNear(lodge, v.x|0, v.y|0);
-        if(entry){ dest=entry; }
-        else {
-          const center=buildingCenter(lodge);
-          dest={x:Math.round(center.x), y:Math.round(center.y)};
-        }
-      }
-    } else if(j.type==='hunt'){
-      const animal=findAnimalById(j.targetAid);
-      if(animal){
-        const approach=findHuntApproachPath(v, animal, { range:HUNT_RANGE });
-        if(approach){
-          dest=approach.dest;
-          plannedPath=approach.path;
-        }
-      }
-      if(!plannedPath){
-        suppressJob(j, HUNT_RETRY_COOLDOWN);
-        v._nextPathTick=tick+12;
-        // No viable path; skip further processing for this villager until retry.
-        return;
-      }
-    }
-    const p=plannedPath || pathfind(v.x|0,v.y|0,dest.x,dest.y);
-    if(p){
-      v.path=p;
-      v.state=j.type==='haul'?'haul_pickup':j.type;
-      if(j.type==='forage' && Number.isInteger(j.targetI)){
-        v.targetI=j.targetI;
-      }
-      v.targetJob=j;
-      v.thought=j.type==='haul'?moodThought(v,'Hauling'):moodThought(v,j.type.toUpperCase());
-      j.assigned++;
-      noteJobAssignmentChanged(j);
-      v._nextPathTick=tick+12;
-      return;
-    }
-    const retryTicks = Number.isFinite(getJobCreationConfig()?.unreachableRetryTicks)
-      ? getJobCreationConfig().unreachableRetryTicks
-      : 0;
-      if(retryTicks>0){
-        suppressJob(j, retryTicks);
-      }
-      v._nextPathTick=tick+12;
-    }
-    if(!j && v.state==='idle' && !urgentFood && !v.targetJob && jobs.length===0){
-      if(tryStorageIdle(v)) return;
-    }
-    if(v.state==='idle' && !needsFood && !urgentFood && !v.targetJob){
-      if(tryCampfireSocial(v, { ambientNow })) return;
-    }
-  if(handleIdleRoam(v, { stage, needsFood, urgentFood })) return;
-}
 function nearbyWarmth(x,y){
   return buildings.some(b=>b.kind==='campfire' && distanceToFootprint(x,y,b)<=CAMPFIRE_EFFECT_RADIUS);
 }
@@ -3943,13 +3592,53 @@ const planner = createPlanner({
   toTile
 });
 
+const _villagerTick = createVillagerTick({
+  state: gameState,
+  policy,
+  pathfind,
+  ambientAt,
+  nearbyWarmth,
+  agricultureBonusesAt,
+  getBuildingById,
+  noteBuildingActivity,
+  endBuildingStay,
+  finishJob,
+  issueStarveToast,
+  enterSickState,
+  suppressJob,
+  noteJobAssignmentChanged,
+  getJobCreationConfig,
+  findEntryTileNear,
+  findNearestBuilding,
+  buildingCenter,
+  findHuntApproachPath,
+  findAnimalById,
+  buildingAt,
+  tryEquipBow,
+  tryHydrateAtWell,
+  tryCampfireSocial,
+  tryStorageIdle,
+  foragingJob,
+  goRest,
+  seekEmergencyFood,
+  consumeFood,
+  findPanicHarvestJob,
+  pickJobFor,
+  maybeInterruptJob,
+  tryStartPregnancy,
+  completePregnancy,
+  promoteChildToAdult,
+  handleIdleRoam,
+  stepAlong
+});
+
 const tickRunner = createTickRunner({
   state: gameState,
   policy,
   planZones: planner.planZones,
   planBuildings: planner.planBuildings,
   generateJobs: planner.generateJobs,
-  villagerTick,
+  villagerTick: _villagerTick.villagerTick,
   updateAnimals,
   updateNocturnalEntities,
   seasonTick,

--- a/src/app/villagerTick.js
+++ b/src/app/villagerTick.js
@@ -1,0 +1,460 @@
+import { clamp } from './rng.js';
+import {
+  addJobExperience,
+  isDawnAmbient,
+  isNightAmbient,
+  moodMotivation,
+  moodThought
+} from './simulation.js';
+import { DAY_LENGTH, HUNT_RANGE, HUNT_RETRY_COOLDOWN } from './constants.js';
+
+const STARVE_THRESH = { hungry: 0.82, starving: 1.08, sick: 1.22 };
+
+const HUNGER_RATE = 0.00095;
+const ENERGY_DRAIN_BASE = 0.0011;
+
+const CHILDHOOD_TICKS = DAY_LENGTH * 5;
+
+const REST_BASE_TICKS = 90;
+const REST_EXTRA_PER_ENERGY = 110;
+const REST_ENERGY_RECOVERY = 0.0024;
+const REST_MOOD_TICK = 0.0009;
+const REST_FINISH_MOOD = 0.05;
+const REST_HUNGER_MULT = 0.42;
+
+const HYDRATION_DECAY = 0.00018;
+const HYDRATION_LOW = 0.28;
+const HYDRATION_BUFF_TICKS = 320;
+const HYDRATION_HUNGER_MULT = 0.9;
+const HYDRATION_FATIGUE_BONUS = 0.8;
+const HYDRATION_DEHYDRATED_PENALTY = 1.12;
+const HYDRATION_MOOD_TICK = 0.00035;
+
+const SOCIAL_BASE_TICKS = 88;
+const SOCIAL_COOLDOWN_TICKS = DAY_LENGTH * 0.2;
+const SOCIAL_MOOD_TICK = 0.0013;
+const SOCIAL_ENERGY_TICK = 0.00055;
+
+const NIGHT_CAMPFIRE_MOOD_TICK = 0.0012;
+const NIGHT_CAMPFIRE_XP_TICK = 0.15;
+
+const STORAGE_IDLE_BASE = 70;
+const STORAGE_IDLE_COOLDOWN = DAY_LENGTH * 0.12;
+
+export function createVillagerTick(opts) {
+  const {
+    state,
+    policy,
+    pathfind,
+    ambientAt,
+    nearbyWarmth,
+    agricultureBonusesAt,
+    getBuildingById,
+    noteBuildingActivity,
+    endBuildingStay,
+    finishJob,
+    issueStarveToast,
+    enterSickState,
+    suppressJob,
+    noteJobAssignmentChanged,
+    getJobCreationConfig,
+    findEntryTileNear,
+    findNearestBuilding,
+    buildingCenter,
+    findHuntApproachPath,
+    findAnimalById,
+    buildingAt,
+    tryEquipBow,
+    tryHydrateAtWell,
+    tryCampfireSocial,
+    tryStorageIdle,
+    foragingJob,
+    goRest,
+    seekEmergencyFood,
+    consumeFood,
+    findPanicHarvestJob,
+    pickJobFor,
+    maybeInterruptJob,
+    tryStartPregnancy,
+    completePregnancy,
+    promoteChildToAdult,
+    handleIdleRoam,
+    stepAlong
+  } = opts;
+
+  function villagerTick(v) {
+    if (v.condition === undefined) v.condition = 'normal';
+    if (v.starveStage === undefined) v.starveStage = 0;
+    if (v.nextStarveWarning === undefined) v.nextStarveWarning = 0;
+    if (v.sickTimer === undefined) v.sickTimer = 0;
+    if (v.recoveryTimer === undefined) v.recoveryTimer = 0;
+    if (v.restTimer === undefined) v.restTimer = 0;
+    if (!Number.isFinite(v.hydration)) v.hydration = 0.7;
+    if (!Number.isFinite(v.hydrationBuffTicks)) v.hydrationBuffTicks = 0;
+    if (!Number.isFinite(v.nextHydrateTick)) v.nextHydrateTick = 0;
+    if (!Number.isFinite(v.hydrationTimer)) v.hydrationTimer = 0;
+    if (!Number.isFinite(v.socialTimer)) v.socialTimer = 0;
+    if (!Number.isFinite(v.nextSocialTick)) v.nextSocialTick = 0;
+    if (!Number.isFinite(v.storageIdleTimer)) v.storageIdleTimer = 0;
+    if (!Number.isFinite(v.nextStorageIdleTick)) v.nextStorageIdleTick = 0;
+    if (v.activeBuildingId === undefined) v.activeBuildingId = null;
+    if (!Number.isFinite(v.ageTicks)) v.ageTicks = 0;
+    if (!v.lifeStage) v.lifeStage = 'adult';
+    if (!Number.isFinite(v.pregnancyTimer)) v.pregnancyTimer = 0;
+    if (!Number.isFinite(v.childhoodTimer)) v.childhoodTimer = v.lifeStage === 'child' ? CHILDHOOD_TICKS : 0;
+    if (!Array.isArray(v.parents)) v.parents = [];
+    if (v.pregnancyMateId === undefined) v.pregnancyMateId = null;
+    if (!Number.isFinite(v.nextPregnancyTick)) v.nextPregnancyTick = 0;
+    v.ageTicks++;
+    if (v.lifeStage === 'child') {
+      if (v.childhoodTimer > 0) v.childhoodTimer--;
+      if (v.childhoodTimer <= 0) promoteChildToAdult(v);
+    }
+    if (v.lifeStage === 'adult') {
+      if (v.pregnancyTimer > 0) {
+        v.pregnancyTimer--;
+        if (v.pregnancyTimer <= 0) completePregnancy(v);
+      } else {
+        tryStartPregnancy(v);
+      }
+    }
+
+    const tick = state.time.tick;
+    const dayTime = state.time.dayTime;
+    const ambientNow = ambientAt(dayTime);
+    const nightNow = isNightAmbient(ambientNow);
+    const dawnNow = isDawnAmbient(ambientNow);
+    const style = policy?.style?.jobScoring || {};
+    const blackboard = state.bb;
+    const buildings = state.units.buildings;
+    const jobs = state.units.jobs;
+
+    const resting = v.state === 'resting';
+    const hydrationDecay = HYDRATION_DECAY * (resting ? 0.55 : 1);
+    v.hydration = clamp(v.hydration - hydrationDecay, 0, 1);
+    if (v.hydrationBuffTicks > 0) v.hydrationBuffTicks--;
+    const hydratedBuff = (v.hydrationBuffTicks || 0) > 0;
+    const dehydrated = v.hydration < HYDRATION_LOW;
+    const hungerRate = (resting ? HUNGER_RATE * REST_HUNGER_MULT : HUNGER_RATE) * (hydratedBuff ? HYDRATION_HUNGER_MULT : (dehydrated ? HYDRATION_DEHYDRATED_PENALTY : 1));
+    v.hunger += hungerRate;
+
+    const tileX = v.x | 0;
+    const tileY = v.y | 0;
+    const warm = nearbyWarmth(tileX, tileY);
+    let energyDelta = -ENERGY_DRAIN_BASE;
+    const moodEnergyBoost = moodMotivation(v) * 0.00045;
+    let happyDelta = warm ? 0.001 : -0.0002;
+    const { moodBonus } = agricultureBonusesAt(tileX, tileY);
+    if (moodBonus) { happyDelta += moodBonus; }
+    if (warm && nightNow) {
+      happyDelta += NIGHT_CAMPFIRE_MOOD_TICK;
+      addJobExperience(v, 'socialize', NIGHT_CAMPFIRE_XP_TICK);
+    }
+    const wellFed = v.hunger < STARVE_THRESH.hungry * 0.55;
+    const wellRested = v.energy > 0.55;
+    if (wellFed && wellRested) {
+      happyDelta += 0.0008 + Math.max(0, v.energy - 0.55) * 0.0006;
+    }
+    energyDelta += moodEnergyBoost;
+    if (hydratedBuff) {
+      energyDelta *= HYDRATION_FATIGUE_BONUS;
+      happyDelta += HYDRATION_MOOD_TICK * 0.5;
+    } else if (dehydrated) {
+      energyDelta *= HYDRATION_DEHYDRATED_PENALTY;
+      happyDelta -= HYDRATION_MOOD_TICK;
+    }
+    if (resting) {
+      energyDelta += REST_ENERGY_RECOVERY;
+      happyDelta += REST_MOOD_TICK;
+    }
+
+    const prevStage = v.starveStage || 0;
+    let stage = 0;
+    if (v.hunger > STARVE_THRESH.hungry) stage = 1;
+    if (v.hunger > STARVE_THRESH.starving) stage = 2;
+    if (v.hunger > STARVE_THRESH.sick) stage = 3;
+    if (v.recoveryTimer > 0) {
+      v.recoveryTimer--;
+      energyDelta *= 0.6;
+      happyDelta += 0.0006;
+      if (v.recoveryTimer === 0 && stage === 0) v.condition = 'normal';
+    } else if (v.condition === 'recovering' && stage === 0) {
+      v.condition = 'normal';
+    }
+    if (stage >= 1) energyDelta -= 0.00025;
+    if (stage >= 2) { energyDelta -= 0.00045; happyDelta -= 0.00045; }
+    if (stage >= 3) { energyDelta -= 0.0006; happyDelta -= 0.0009; }
+    if (stage > prevStage) {
+      if (stage === 1) { if (v.condition !== 'sick') v.condition = 'hungry'; }
+      else if (stage === 2) { if (v.condition !== 'sick') v.condition = 'starving'; issueStarveToast(v, 'A villager is starving! Set up food or gather berries.'); }
+      else if (stage >= 3) { enterSickState(v); }
+    } else if (stage < prevStage) {
+      if (prevStage >= 2 && stage <= 1 && v.condition !== 'recovering') issueStarveToast(v, 'Villager ate and is stabilizing.', true);
+      if (stage === 0 && v.recoveryTimer <= 0) v.condition = 'normal';
+      else if (stage === 1 && v.condition !== 'sick' && v.recoveryTimer <= 0) v.condition = 'hungry';
+    } else if (stage === 0 && v.recoveryTimer <= 0 && v.condition !== 'normal' && v.condition !== 'recovering') {
+      v.condition = 'normal';
+    }
+    if (v.condition === 'sick' && v.sickTimer <= 0 && stage < 3) {
+      v.condition = stage >= 2 ? 'starving' : stage === 1 ? 'hungry' : 'normal';
+    }
+    v.starveStage = stage;
+    if (v.condition === 'sick' && v.sickTimer > 0) {
+      v.sickTimer--;
+      energyDelta -= 0.0006;
+      happyDelta -= 0.0008;
+      if (v.path) v.path.length = 0;
+      finishJob(v);
+      v.state = 'sick';
+      v.thought = moodThought(v, 'Collapsed');
+    }
+    v.hunger = clamp(v.hunger, 0, 1.2);
+    v.energy = clamp(v.energy + energyDelta, 0, 1);
+    v.happy = clamp(v.happy + happyDelta, 0, 1);
+    if (v.condition === 'sick' && v.sickTimer > 0) { return; }
+
+    const urgentFood = stage >= 2 || v.condition === 'sick';
+    const needsFood = stage >= 1;
+    let panicHarvestJob = null;
+
+    if (v.state === 'socializing' && dawnNow) {
+      endBuildingStay(v);
+      v.state = 'idle';
+      v.socialTimer = 0;
+      v.thought = moodThought(v, 'Greeting the dawn');
+    }
+    // If daylight has clearly arrived, break out of lingering campfire gatherings.
+    if (!nightNow && (v.state === 'socialize' || v.state === 'socializing')) {
+      endBuildingStay(v);
+      v.state = 'idle';
+      v.socialTimer = 0;
+      v.nextSocialTick = Math.max(v.nextSocialTick || 0, tick + Math.floor(SOCIAL_COOLDOWN_TICKS * 0.4));
+      v.thought = moodThought(v, 'Back to work');
+    }
+
+    if (v.state === 'resting') {
+      if (urgentFood) {
+        endBuildingStay(v);
+        v.state = 'idle';
+      } else {
+        const minRest = REST_BASE_TICKS + Math.round(Math.max(0, 1 - v.energy) * REST_EXTRA_PER_ENERGY * 0.35);
+        if (v.restTimer < minRest) v.restTimer = minRest;
+        v.restTimer = Math.max(0, v.restTimer - 1);
+        if (v.restTimer <= 0 || v.energy >= 0.995) {
+          endBuildingStay(v);
+          v.state = 'idle';
+          v.restTimer = 0;
+          v.happy = clamp(v.happy + REST_FINISH_MOOD, 0, 1);
+          v.thought = moodThought(v, 'Rested');
+        } else {
+          const active = getBuildingById(v.activeBuildingId);
+          if (active) noteBuildingActivity(active, 'rest');
+          v.thought = moodThought(v, 'Resting');
+          return;
+        }
+      }
+    }
+
+    if (v.state === 'hydrating') {
+      if (urgentFood) { endBuildingStay(v); v.state = 'idle'; }
+      else {
+        const active = getBuildingById(v.activeBuildingId);
+        v.hydration = 1;
+        v.hydrationBuffTicks = Math.max(v.hydrationBuffTicks, HYDRATION_BUFF_TICKS);
+        v.hydrationTimer = Math.max(v.hydrationTimer || 0, Math.round(HYDRATION_BUFF_TICKS * 0.2));
+        v.hydrationTimer = Math.max(0, v.hydrationTimer - 1);
+        if (active) noteBuildingActivity(active, 'hydrate');
+        v.happy = clamp(v.happy + HYDRATION_MOOD_TICK, 0, 1);
+        v.thought = moodThought(v, 'Drinking');
+        if (v.hydrationTimer <= 0) {
+          endBuildingStay(v);
+          v.state = 'idle';
+          v.hydrationTimer = 0;
+          v.nextHydrateTick = tick + Math.floor(DAY_LENGTH * 0.16);
+          v.thought = moodThought(v, 'Hydrated');
+        } else {
+          return;
+        }
+      }
+    }
+
+    if (v.state === 'socializing') {
+      if (urgentFood) { endBuildingStay(v); v.state = 'idle'; }
+      else {
+        v.socialTimer = Math.max(v.socialTimer || 0, SOCIAL_BASE_TICKS);
+        v.socialTimer = Math.max(0, v.socialTimer - 1);
+        v.happy = clamp(v.happy + SOCIAL_MOOD_TICK, 0, 1);
+        v.energy = clamp(v.energy + SOCIAL_ENERGY_TICK, 0, 1);
+        const active = getBuildingById(v.activeBuildingId);
+        if (active) noteBuildingActivity(active, 'social');
+        v.thought = moodThought(v, 'Sharing stories');
+        if (v.socialTimer <= 0) {
+          endBuildingStay(v);
+          v.state = 'idle';
+          v.nextSocialTick = tick + SOCIAL_COOLDOWN_TICKS;
+          v.thought = moodThought(v, 'Refreshed');
+        } else {
+          return;
+        }
+      }
+    }
+
+    if (v.state === 'storage_linger') {
+      if (urgentFood) { endBuildingStay(v); v.state = 'idle'; }
+      else {
+        v.storageIdleTimer = Math.max(v.storageIdleTimer || 0, STORAGE_IDLE_BASE);
+        v.storageIdleTimer = Math.max(0, v.storageIdleTimer - 1);
+        v.happy = clamp(v.happy + 0.00045, 0, 1);
+        const active = getBuildingById(v.activeBuildingId);
+        if (active) noteBuildingActivity(active, 'use');
+        v.thought = moodThought(v, 'Tidying storage');
+        if (v.storageIdleTimer <= 0) {
+          endBuildingStay(v);
+          v.state = 'idle';
+          v.nextStorageIdleTick = tick + STORAGE_IDLE_COOLDOWN;
+          v.thought = moodThought(v, 'Organized');
+        } else {
+          return;
+        }
+      }
+    }
+
+    if (urgentFood) {
+      if (consumeFood(v)) { v.thought = moodThought(v, 'Eating'); return; }
+      if (foragingJob(v)) return;
+      if (seekEmergencyFood(v, { pathLimit: 240, radius: 16 })) return;
+    } else if (needsFood) {
+      if (consumeFood(v)) { v.thought = moodThought(v, 'Eating'); return; }
+      if (foragingJob(v)) return;
+    }
+    // Panic harvest behavior when hungry: grab ripe crops if idle and food is tight.
+    if ((urgentFood || needsFood) && v.state === 'idle' && !v.targetJob) {
+      panicHarvestJob = findPanicHarvestJob(v);
+    }
+    if (v.state === 'idle' && !urgentFood && !needsFood && !v.targetJob) {
+      if (tryEquipBow(v)) return;
+    }
+    const restThreshold = Number.isFinite(style.restEnergyThreshold) ? style.restEnergyThreshold : 0.22;
+    const fatigueThreshold = Number.isFinite(style.energyFatigueThreshold) ? style.energyFatigueThreshold : 0.32;
+    const restFatigueBoost = Number.isFinite(style.restFatigueBoost) ? style.restFatigueBoost : 0.08;
+    const fatigueFlag = !!blackboard?.energy?.fatigue;
+    const shouldRest = v.energy < restThreshold || (fatigueFlag && v.energy < restThreshold + restFatigueBoost) || v.energy < (fatigueThreshold * 0.8);
+    if (shouldRest) { if (goRest(v)) return; }
+    if (v.state === 'idle' && !urgentFood) {
+      if (tryHydrateAtWell(v)) return;
+    }
+    if (nightNow && v.state === 'idle' && !needsFood && !urgentFood && !v.targetJob) {
+      if (tryCampfireSocial(v, { ambientNow, forceNight: true })) return;
+    }
+    const reprioritizeMargin = Number.isFinite(style.reprioritizeMargin) ? style.reprioritizeMargin : 0.06;
+    if (maybeInterruptJob(v, { blackboard, margin: reprioritizeMargin })) return;
+    if (v.path && v.path.length > 0) { stepAlong(v); return; }
+    if (v.inv) {
+      const s = findNearestBuilding(v.x | 0, v.y | 0, 'storage');
+      if (s && tick >= v._nextPathTick) {
+        const entry = findEntryTileNear(s, v.x | 0, v.y | 0) || { x: Math.round(buildingCenter(s).x), y: Math.round(buildingCenter(s).y) };
+        const p = pathfind(v.x | 0, v.y | 0, entry.x, entry.y);
+        if (p) {
+          v.path = p;
+          v.state = 'to_storage';
+          v.thought = moodThought(v, 'Storing');
+          v._nextPathTick = tick + 12;
+          return;
+        }
+      }
+    }
+    if (v.lifeStage === 'child') {
+      v.targetJob = null;
+    }
+    const j = (panicHarvestJob || pickJobFor(v));
+    if (j && tick >= v._nextPathTick) {
+      let dest = { x: j.x, y: j.y };
+      let plannedPath = null;
+      if (j.type === 'build') {
+        const b = buildings.find(bb => bb.id === j.bid);
+        if (b) {
+          const entry = findEntryTileNear(b, v.x | 0, v.y | 0);
+          if (entry) { dest = entry; }
+          else {
+            const center = buildingCenter(b);
+            dest = { x: Math.round(center.x), y: Math.round(center.y) };
+          }
+        }
+      } else if (j.type === 'haul') {
+        if (j.src) {
+          const srcBuilding = buildingAt(j.src.x, j.src.y);
+          if (srcBuilding) {
+            const entry = findEntryTileNear(srcBuilding, v.x | 0, v.y | 0);
+            if (entry) { dest = entry; }
+            else { dest = { x: j.src.x, y: j.src.y }; }
+          } else { dest = { x: j.src.x, y: j.src.y }; }
+        } else {
+          const b = buildings.find(bb => bb.id === j.bid);
+          if (b) {
+            const entry = findEntryTileNear(b, v.x | 0, v.y | 0);
+            if (entry) { dest = entry; }
+            else {
+              const center = buildingCenter(b);
+              dest = { x: Math.round(center.x), y: Math.round(center.y) };
+            }
+          }
+        }
+      } else if (j.type === 'craft_bow') {
+        const lodge = buildings.find(bb => bb.id === j.bid && bb.kind === 'hunterLodge');
+        if (lodge) {
+          const entry = findEntryTileNear(lodge, v.x | 0, v.y | 0);
+          if (entry) { dest = entry; }
+          else {
+            const center = buildingCenter(lodge);
+            dest = { x: Math.round(center.x), y: Math.round(center.y) };
+          }
+        }
+      } else if (j.type === 'hunt') {
+        const animal = findAnimalById(j.targetAid);
+        if (animal) {
+          const approach = findHuntApproachPath(v, animal, { range: HUNT_RANGE });
+          if (approach) {
+            dest = approach.dest;
+            plannedPath = approach.path;
+          }
+        }
+        if (!plannedPath) {
+          suppressJob(j, HUNT_RETRY_COOLDOWN);
+          v._nextPathTick = tick + 12;
+          // No viable path; skip further processing for this villager until retry.
+          return;
+        }
+      }
+      const p = plannedPath || pathfind(v.x | 0, v.y | 0, dest.x, dest.y);
+      if (p) {
+        v.path = p;
+        v.state = j.type === 'haul' ? 'haul_pickup' : j.type;
+        if (j.type === 'forage' && Number.isInteger(j.targetI)) {
+          v.targetI = j.targetI;
+        }
+        v.targetJob = j;
+        v.thought = j.type === 'haul' ? moodThought(v, 'Hauling') : moodThought(v, j.type.toUpperCase());
+        j.assigned++;
+        noteJobAssignmentChanged(j);
+        v._nextPathTick = tick + 12;
+        return;
+      }
+      const retryTicks = Number.isFinite(getJobCreationConfig()?.unreachableRetryTicks)
+        ? getJobCreationConfig().unreachableRetryTicks
+        : 0;
+      if (retryTicks > 0) {
+        suppressJob(j, retryTicks);
+      }
+      v._nextPathTick = tick + 12;
+    }
+    if (!j && v.state === 'idle' && !urgentFood && !v.targetJob && jobs.length === 0) {
+      if (tryStorageIdle(v)) return;
+    }
+    if (v.state === 'idle' && !needsFood && !urgentFood && !v.targetJob) {
+      if (tryCampfireSocial(v, { ambientNow })) return;
+    }
+    if (handleIdleRoam(v, { stage, needsFood, urgentFood })) return;
+  }
+
+  return { villagerTick };
+}


### PR DESCRIPTION
Mirrors the explicit-deps pattern already used by createPlanner and
createTickRunner: the new createVillagerTick(deps) factory takes
state/policy/pathfind, the building/job helpers, and the per-villager
AI callbacks (pickJobFor, goRest, consumeFood, etc.) as parameters
rather than closing over src/app.js module-locals. createTickRunner
still receives the function as a dep at the wiring site, so the
per-frame fan-out is unchanged.

The decay/mood/buff knobs that only villagerTick reads (HUNGER_RATE,
ENERGY_DRAIN_BASE, the REST_* recovery numbers, HYDRATION_DECAY/LOW/
HUNGER_MULT/FATIGUE_BONUS, SOCIAL_MOOD_TICK/SOCIAL_ENERGY_TICK,
NIGHT_CAMPFIRE_*) moved with it. Constants that other still-in-app.js
helpers also read are temporarily duplicated and tracked under the
new "src/app.js follow-on extractions" AUDIT entry; the duplication
collapses naturally once the villager-AI helper bundle extracts next.

src/app.js drops from ~4,017 to ~3,706 lines. Lint and build both pass.

AUDIT.md updated:
- Top high-severity entry rewritten to reflect the new state and to
  enumerate what remains in src/app.js by area.
- New Open-Medium entry "src/app.js follow-on extractions" tracks the
  next-best targets in priority order: villager-AI helpers, onArrive,
  job lifecycle, materials/haul, render body, animals, population,
  DebugKit, nocturnal entities.
- Resolved entry added for the villagerTick extraction.
- "Simulation tick interleaved with render" entry's Where line
  updated to point villagerTick at its new module.

https://claude.ai/code/session_016FRn8x5VEifhevpC4nWj9H