### PR TITLE
Extract eight more bundles out of src/app.js

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -12,35 +12,47 @@ have since been merged.
 
 ## Open — High
 
-### `src/app.js` is still a single ~3,700-line module
+### `src/app.js` is down to ~1,912 lines
 - **Where**: `src/app.js`
-- **Status**: Significant progress. Pathfinding, save/load, UI/pointer input,
-  rendering helpers, world/building data, time-of-day/experience helpers,
-  the planner, per-frame tick orchestration, and now `villagerTick` have
-  all been carved out into
-  `src/app/{pathfinding,save,ui,render,world,simulation,planner,tick,villagerTick}.js`.
-  The file is down to ~3,706 lines (from ~4,017 before the
-  `villagerTick` extraction). What remains in-file is the job lifecycle,
-  the material-reservation/haul layer, `onArrive` (the per-job arrival
-  branch), the villager-AI helper bundle (`pickJobFor`,
-  `maybeInterruptJob`, `foragingJob`, `goRest`, `seekEmergencyFood`,
-  `consumeFood`, `tryEquipBow`, `tryHydrateAtWell`, `tryCampfireSocial`,
-  `tryStorageIdle`, `handleIdleRoam`, `nearestFoodTarget`,
-  `collectFoodHubs`, `pickWeightedRandom`, `selectReachableWanderTarget`),
-  the animal system (~350 lines), the render body
-  (`render`/`drawBuildingAt`/`drawAnimal`/`drawVillager` plus overlay
-  helpers, ~600 lines), the population/birth helpers, the DebugKit
-  bridge, and boot wiring.
-- **Why it matters**: The remaining file still owns module-local mirrors of
-  `gameState` arrays (`buildings`, `villagers`, `jobs`, `animals`,
-  `itemsOnGround`) and a property-getter/setter for `world`. Most of the
-  trickier remaining items below trace back to that coupling.
-- **Suggested next pass**: Track follow-on extraction targets under the
-  new "src/app.js follow-on extractions" entry below. The villager-AI
-  helper bundle is the highest-leverage next target because every
-  helper there is also a dep that `createVillagerTick` currently has
-  to be handed via the deps bag — extracting them next will collapse
-  the bag and let `villagerTick` import its callees directly.
+- **Status**: Eight more bundles extracted in the latest pass — jobs,
+  animals, nocturnal entities, DebugKit bridge, material reservation /
+  haul scheduling, population / birth, the villager-AI helper bundle,
+  and `stepAlong`/`onArrive`. New modules:
+  `src/app/{jobs,animals,nocturnal,debugkit,materials,population,villagerAI,onArrive}.js`.
+  The file went from 3,706 → 1,912 lines (-48%, ~1,794 lines removed).
+  The villager-tuning constants (`STARVE_THRESH`, `REST_BASE_TICKS`,
+  `HYDRATION_BUFF_TICKS`, `SOCIAL_*`, `STORAGE_IDLE_*`, `CHILDHOOD_TICKS`,
+  …) now live in a single source of truth (`villagerAI.js` /
+  `population.js`) and are imported by `villagerTick.js` and
+  `onArrive.js`, closing the cross-cutting duplication.
+- **What's left in-file** (in roughly top-to-bottom order):
+  - The render body — `render()` (~300 lines),
+    `drawBuildingAt`/`drawAnimal`/`drawVillager`/`drawQueuedVillagerLabels`
+    (~250 lines), the overlay helpers
+    (`drawStaticAlbedo`/`drawShadow`/`drawZoneOverlay`/`drawWaterOverlay`/
+    the row-mask + cache scaffolding), and `markStaticDirty` /
+    `markZoneOverlayDirty`. Together these are ~700 lines and are the
+    only outstanding extraction target.
+  - Boot wiring: factory instantiation block, `newWorld()`, `update()`,
+    `boot()`, `window.AIV_APP` glue.
+  - Module-local mirrors of `gameState` arrays (`buildings`,
+    `villagers`, `jobs`, `animals`, `itemsOnGround`), the `world`
+    getter/setter, and the `tick`/`dayTime` getter shims.
+  - A small handful of building-query thunks (`addBuilding`,
+    `tileOccupiedByBuilding`, `buildingAt`, `validateFootprintPlacement`,
+    `findEntryTileNear`, `getBuildingById`, `noteBuildingActivity`,
+    `setActiveBuilding`, `clearActiveBuilding`, `endBuildingStay`,
+    `agricultureBonusesAt`) that close over the in-file `buildings`
+    array.
+  - `el`, `ZONE_JOB_TYPES`, `zoneCanEverWork`, `zoneHasWorkNow`,
+    `seasonTick`, `dropItem`, `processVillagerItemPickup`,
+    `centerCamera`, the shading-mode glue
+    (`normalizeShadingMode`/`computeShadeForMode`/`applyShadingMode`/
+    `applyShadingParams`), and `ensureBlackboardSnapshot`.
+- **Why it matters**: The remaining file still owns module-local mirrors
+  of `gameState` arrays. Once the render body extracts, those mirrors
+  can collapse into a single `createGameStateAccess()` helper and
+  `src/app.js` will be ~1,200 lines of pure boot wiring.
 
 ### Simulation tick interleaved with render
 - **Where**: `src/app.js` `update()` calls `tickRunner.runFrame()`
@@ -61,85 +73,39 @@ have since been merged.
 
 ## Open — Medium
 
-### `src/app.js` follow-on extractions
-- **Where**: `src/app.js`
-- **Status**: Track-list of the next-best extraction targets, in priority
-  order, now that `villagerTick` has moved to its own module. Each item
-  is sized so that a single PR can land it without rewriting unrelated
-  systems.
-  1. **Villager-AI helper bundle** — `pickJobFor`, `maybeInterruptJob`,
-     `scoreExistingJobForVillager`, `findPanicHarvestJob`, `foragingJob`,
-     `goRest`, `tryEquipBow`, `tryHydrateAtWell`, `tryCampfireSocial`,
-     `tryStorageIdle`, `consumeFood`, `seekEmergencyFood`,
-     `nearestFoodTarget`, `collectFoodHubs`, `pickWeightedRandom`,
-     `selectReachableWanderTarget`, `handleIdleRoam`, `findNearestBuilding`,
-     plus the starve-cycle trio (`issueStarveToast`, `enterSickState`,
-     `handleVillagerFed`) at `src/app.js:~1596-2538`. Extract into
-     `src/app/villagerAI.js` using the `createVillagerAI(deps)` factory
-     pattern. **High leverage**: `createVillagerTick`'s ~30-entry deps
-     bag mostly points at this bundle, so once it lands the bag
-     collapses to a handful of cross-module entries (`pathfind`,
-     `ambientAt`, building/job helpers).
-  2. **`onArrive`** (`src/app.js:~2540-2950`, ~400 lines branching on
-     every job type — `chop`, `mine`, `sow`, `harvest`, `forage`,
-     `build`, `haul`, `craft_bow`, `hunt`, `rest`, `hydrate`,
-     `socialize`, `storage_*`). Reads `world`, `buildings`, `jobs`,
-     `itemsOnGround`, `storageTotals`, `storageReserved` directly.
-     Extract into `src/app/onArrive.js` (or fold into `villagerAI.js`).
-  3. **Job lifecycle** — `addJob`, `finishJob`, `noteJobAssignmentChanged`,
-     `noteJobRemoved`, `suppressJob`, `isJobSuppressed`, `hasSimilarJob`,
-     `jobKey`, `getJobCreationConfig`, plus the `jobSuppression` /
-     `activeZoneJobs` indices at `src/app.js:~1482-1556`. Extract into
-     `src/app/jobs.js`.
-  4. **Material reservation / haul scheduling** — `availableToReserve`,
-     `canReserveMaterials`, `reserveMaterials`, `releaseReservedMaterials`,
-     `spendCraftMaterials`, `scheduleHaul`, `requestBuildHauls`,
-     `cancelHaulJobsForBuilding` at `src/app.js:~1347-1465`. Extract
-     into `src/app/materials.js`.
-  5. **Render body** — `render` and its draw helpers
-     (`drawBuildingAt`, `drawAnimal`, `drawVillager`,
-     `drawQueuedVillagerLabels`, `drawShadow`, `drawZoneOverlay`,
-     `drawWaterOverlay`, `drawNocturnalEntities`, `drawStaticAlbedo`)
-     at `src/app.js:~3037-3650`. Fattens `src/app/render.js` (which
-     today only owns lower-level helpers).
-  6. **Animal system** — `spawnAnimalsForWorld`, `behaviorForAnimal`,
-     `ensureAnimalDefaults`, `animalTileBlocked`, `pickRoamTarget`,
-     `attemptGraze`, `chooseFleeTarget`, `findAnimalById`,
-     `removeAnimal`, `resolveHuntYield`, `findHuntApproachPath`,
-     `interactWithVillage`, `stepAnimal`, `animalTick`, `updateAnimals`
-     at `src/app.js:~658-1010`. Extract into `src/app/animals.js`.
-  7. **Population/birth helpers** — `housingCapacity`,
-     `populationLimit`, `canSupportBirth`, `findBirthMate`,
-     `tryStartPregnancy`, `spawnChildNearParents`, `flushPendingBirths`,
-     `completePregnancy`, `promoteChildToAdult`, plus
-     `assignAdultTraits`/`rollAdultRole`/`newVillager`/`newChildVillager`
-     at `src/app.js:~1174-2148`. Extract into `src/app/population.js`.
-  8. **DebugKit bridge** — `debugKitGetPipeline`, `describeCanvasContext`,
-     `debugKitGetLightingProbe`, `debugKitEnterSafeMode`,
-     `debugKitGetState`, `configureDebugKitBridge`,
-     `installDebugKitWatcher`, `ensureDebugKitConfigured` at
-     `src/app.js:~373-598`. Extract into `src/app/debugkit.js`.
-  9. **Nocturnal entities** — `nocturnalAmbientStrength`,
-     `spawnNocturnalEntity`, `updateNocturnalEntities`,
-     `drawNocturnalEntities`, plus the `nocturnalEntities` array and
-     `nocturnalSpawnCooldown` at `src/app.js:~235-247, 3807-3900`.
-     Bundle with the render extraction.
-- **Why it matters**: Each leaves `src/app.js` smaller and
-  `gameState`-coupling more localized; combined, they take the file
-  below ~1,000 lines (mostly boot wiring + the module-local mirrors
-  themselves), at which point the mirrors can finally collapse.
-- **Cross-cutting cleanup**: A handful of villager-tuning constants
-  (`STARVE_THRESH`, `CHILDHOOD_TICKS`, `HYDRATION_BUFF_TICKS`,
-  `HYDRATION_DEHYDRATED_PENALTY`, `HYDRATION_MOOD_TICK`,
-  `REST_BASE_TICKS`, `REST_EXTRA_PER_ENERGY`, `SOCIAL_BASE_TICKS`,
-  `SOCIAL_COOLDOWN_TICKS`, `STORAGE_IDLE_BASE`, `STORAGE_IDLE_COOLDOWN`)
-  are duplicated between `src/app.js:1567-1591` and
-  `src/app/villagerTick.js:11-43` because the helpers that read them
-  in `src/app.js` haven't moved yet. The cleanup falls out for free
-  once the villager-AI helper bundle (#1) lands — both files start
-  importing from a single source. Until then, treat the duplication
-  as a bug magnet and keep the two blocks in sync if any value
-  changes.
+### Render body still in `src/app.js`
+- **Where**: `src/app.js` (~lines 800–1620 of the current 1,912-line
+  file).
+- **Status**: This is the only follow-on extraction target left in the
+  original "src/app.js follow-on extractions" track-list. The other
+  eight bundles landed in the latest pass; see Resolved.
+- **Functions to move**: `render` (~300 lines), `drawBuildingAt`,
+  `drawAnimal`, `drawVillager`, `drawQueuedVillagerLabels`,
+  `drawStaticAlbedo`, `drawShadow`, `drawZoneOverlay`,
+  `drawWaterOverlay`, `ensureZoneOverlayCanvas`, `activeZoneSignature`,
+  `rebuildZoneOverlay`, `ensureWaterOverlayCanvas`, `maybeBuildLightmap`
+  (the in-file 3-line wrapper), `markStaticDirty`,
+  `markZoneOverlayDirty`, plus the row-mask helpers
+  (`ensureRowMasksSize`, `refreshWaterRowMaskFromTiles`,
+  `refreshZoneRowMask`, `updateZoneRow`) and the cache locals
+  (`waterRowMask`, `zoneRowMask`, `zoneOverlayCache`,
+  `waterOverlayCache`, `staticAlbedoCanvas`, `staticAlbedoCtx`,
+  `staticDirty`).
+- **Suggested target**: extend `src/app/render.js`'s
+  `createRenderSystem(deps)` with these helpers. The factory's deps
+  bag will grow substantially (gameState arrays, `findAnimalById`,
+  `getBuildingById`, `agricultureBonusesAt`, `nearbyWarmth`, etc.) —
+  expect ~25 new dep entries.
+- **Why it's still here**: This bundle has the most module-local
+  coupling of the nine. Each draw helper closes over `world`, `cam`,
+  `ctx`, and one or more `units.*` arrays, plus the overlay caches
+  are themselves stateful. A clean extraction needs careful design
+  of the cache ownership and a thunk strategy for the building-query
+  helpers (which still live in `src/app.js`). It was deferred from
+  the latest pass to keep the extraction safe rather than rushed.
+- **Net once it lands**: `src/app.js` drops to ~1,200 lines (boot
+  wiring + module-local mirrors + a few in-file thunks), at which
+  point the gameState mirrors themselves can collapse.
 
 ### Canvas/lightmap context release on world swap
 - **Where**: `src/app.js` `newWorld()` reassigns `world.lightmapCanvas`/
@@ -301,3 +267,78 @@ prior audit; the linked file/line is where the fix lives.
 - **Lint not gated in CI** — `.github/workflows/deploy-pages.yml` now
   runs `npm run lint` between `npm ci` and `npm run build`, so lint
   regressions block the deploy job before it ever uploads `dist/`.
+- **Job lifecycle extracted** — `createJobsSystem(deps)` in
+  `src/app/jobs.js` owns `jobKey`, `isJobSuppressed`, `suppressJob`,
+  `hasSimilarJob`, `violatesSpacing`, `addJob`, `finishJob`,
+  `noteJobAssignmentChanged`, `noteJobRemoved`, `getJobCreationConfig`,
+  `clearActiveZoneJobs`, plus the `jobSuppression` Map and
+  `activeZoneJobs` indices. New `detachVillagersFromJob` helper lifts
+  the villager-cleanup pass out of `cancelHaulJobsForBuilding` so
+  `materials.js` can reuse it.
+- **Animal system extracted** — `createAnimalsSystem(deps)` in
+  `src/app/animals.js` owns the full lifecycle:
+  `spawnAnimalsForWorld`, `behaviorForAnimal`, `ensureAnimalDefaults`,
+  `animalTileBlocked`, `queueAnimalLabel`, `nearestVillagerWithin`,
+  `pickRoamTarget`, `attemptGraze`, `chooseFleeTarget`,
+  `findAnimalById`, `removeAnimal`, `resolveHuntYield`,
+  `findHuntApproachPath`, `interactWithVillage`, `stepAnimal`,
+  `animalTick`, `updateAnimals`, plus the `DEFAULT_ANIMAL_BEHAVIOR`
+  fallback.
+- **Nocturnal entities extracted** — `createNocturnalSystem()` in
+  `src/app/nocturnal.js` owns the `nocturnalEntities` array,
+  `nocturnalSpawnCooldown`, `nocturnalAmbientStrength`,
+  `spawnNocturnalEntity`, `updateNocturnalEntities`, and
+  `drawNocturnalEntities`. The state was previously a top-level
+  module-local in `src/app.js`.
+- **DebugKit bridge extracted** — `createDebugKitBridge(deps)` in
+  `src/app/debugkit.js` owns `debugKitGetPipeline`,
+  `describeCanvasContext`, `debugKitGetLightingProbe`,
+  `debugKitEnterSafeMode`, `debugKitGetState`,
+  `configureDebugKitBridge`, `installDebugKitWatcher`,
+  `ensureDebugKitConfigured`, plus a new `attachToWindow()` method
+  that bundles the prior `if (typeof window !== 'undefined') { … }`
+  boot block.
+- **Material reservation / haul scheduling extracted** —
+  `createMaterials(deps)` in `src/app/materials.js` owns
+  `availableToReserve`, `canReserveMaterials`, `reserveMaterials`,
+  `releaseReservedMaterials`, `spendCraftMaterials`,
+  `countBuildingsByKind`, `scheduleHaul`, `requestBuildHauls`,
+  `cancelHaulJobsForBuilding`. Cross-references `findNearestBuilding`
+  via a thunk so it can be wired before `villagerAI.js` (which owns
+  that helper).
+- **Population / birth helpers extracted** — `createPopulation(deps)`
+  in `src/app/population.js` owns `rollAdultRole`, `assignAdultTraits`,
+  `newVillager`, `newChildVillager`, `housingCapacity`,
+  `populationLimit`, `canSupportBirth`, `findBirthMate`,
+  `tryStartPregnancy`, `spawnChildNearParents`, `flushPendingBirths`,
+  `completePregnancy`, `promoteChildToAdult`, plus the `pendingBirths`
+  array and the population/pregnancy constants (`PREGNANCY_TICKS`,
+  `CHILDHOOD_TICKS`, `PREGNANCY_ATTEMPT_*`, `POPULATION_*`,
+  `FOOD_HEADROOM_PER_VILLAGER`). `CHILDHOOD_TICKS` is re-exported and
+  consumed by `villagerTick.js`.
+- **Villager-AI helper bundle extracted** — `createVillagerAI(deps)`
+  in `src/app/villagerAI.js` owns `pickJobFor`, `maybeInterruptJob`,
+  `scoreExistingJobForVillager`, `findPanicHarvestJob`, `foragingJob`,
+  `goRest`, `tryEquipBow`, `tryHydrateAtWell`, `tryCampfireSocial`,
+  `tryStorageIdle`, `consumeFood`, `seekEmergencyFood`,
+  `nearestFoodTarget`, `getRallyPoint`, `countNearbyVillagers`,
+  `collectFoodHubs`, `pickWeightedRandom`,
+  `selectReachableWanderTarget`, `handleIdleRoam`,
+  `findNearestBuilding`, `nearbyWarmth`, plus the starve trio
+  (`issueStarveToast`, `enterSickState`, `handleVillagerFed`).
+- **`onArrive` extracted** — `createOnArrive(deps)` in
+  `src/app/onArrive.js` owns the per-job arrival dispatcher and
+  `stepAlong`. The factory takes ~30 deps via the bag pattern; an
+  `onZoneTileSown` callback isolates the render-side row-mask
+  refresh so the module doesn't import the overlay state directly.
+- **Villager-tuning constants deduplicated** — `STARVE_THRESH`,
+  `STARVE_COLLAPSE_TICKS`, `STARVE_RECOVERY_TICKS`,
+  `STARVE_TOAST_COOLDOWN`, `FOOD_HUNGER_RECOVERY`, `REST_BASE_TICKS`,
+  `REST_EXTRA_PER_ENERGY`, `HYDRATION_VISIT_THRESHOLD`,
+  `HYDRATION_BUFF_TICKS`, `SOCIAL_BASE_TICKS`,
+  `SOCIAL_COOLDOWN_TICKS`, `STORAGE_IDLE_BASE`,
+  `STORAGE_IDLE_COOLDOWN` now live only in `src/app/villagerAI.js`
+  and are imported from there by `villagerTick.js` and
+  `onArrive.js`. `CHILDHOOD_TICKS` similarly lives only in
+  `src/app/population.js`. The cross-cutting cleanup tracked under
+  the prior follow-on entry is closed.

--- a/src/app.js
+++ b/src/app.js
@@ -1,28 +1,20 @@
 import { createInitialState } from './state.js';
 import { policy } from './policy/policy.js';
 import { computeBlackboard } from './ai/blackboard.js';
-import { score as scoreJob, computeFamineSeverity } from './ai/scoring.js';
 import {
-  ANIMAL_BEHAVIORS,
-  ANIMAL_TYPES,
-  CRAFTING_RECIPES,
   DAY_LENGTH,
   DIR4,
   ENTITY_TILE_PX,
   GRID_H,
   GRID_SIZE,
   GRID_W,
-  HUNT_RANGE,
-  HUNT_RETRY_COOLDOWN,
   ITEM,
   LAYER_ORDER,
   SHADOW_DIRECTION,
   SHADOW_DIRECTION_ANGLE,
-  SPEEDS,
   TILE,
   TILES,
   TREE_VERTICAL_RAISE,
-  WALKABLE,
   ZONES,
   baseIdx,
   tileToPxX,
@@ -32,7 +24,7 @@ import { AIV_SCOPE, SHADING_DEFAULTS, WORLDGEN_DEFAULTS, generateTerrain, makeHi
 import { LIGHTING, clamp01, makeAltitudeShade, registerShadingHandlers, setShadingMode, setShadingParams } from './app/lighting.js';
 import { Storage, reportFatal, setUpdateCallback } from './app/storage.js';
 import { H, W, cam, clampCam, context2d, ctx } from './app/canvas.js';
-import { R, clamp, irnd, mulberry32, rnd, setRandomSource, uid } from './app/rng.js';
+import { R, clamp, irnd, mulberry32, setRandomSource, uid } from './app/rng.js';
 import { Tileset, SHADOW_TEXTURE, buildTileset, makeCanvas } from './app/tileset.js';
 import { createPathfinder } from './app/pathfinding.js';
 import { createSaveSystem } from './app/save.js';
@@ -41,31 +33,28 @@ import { createRenderSystem } from './app/render.js';
 import { createPlanner } from './app/planner.js';
 import { createTickRunner } from './app/tick.js';
 import { createVillagerTick } from './app/villagerTick.js';
+import { createJobsSystem } from './app/jobs.js';
+import { createAnimalsSystem } from './app/animals.js';
+import { createNocturnalSystem } from './app/nocturnal.js';
+import { createDebugKitBridge } from './app/debugkit.js';
+import { createMaterials } from './app/materials.js';
+import { CHILDHOOD_TICKS, createPopulation } from './app/population.js';
+import { STARVE_THRESH, createVillagerAI } from './app/villagerAI.js';
+import { createOnArrive } from './app/onArrive.js';
 import {
   BUILDINGS,
-  CAMPFIRE_EFFECT_RADIUS,
   agricultureBonusesAt as _agricultureBonusesAt,
   buildingAtIn,
   buildingCenter,
   buildingEntryTiles,
-  buildingResourceNeed,
-  buildingSupplyStatus,
-  distanceToFootprint,
   ensureBuildingData,
   getFootprint,
   tileOccupiedByBuildingIn,
   validateFootprintPlacementIn
 } from './app/world.js';
 import {
-  DAWN_AMBIENT_THRESHOLD,
-  addJobExperience,
-  applySkillGain,
-  createExperienceLedger,
   createTimeOfDay,
-  effectiveSkillFromExperience,
-  isDawnAmbient,
   isNightAmbient,
-  moodThought,
   normalizeExperienceLedger
 } from './app/simulation.js';
 
@@ -212,41 +201,11 @@ function reindexAllBuildings(){
 }
 let emittersDirty = true;
 function markEmittersDirty(){ emittersDirty = true; }
-const activeZoneJobs = { sow: new Set(), chop: new Set(), mine: new Set() };
-function clearActiveZoneJobs(){
-  activeZoneJobs.sow.clear();
-  activeZoneJobs.chop.clear();
-  activeZoneJobs.mine.clear();
-}
-function noteJobAssignmentChanged(j){
-  if(!j) return;
-  const set = activeZoneJobs[j.type];
-  if(!set) return;
-  const key = j.y * GRID_W + j.x;
-  if((j.assigned||0) > 0) set.add(key);
-  else set.delete(key);
-}
-function noteJobRemoved(j){
-  if(!j) return;
-  const set = activeZoneJobs[j.type];
-  if(!set) return;
-  set.delete(j.y * GRID_W + j.x);
-}
-const nocturnalEntities = new Array(28).fill(null).map(() => ({
-  active: false,
-  x: 0,
-  y: 0,
-  vx: 0,
-  vy: 0,
-  radius: 0.45,
-  alpha: 0,
-  energy: 1,
-  fade: 0,
-  wanderTicks: 0
-}));
-let nocturnalSpawnCooldown = 0;
-const pendingBirths = [];
-const jobSuppression = new Map();
+// activeZoneJobs / clearActiveZoneJobs / noteJobAssignmentChanged / noteJobRemoved
+// moved to src/app/jobs.js (createJobsSystem). Wired below.
+// nocturnalEntities and nocturnalSpawnCooldown moved to src/app/nocturnal.js.
+// pendingBirths moved to src/app/population.js.
+// jobSuppression moved to src/app/jobs.js.
 const itemTileIndex = new Map();
 let itemTileIndexDirty = true;
 const storageTotals = stocks.totals;
@@ -370,231 +329,6 @@ Object.defineProperty(rng, 'generator', {
 });
 rng.seed = Number.isFinite(rng.seed) ? rng.seed >>> 0 : (Date.now() | 0);
 
-let debugKitInstance = null;
-let debugKitWatcherInstalled = false;
-
-function debugKitGetPipeline() {
-  const pipe = world?.__debug?.pipeline;
-  if (!Array.isArray(pipe) || pipe.length === 0) {
-    return [];
-  }
-  return pipe.map((entry) => {
-    if (!entry) return entry;
-    return {
-      name: entry.name || '',
-      ok: entry.ok === true,
-      extra: entry.extra === undefined ? null : entry.extra
-    };
-  });
-}
-
-function describeCanvasContext(ctx) {
-  if (!ctx || !ctx.canvas) {
-    return null;
-  }
-  const canvas = ctx.canvas;
-  let type = 'unknown';
-  if (typeof ctx.getContextAttributes === 'function') {
-    type = 'webgl';
-  } else if (typeof ctx.getImageData === 'function') {
-    type = '2d';
-  }
-  return {
-    type,
-    size: {
-      width: Number.isFinite(canvas.width) ? canvas.width : null,
-      height: Number.isFinite(canvas.height) ? canvas.height : null
-    }
-  };
-}
-
-function debugKitGetLightingProbe() {
-  const mode = LIGHTING?.mode ?? 'unknown';
-  const useMultiply = LIGHTING?.useMultiplyComposite === true;
-  const scale = Number.isFinite(LIGHTING?.lightmapScale) ? LIGHTING.lightmapScale : null;
-  const hillshadeQ = world?.hillshadeQ || null;
-  const lightmapQ = world?.lightmapQ || null;
-  const statsFn = (debugKitInstance && typeof debugKitInstance.arrMinMax === 'function')
-    ? debugKitInstance.arrMinMax
-    : null;
-  const hillshadeStats = statsFn && hillshadeQ ? statsFn(hillshadeQ) : null;
-  const lightmapStats = statsFn && lightmapQ ? statsFn(lightmapQ) : null;
-  const reasons = [];
-  let canMultiply = useMultiply;
-
-  if (!world) {
-    reasons.push('World not initialized');
-    canMultiply = false;
-  } else {
-    if (mode === 'off') {
-      reasons.push('Lighting mode set to off');
-      canMultiply = false;
-    }
-    if (!world.lightmapCtx) {
-      reasons.push('lightmapCtx missing');
-      canMultiply = false;
-    }
-    if (!lightmapQ) {
-      reasons.push('lightmapQ not built');
-      canMultiply = false;
-    }
-  }
-
-  return {
-    mode,
-    useMultiplyComposite: useMultiply,
-    lightmapScale: scale,
-    contexts: {
-      lightmap: describeCanvasContext(world?.lightmapCtx || null),
-      albedo: describeCanvasContext(world?.staticAlbedoCtx || null)
-    },
-    hillshadeQ,
-    lightmapQ,
-    HqMin: hillshadeStats ? hillshadeStats.min : null,
-    HqMax: hillshadeStats ? hillshadeStats.max : null,
-    LqMin: lightmapStats ? lightmapStats.min : null,
-    LqMax: lightmapStats ? lightmapStats.max : null,
-    canMultiply,
-    reasons
-  };
-}
-
-function debugKitEnterSafeMode() {
-  try {
-    if (typeof applyShadingMode === 'function') {
-      applyShadingMode('off');
-    } else if (LIGHTING) {
-      LIGHTING.mode = 'off';
-      LIGHTING.useMultiplyComposite = false;
-    }
-    if (world) {
-      world.lightmapQ = null;
-      if (world.lightmapCtx && world.lightmapCanvas) {
-        try {
-          world.lightmapCtx.clearRect(0, 0, world.lightmapCanvas.width, world.lightmapCanvas.height);
-        } catch (err) {
-          /* ignore */
-        }
-      }
-      if (typeof markStaticDirty === 'function') {
-        markStaticDirty();
-      }
-    }
-  } catch (err) {
-    console.warn('DebugKit safe mode failed', err);
-  }
-}
-
-function debugKitGetState() {
-  const villagerCount = Array.isArray(villagers) ? villagers.length : 0;
-  let snapshotTime = null;
-  if (world?.clock && Number.isFinite(world.clock.timeOfDay)) {
-    snapshotTime = world.clock.timeOfDay;
-  } else if (Number.isFinite(dayTime)) {
-    snapshotTime = dayTime;
-  }
-  const villagerDetails = Array.isArray(villagers)
-    ? villagers.map((v) => ({
-        id: v.id,
-        number: ensureVillagerNumber(v),
-        role: v.role,
-        lifeStage: v.lifeStage,
-        state: v.state,
-        thought: v.thought,
-        condition: v.condition,
-        hunger: clamp(Number.isFinite(v.hunger) ? v.hunger : 0, 0, 1),
-        energy: clamp(Number.isFinite(v.energy) ? v.energy : 0, 0, 1),
-        hydration: clamp(Number.isFinite(v.hydration) ? v.hydration : 0, 0, 1),
-        happy: clamp(Number.isFinite(v.happy) ? v.happy : 0, 0, 1),
-        position: { x: v.x, y: v.y },
-        targetJob: v.targetJob
-          ? { type: v.targetJob.type, x: v.targetJob.x, y: v.targetJob.y, bid: v.targetJob.bid ?? null }
-          : null,
-        carrying: v.inv ? { type: v.inv.type, qty: v.inv.qty ?? 1 } : null,
-        activeBuildingId: v.activeBuildingId ?? null
-      }))
-    : [];
-  return {
-    frame: world?.__debug?.lastFrame ?? 0,
-    timeOfDay: snapshotTime,
-    villagers: villagerCount,
-    lightingMode: LIGHTING?.mode ?? 'unknown',
-    multiplyComposite: LIGHTING?.useMultiplyComposite === true,
-    villagerDetails
-  };
-}
-
-function configureDebugKitBridge(instance) {
-  if (!instance || typeof instance.configure !== 'function') {
-    return;
-  }
-  debugKitInstance = instance;
-  try {
-    instance.configure({
-      getPipeline: debugKitGetPipeline,
-      getLightingProbe: debugKitGetLightingProbe,
-      onSafeMode: debugKitEnterSafeMode,
-      getState: debugKitGetState
-    });
-  } catch (err) {
-    console.warn('DebugKit configure failed', err);
-  }
-}
-
-function installDebugKitWatcher() {
-  if (debugKitWatcherInstalled || typeof window === 'undefined') {
-    return;
-  }
-  debugKitWatcherInstalled = true;
-  let currentKit = window.DebugKit;
-  const descriptor = Object.getOwnPropertyDescriptor(window, 'DebugKit');
-  const canRedefine = !descriptor || descriptor.configurable === true;
-  if (canRedefine) {
-    Object.defineProperty(window, 'DebugKit', {
-      configurable: true,
-      enumerable: true,
-      get() {
-        return currentKit;
-      },
-      set(value) {
-        currentKit = value;
-        if (value && typeof value.configure === 'function') {
-          configureDebugKitBridge(value);
-        }
-      }
-    });
-  }
-  if (currentKit && typeof currentKit.configure === 'function') {
-    configureDebugKitBridge(currentKit);
-  }
-}
-
-function ensureDebugKitConfigured() {
-  if (debugKitInstance) {
-    configureDebugKitBridge(debugKitInstance);
-  } else if (typeof window !== 'undefined' && window.DebugKit != null) {
-    configureDebugKitBridge(window.DebugKit);
-  }
-}
-
-if (typeof window !== 'undefined') {
-  installDebugKitWatcher();
-  if (window.DebugKit != null) {
-    configureDebugKitBridge(window.DebugKit);
-  }
-  const prevReady = typeof window.__AIV_DEBUGKIT_READY__ === 'function'
-    ? window.__AIV_DEBUGKIT_READY__
-    : null;
-  window.__AIV_DEBUGKIT_READY__ = function (kit) {
-    try {
-      configureDebugKitBridge(kit);
-    } finally {
-      if (prevReady && prevReady !== window.__AIV_DEBUGKIT_READY__) {
-        try { prevReady(kit); } catch (err) { console.warn('DebugKit ready hook failed', err); }
-      }
-    }
-  };
-}
 
 const _timeOfDay = createTimeOfDay({
   getTick: () => tick,
@@ -655,357 +389,6 @@ function applyShadingParams({ ambient, intensity, slopeScale } = {}) {
 
 registerShadingHandlers({ setMode: applyShadingMode, setParams: applyShadingParams });
 
-function desiredAnimalsForType(type){
-  const def = ANIMAL_TYPES[type];
-  if(!def) return 0;
-  const density = typeof def.density === 'number' ? def.density : 0;
-  const baseCount = Math.round(GRID_SIZE * density);
-  const minCount = def.minCount || 0;
-  return Math.max(minCount, baseCount);
-}
-
-function isAnimalTileAllowed(tile, def, allowFallback){
-  const preferred = Array.isArray(def?.preferred) ? def.preferred : [];
-  const fallback = Array.isArray(def?.fallback) ? def.fallback : preferred;
-  const allowedSet = allowFallback ? (fallback.length ? fallback : preferred) : preferred;
-  if(allowedSet.length === 0){
-    return WALKABLE.has(tile);
-  }
-  return allowedSet.includes(tile);
-}
-
-function spawnAnimalsForWorld(){
-  animals.length = 0;
-  const occupied = new Set();
-
-  const tileFree = (x,y)=>{
-    if(x<0||y<0||x>=GRID_W||y>=GRID_H) return false;
-    const idx = y*GRID_W + x;
-    if(occupied.has(idx)) return false;
-    if(tileOccupiedByBuilding(x,y)) return false;
-    const tile = world.tiles[idx];
-    if(tile === TILES.WATER) return false;
-    if(world.trees[idx]>0 || world.rocks[idx]>0) return false;
-    return WALKABLE.has(tile);
-  };
-
-  for(const [type, def] of Object.entries(ANIMAL_TYPES)){
-    const target = desiredAnimalsForType(type);
-    if(target <= 0) continue;
-    let placed = 0;
-    let attempts = 0;
-    const maxAttempts = Math.max(target * 180, target * 24);
-    while(placed < target && attempts < maxAttempts){
-      attempts++;
-      const x = irnd(0, GRID_W-1);
-      const y = irnd(0, GRID_H-1);
-      if(!tileFree(x,y)) continue;
-      const idx = y*GRID_W + x;
-      const tile = world.tiles[idx];
-      const allowFallback = attempts > target * 60;
-      if(!isAnimalTileAllowed(tile, def, allowFallback)) continue;
-      animals.push({ id: uid(), type, x, y, dir: R() < 0.5 ? 'left' : 'right' });
-      occupied.add(idx);
-      placed++;
-    }
-  }
-}
-
-const DEFAULT_ANIMAL_BEHAVIOR = {
-  roamRadius: 2,
-  idleTicks: [20, 60],
-  roamTicks: [40, 90],
-  speed: 0.12,
-  fleeSpeed: 0.16,
-  grazeChance: 0.1,
-  grazeRadius: 1,
-  fearRadius: 3,
-  fleeDistance: 3,
-  observeMood: 0.003,
-  idleBob: 1
-};
-
-function behaviorForAnimal(a){
-  return ANIMAL_BEHAVIORS[a.type] || DEFAULT_ANIMAL_BEHAVIOR;
-}
-
-function ensureAnimalDefaults(a){
-  if(!a.state) a.state='idle';
-  if(!Number.isFinite(a.nextActionTick)) a.nextActionTick=tick+irnd(12,48);
-  if(!Number.isFinite(a.idlePhase)) a.idlePhase=irnd(0,900);
-  if(!Number.isFinite(a.nextVillageTick)) a.nextVillageTick=0;
-  if(!Number.isFinite(a.nextGrazeTick)) a.nextGrazeTick=0;
-  if(!Number.isFinite(a.fleeTicks)) a.fleeTicks=0;
-}
-
-function animalTileBlocked(x,y, occupancy, id){
-  const tx=x|0, ty=y|0;
-  if(tx<0||ty<0||tx>=GRID_W||ty>=GRID_H) return true;
-  const i=ty*GRID_W+tx;
-  if(world.tiles[i]===TILES.WATER) return true;
-  if(world.trees[i]>0 || world.rocks[i]>0) return true;
-  if(tileOccupiedByBuilding(tx,ty)) return true;
-  if(occupancy){
-    const key=ty*GRID_W+tx;
-    const other=occupancy.get(key);
-    if(other && other!==id) return true;
-  }
-  return false;
-}
-
-function queueAnimalLabel(text,color,x,y){
-  if(!text) return;
-  const fontSize=Math.max(6,6*cam.z);
-  const boxH=fontSize+4*cam.z;
-  villagerLabels.push({
-    text,
-    color,
-    cx:tileToPxX(x, cam),
-    cy:tileToPxY(y, cam)-6*cam.z,
-    fontSize,
-    boxH,
-    camZ:cam.z
-  });
-}
-
-function nearestVillagerWithin(x,y,radius){
-  let best=null, bd=radius+0.001;
-  for(const v of villagers){
-    const d=Math.hypot((v.x|0)-x,(v.y|0)-y);
-    if(d<=bd){ bd=d; best=v; }
-  }
-  return best;
-}
-
-function pickRoamTarget(a, behavior, occupancy){
-  const tries=14;
-  for(let t=0;t<tries;t++){
-    const dx=irnd(-behavior.roamRadius, behavior.roamRadius);
-    const dy=irnd(-behavior.roamRadius, behavior.roamRadius);
-    const tx=clamp((a.x|0)+dx,0,GRID_W-1);
-    const ty=clamp((a.y|0)+dy,0,GRID_H-1);
-    const i=ty*GRID_W+tx;
-    const def=ANIMAL_TYPES[a.type];
-    if(!isAnimalTileAllowed(world.tiles[i], def, true)) continue;
-    if(animalTileBlocked(tx,ty,occupancy,a.id)) continue;
-    return {x:tx+0.02*R(), y:ty+0.02*R()};
-  }
-  return null;
-}
-
-function attemptGraze(animal, behavior){
-  if(animal.nextGrazeTick>tick) return false;
-  if(R()>behavior.grazeChance) return false;
-  const radius=Math.max(1, behavior.grazeRadius||1);
-  const ax=animal.x|0, ay=animal.y|0;
-  let target=null;
-  for(let y=ay-radius; y<=ay+radius; y++){
-    for(let x=ax-radius; x<=ax+radius; x++){
-      const i=idx(x,y);
-      if(i<0) continue;
-      if(world.berries[i]>0){ target={x,y,i}; break; }
-    }
-    if(target) break;
-  }
-  if(!target) return false;
-  world.berries[target.i]=Math.max(0, world.berries[target.i]-1);
-  animal.nextGrazeTick=tick+Math.round(60+R()*120);
-  queueAnimalLabel('Grazing', '#cde6b7', target.x+0.1, target.y-0.15);
-  return true;
-}
-
-function chooseFleeTarget(animal, from, behavior, occupancy){
-  const fx=from?.x ?? animal.x;
-  const fy=from?.y ?? animal.y;
-  const dirX=animal.x - fx;
-  const dirY=animal.y - fy;
-  const mag=Math.hypot(dirX, dirY) || 1;
-  const dist=Math.max(behavior.fleeDistance||3,1.5);
-  const targetX=clamp(Math.round(animal.x + (dirX/mag)*dist),0,GRID_W-1);
-  const targetY=clamp(Math.round(animal.y + (dirY/mag)*dist),0,GRID_H-1);
-  if(!animalTileBlocked(targetX,targetY,occupancy,animal.id)){
-    return { x: targetX+0.12*R(), y: targetY+0.12*R() };
-  }
-  return pickRoamTarget(animal, behavior, occupancy);
-}
-
-function findAnimalById(id){
-  if(!id) return null;
-  for(const a of animals){
-    if(a && a.id===id){ return a; }
-  }
-  return null;
-}
-
-function removeAnimal(animal){
-  if(!animal) return false;
-  const idx=animals.indexOf(animal);
-  if(idx!==-1){ animals.splice(idx,1); return true; }
-  return false;
-}
-
-function resolveHuntYield({ animal: _animal, lodge }){
-  const effects=lodge?.effects || {};
-  const gameBonus=Number.isFinite(effects.gameYieldBonus)?effects.gameYieldBonus:0;
-  const hideBonus=Number.isFinite(effects.hideYieldBonus)?effects.hideYieldBonus:0;
-  const baseMeat=1 + (R()<0.42 ? 1 : 0);
-  const meat=Math.max(1, Math.round(baseMeat * (1+gameBonus)));
-  const hideChance=0.35 + hideBonus*0.5;
-  return { meat, pelts: R()<hideChance ? 1 : 0 };
-}
-
-function findHuntApproachPath(v, animal, { range=HUNT_RANGE, maxPath=320 }={}){
-  if(!v || !animal) return null;
-  const ax=Math.round(animal.x);
-  const ay=Math.round(animal.y);
-  const radius=Math.max(1, Math.ceil(range));
-  let best=null;
-  for(let dy=-radius; dy<=radius; dy++){
-    for(let dx=-radius; dx<=radius; dx++){
-      const tx=ax+dx, ty=ay+dy;
-      const dist=Math.hypot(tx - animal.x, ty - animal.y);
-      if(dist>range) continue;
-      if(tx<0||ty<0||tx>=GRID_W||ty>=GRID_H) continue;
-      if(tileOccupiedByBuilding(tx,ty)) continue;
-      const tile=world.tiles[idx(tx,ty)];
-      if(tile===TILES.WATER) continue;
-      if(!WALKABLE.has(tile)) continue;
-      const p=pathfind(v.x|0, v.y|0, tx, ty, maxPath);
-      if(!p) continue;
-      if(!best || p.length<best.score){
-        best={ path:p, score:p.length, dest:{x:tx,y:ty} };
-      }
-    }
-  }
-  return best;
-}
-
-function interactWithVillage(animal, behavior, occupancy){
-  if(animal.nextVillageTick>tick) return;
-  const radius=Math.max(2, behavior.fearRadius||3);
-  const villager=nearestVillagerWithin(animal.x, animal.y, radius);
-  if(!villager) return;
-  const hungry=(villager.starveStage||0)>=1 || villager.condition==='hungry' || villager.condition==='starving';
-  if(hungry && R()<0.08){
-    dropItem(animal.x|0, animal.y|0, ITEM.FOOD, 1);
-    villager.hunger=Math.max(0, villager.hunger-0.12);
-    villager.thought=moodThought(villager,'Hunted game');
-    queueAnimalLabel('Hunted', '#ffd27f', animal.x+0.15, animal.y-0.1);
-    animal.state='flee';
-    animal.target=chooseFleeTarget(animal, villager, behavior, occupancy);
-    animal.fleeTicks=Math.round(behavior.roamTicks ? behavior.roamTicks[0] : 40);
-    animal.nextVillageTick=tick+280;
-    return;
-  }
-  if(R()<0.16){
-    villager.happy=clamp(villager.happy+(behavior.observeMood||0.003),0,1);
-    villager.thought=moodThought(villager,'Watching wildlife');
-    queueAnimalLabel('👀', '#d8e7ff', animal.x+0.05, animal.y-0.2);
-    animal.nextVillageTick=tick+Math.round(90+R()*120);
-  }
-}
-
-function stepAnimal(animal, behavior, occupancy){
-  const oldKey=(animal.y|0)*GRID_W+(animal.x|0);
-  let speed=behavior.speed||0.12;
-  if(animal.state==='flee') speed=behavior.fleeSpeed||speed*1.3;
-  const target=animal.target;
-  if(!target){ return; }
-  const dx=target.x-animal.x;
-  const dy=target.y-animal.y;
-  const dist=Math.hypot(dx,dy);
-  if(dist<0.001){ animal.state='idle'; animal.target=null; return; }
-  const step=Math.min(dist, speed);
-  const nx=animal.x + (dx/dist)*step;
-  const ny=animal.y + (dy/dist)*step;
-  const blocked=animalTileBlocked(nx,ny,occupancy,animal.id);
-  if(blocked){
-    animal.state='idle';
-    animal.target=null;
-    animal.nextActionTick=tick+irnd(10,40);
-    return;
-  }
-  const newKey=(ny|0)*GRID_W+(nx|0);
-  if(newKey!==oldKey){
-    const occupant=occupancy.get(newKey);
-    if(occupant && occupant!==animal.id){
-      animal.state='idle';
-      animal.target=null;
-      animal.nextActionTick=tick+irnd(8,24);
-      return;
-    }
-    occupancy.delete(oldKey);
-    occupancy.set(newKey, animal.id);
-  }
-  animal.x=nx;
-  animal.y=ny;
-  if(dx<0) animal.dir='left';
-  else if(dx>0) animal.dir='right';
-  if(dist<=step+0.01){
-    animal.state='idle';
-    animal.target=null;
-    animal.nextActionTick=tick+irnd(behavior.idleTicks[0], behavior.idleTicks[1]);
-  }
-}
-
-function animalTick(animal, occupancy){
-  ensureAnimalDefaults(animal);
-  const behavior=behaviorForAnimal(animal);
-  animal.bobOffset=Math.sin((tick+animal.idlePhase)*0.16)*(behavior.idleBob||1);
-  const blocked=animalTileBlocked(animal.x,animal.y,occupancy,animal.id);
-  if(blocked){
-    const target=pickRoamTarget(animal, behavior, occupancy);
-    if(target){
-      animal.x=target.x;
-      animal.y=target.y;
-      const k=(animal.y|0)*GRID_W+(animal.x|0);
-      occupancy.set(k, animal.id);
-    }
-  }
-
-  if(animal.state==='idle' && attemptGraze(animal, behavior)){
-    animal.nextActionTick=Math.max(animal.nextActionTick||tick, tick+behavior.idleTicks[0]);
-  }
-  interactWithVillage(animal, behavior, occupancy);
-
-  if(animal.state==='idle' && tick>=animal.nextActionTick){
-    const target=pickRoamTarget(animal, behavior, occupancy);
-    if(target){
-      animal.state='roam';
-      animal.target=target;
-      animal.nextActionTick=tick+irnd(behavior.roamTicks[0], behavior.roamTicks[1]);
-    } else {
-      animal.nextActionTick=tick+irnd(behavior.idleTicks[0], behavior.idleTicks[1]);
-    }
-  }
-  if(animal.state==='flee'){
-    animal.fleeTicks=Math.max(0,(animal.fleeTicks|0)-1);
-    if(!animal.target){
-      animal.target=pickRoamTarget(animal, behavior, occupancy);
-    }
-    if(animal.fleeTicks<=0 && animal.target){
-      animal.state='roam';
-    }
-  }
-  if(animal.state==='roam' || animal.state==='flee'){
-    if(!animal.target){ animal.state='idle'; return; }
-    stepAnimal(animal, behavior, occupancy);
-  } else if(animal.state==='idle' && R()<0.015){
-    animal.dir=animal.dir==='left'?'right':'left';
-  }
-}
-
-function updateAnimals(){
-  if(animals.length===0) return;
-  const occupancy=new Map();
-  for(const a of animals){
-    const key=(a.y|0)*GRID_W+(a.x|0);
-    if(!occupancy.has(key)) occupancy.set(key, a.id);
-  }
-  for(const a of animals){
-    animalTick(a, occupancy);
-  }
-}
 
 function newWorld(seed=Date.now()|0){
   if(typeof unbindUIListeners === 'function') unbindUIListeners();
@@ -1171,32 +554,6 @@ function newWorld(seed=Date.now()|0){
   if(typeof bindCanvasInputs === 'function') bindCanvasInputs();
   if(typeof bindUIListeners === 'function') bindUIListeners();
 }
-function rollAdultRole(){ const r=R(); return r<0.25?'farmer':r<0.5?'worker':r<0.75?'explorer':'sleepy'; }
-function assignAdultTraits(v, role=rollAdultRole()){
-  const farmingSkill=Math.min(1, Math.max(0, rnd(0.35,0.75)+(role==='farmer'?0.1:0)));
-  const constructionSkill=Math.min(1, Math.max(0, rnd(0.35,0.7)+(role==='worker'?0.12:0)));
-  v.role=role;
-  v.speed=2+rnd(-0.2,0.2);
-  v.farmingSkill=farmingSkill;
-  v.constructionSkill=constructionSkill;
-}
-function newVillager(x,y){ const v={ id:uid(), x,y,path:[], hunger:rnd(0.2,0.5), energy:rnd(0.5,0.9), happy:rnd(0.4,0.8), hydration:0.7, hydrationBuffTicks:0, nextHydrateTick:0, inv:null, state:'idle', thought:'Wandering', _nextPathTick:0, _wanderFailures:new Map(), _forageFailures:new Map(), condition:'normal', starveStage:0, nextStarveWarning:0, sickTimer:0, recoveryTimer:0, ageTicks:0, lifeStage:'adult', pregnancyTimer:0, pregnancyMateId:null, childhoodTimer:0, parents:[], nextPregnancyTick:0, socialTimer:0, nextSocialTick:0, storageIdleTimer:0, nextStorageIdleTick:0, hydrationTimer:0, activeBuildingId:null, equippedBow:false, experience:createExperienceLedger() }; assignAdultTraits(v); ensureVillagerNumber(v); return v; }
-function newChildVillager(x,y,parents){
-  const v=newVillager(x,y);
-  v.role='child';
-  v.speed=1.6+rnd(-0.1,0.1);
-  v.hunger=rnd(0.1,0.3);
-  v.energy=rnd(0.55,0.85);
-  v.happy=rnd(0.45,0.85);
-  v.lifeStage='child';
-  v.childhoodTimer=CHILDHOOD_TICKS;
-  v.pregnancyTimer=0;
-  v.pregnancyMateId=null;
-  v.farmingSkill=Math.max(0, v.farmingSkill-0.2);
-  v.constructionSkill=Math.max(0, v.constructionSkill-0.2);
-  v.parents=Array.isArray(parents)?parents.slice(0,2):[];
-  return v;
-}
 function addBuilding(kind,x,y,opts={}){
   const def=BUILDINGS[kind]||{};
   const built=opts.built?1:0;
@@ -1344,125 +701,6 @@ bindCanvasInputs();
 
 /* ==================== Automation Helpers ==================== */
 
-function availableToReserve(resource){
-  return (storageTotals[resource]||0) - (storageReserved[resource]||0);
-}
-
-function canReserveMaterials(cost={}){
-  for(const [key, qty] of Object.entries(cost)){
-    if(qty>0 && availableToReserve(key)<qty) return false;
-  }
-  return true;
-}
-
-function reserveMaterials(cost={}){
-  if(!canReserveMaterials(cost)) return false;
-  for(const [key, qty] of Object.entries(cost)){
-    if(qty>0){
-      storageReserved[key]=(storageReserved[key]||0)+qty;
-    }
-  }
-  return true;
-}
-
-function releaseReservedMaterials(cost={}){
-  for(const [key, qty] of Object.entries(cost)){
-    if(qty>0){
-      storageReserved[key]=Math.max(0,(storageReserved[key]||0)-qty);
-    }
-  }
-}
-
-function spendCraftMaterials(cost={}){
-  for(const [key, qty] of Object.entries(cost)){
-    if(qty>0 && (storageTotals[key]||0)<qty){
-      releaseReservedMaterials(cost);
-      return false;
-    }
-  }
-  for(const [key, qty] of Object.entries(cost)){
-    if(qty>0){
-      storageTotals[key]=Math.max(0,(storageTotals[key]||0)-qty);
-      releaseReservedMaterials({ [key]: qty });
-    }
-  }
-  return true;
-}
-
-function countBuildingsByKind(kind){
-  let built=0, planned=0;
-  for(const b of buildings){
-    if(!b || b.kind!==kind) continue;
-    if(b.built>=1) built++; else planned++;
-  }
-  return { built, planned, total: built+planned };
-}
-
-function scheduleHaul(b, resource, amount){
-  if(!b || amount<=0) return;
-  ensureBuildingData(b);
-  const available=availableToReserve(resource);
-  if(available<=0) return;
-  const qty=Math.min(Math.ceil(amount), available);
-  if(qty<=0) return;
-  const center=buildingCenter(b);
-  const storageBuilding=findNearestBuilding(center.x, center.y, 'storage');
-  if(!storageBuilding) return;
-  const job=addJob({
-    type:'haul',
-    bid:b.id,
-    resource,
-    qty,
-    prio:0.6+(policy.sliders.build||0)*0.5,
-    x:storageBuilding.x,
-    y:storageBuilding.y
-  });
-  job.src={x:storageBuilding.x, y:storageBuilding.y};
-  job.dest={x:b.x, y:b.y};
-  job.stage='pickup';
-  storageReserved[resource]=(storageReserved[resource]||0)+qty;
-  b.pending[resource]=(b.pending[resource]||0)+qty;
-}
-
-function requestBuildHauls(b){
-  if(!b || b.built>=1) return;
-  ensureBuildingData(b);
-  const store=b.store||{};
-  const pending=b.pending||{};
-  const woodNeed=buildingResourceNeed(b,'wood');
-  const stoneNeed=buildingResourceNeed(b,'stone');
-  const woodShort=Math.max(0, woodNeed - ((store.wood||0)+(pending.wood||0)));
-  const stoneShort=Math.max(0, stoneNeed - ((store.stone||0)+(pending.stone||0)));
-  if(woodShort>0) scheduleHaul(b, ITEM.WOOD, woodShort);
-  if(stoneShort>0) scheduleHaul(b, ITEM.STONE, stoneShort);
-}
-
-function cancelHaulJobsForBuilding(b){
-  if(!b || !b.id) return;
-  ensureBuildingData(b);
-  for(let i=jobs.length-1;i>=0;i--){
-    const job=jobs[i];
-    if(job.type==='haul' && job.bid===b.id){
-      if(job.stage==='deliver'){
-        job.cancelled=true;
-        continue;
-      }
-      const res=job.resource;
-      const qty=job.qty||0;
-      storageReserved[res]=Math.max(0,(storageReserved[res]||0)-qty);
-      b.pending[res]=Math.max(0,(b.pending[res]||0)-qty);
-      for(const villager of villagers){
-        if(villager.targetJob===job){
-          villager.targetJob=null;
-          if(villager.path) villager.path.length=0;
-          villager.state='idle';
-        }
-      }
-      noteJobRemoved(job);
-      jobs.splice(i,1);
-    }
-  }
-}
 function idx(x,y){ if(x<0||y<0||x>=GRID_W||y>=GRID_H) return -1; return baseIdx(x,y); }
 const _pathfinder = createPathfinder({
   idx,
@@ -1479,9 +717,6 @@ function centerCamera(x,y){
   cam.y = y - H / (TILE * cam.z) * 0.5;
   clampCam();
 }
-function getJobCreationConfig(){
-  return policy?.style?.jobCreation || {};
-}
 
 // ensureBlackboardSnapshot lives on the tick runner (src/app/tick.js); use the
 // thunk below so callers in this file keep a stable call shape until the runner
@@ -1491,1112 +726,8 @@ let ensureBlackboardSnapshot = () => {
   return gameState.bb;
 };
 
-function jobKey(job){
-  if(!job || !job.type) return null;
-  const base = `${job.type}:${Number.isFinite(job.x)?job.x:'?'},${Number.isFinite(job.y)?job.y:'?'}`;
-  if(job.bid!==undefined){
-    return `${base}:b${job.bid}`;
-  }
-  return base;
-}
 
-function isJobSuppressed(job){
-  const key = jobKey(job);
-  if(!key) return false;
-  const until = jobSuppression.get(key);
-  if(until===undefined) return false;
-  if(until<=tick){
-    jobSuppression.delete(key);
-    return false;
-  }
-  return true;
-}
-
-function suppressJob(job, duration=0){
-  const key = jobKey(job);
-  if(!key || duration<=0) return;
-  jobSuppression.set(key, tick+duration);
-}
-
-function hasSimilarJob(job){
-  return jobs.some(j=>j && j.type===job.type && j.x===job.x && j.y===job.y && (j.bid||null)===(job.bid||null));
-}
-
-function violatesSpacing(x,y,type,cfg){
-  const spacing = cfg?.minSpacing?.[type];
-  if(!Number.isFinite(spacing) || spacing<=0) return false;
-  for(const j of jobs){
-    if(!j || j.type!==type) continue;
-    const dist = Math.abs((j.x||0)-x)+Math.abs((j.y||0)-y);
-    if(dist<=spacing) return true;
-  }
-  return false;
-}
-
-function addJob(job){
-  if(!job || !job.type) return null;
-  if(hasSimilarJob(job) || isJobSuppressed(job)) return null;
-  job.id=uid(); job.assigned=0; jobs.push(job); return job;
-}
-
-function finishJob(v, remove=false){
-  const job = v.targetJob;
-  if(job){
-    job.assigned = Math.max(0, (job.assigned||0)-1);
-    noteJobAssignmentChanged(job);
-    if(remove){
-      const ji = jobs.indexOf(job);
-      if(ji !== -1){
-        noteJobRemoved(job);
-        jobs.splice(ji,1);
-      }
-    }
-  }
-  v.targetJob=null;
-}
-
-// Shared villager-tuning constants. The decay/mood/buff knobs that live
-// only inside `villagerTick` (HUNGER_RATE, ENERGY_DRAIN_BASE, the REST_*
-// recovery numbers, HYDRATION_DECAY/LOW/HUNGER_MULT/FATIGUE_BONUS,
-// SOCIAL_MOOD_TICK / SOCIAL_ENERGY_TICK, NIGHT_CAMPFIRE_*) now live next
-// to that function in `src/app/villagerTick.js`. Anything that is also
-// read by helpers still in this file (foragingJob, goRest,
-// tryHydrateAtWell, tryCampfireSocial, tryStorageIdle, onArrive, the
-// pregnancy/birth helpers, etc.) stays here for now and will collapse
-// into a single source of truth when the villager-AI helper bundle
-// extracts in a follow-on pass.
-const STARVE_THRESH={ hungry:0.82, starving:1.08, sick:1.22 };
-const STARVE_COLLAPSE_TICKS=140;
-const STARVE_RECOVERY_TICKS=280;
-const STARVE_TOAST_COOLDOWN=420;
-// Balance knob: how much a bite of food reduces hunger.
-const FOOD_HUNGER_RECOVERY=0.65;
-const PREGNANCY_TICKS=DAY_LEN*2;
-const CHILDHOOD_TICKS=DAY_LEN*5;
-const PREGNANCY_ATTEMPT_COOLDOWN_TICKS=Math.floor(DAY_LEN*1.1);
-const PREGNANCY_ATTEMPT_CHANCE=0.12;
-const POPULATION_SOFT_BUFFER=2;
-const POPULATION_HARD_CAP=80;
-const FOOD_HEADROOM_PER_VILLAGER=1.25;
-const REST_BASE_TICKS=90;
-const REST_EXTRA_PER_ENERGY=110;
-const HYDRATION_VISIT_THRESHOLD=0.46;
-const HYDRATION_BUFF_TICKS=320;
-const SOCIAL_BASE_TICKS=88;
-const SOCIAL_COOLDOWN_TICKS=DAY_LEN*0.2;
-const STORAGE_IDLE_BASE=70;
-const STORAGE_IDLE_COOLDOWN=DAY_LEN*0.12;
-function issueStarveToast(v,text,force=false){ const ready=(v.nextStarveWarning||0)<=tick; if(force||ready){ Toast.show(text); v.nextStarveWarning=tick+STARVE_TOAST_COOLDOWN; } }
-function enterSickState(v){ if(v.condition==='sick') return; v.condition='sick'; v.sickTimer=STARVE_COLLAPSE_TICKS; v.starveStage=Math.max(3,v.starveStage||0); finishJob(v); if(v.path) v.path.length=0; v.state='sick'; v.thought=moodThought(v,'Collapsed'); issueStarveToast(v,'A villager collapsed from hunger! They need food now.',true); }
-function handleVillagerFed(v,source='food'){ const wasCritical=(v.condition==='sick')||((v.starveStage||0)>=2); v.sickTimer=0; v.starveStage=0; if(wasCritical){ v.condition='recovering'; v.recoveryTimer=STARVE_RECOVERY_TICKS; } else { v.condition='normal'; v.recoveryTimer=Math.max(v.recoveryTimer, Math.floor(STARVE_RECOVERY_TICKS/3)); } v.nextStarveWarning=tick+Math.floor(STARVE_TOAST_COOLDOWN*0.6); if(v.state==='sick') v.state='idle'; v.thought=moodThought(v,wasCritical?'Recovering':'Content'); v.happy=clamp(v.happy+0.05,0,1); if(wasCritical){ const detail=source==='camp'?'camp stores':source==='pack'?'their pack':source==='berries'?'wild berries':source; issueStarveToast(v,`Villager recovered after eating ${detail}.`,true); } }
-function nearbyWarmth(x,y){
-  return buildings.some(b=>b.kind==='campfire' && distanceToFootprint(x,y,b)<=CAMPFIRE_EFFECT_RADIUS);
-}
-function consumeFood(v){
-  let source=null;
-  if(v.inv && v.inv.type===ITEM.FOOD){
-    v.hunger-=FOOD_HUNGER_RECOVERY;
-    v.inv=null;
-    source='pack';
-  } else if(storageTotals.food>0){
-    storageTotals.food--;
-    v.hunger-=FOOD_HUNGER_RECOVERY;
-    source='camp';
-  }
-  if(source){
-    if(v.hunger<0) v.hunger=0;
-    handleVillagerFed(v, source);
-    return true;
-  }
-  return false;
-}
-function nearestFoodTarget(v,{radius=12,pathLimit=200}={}){
-  const sx=v.x|0, sy=v.y|0;
-  let best=null;
-  const consider=(target)=>{
-    if(!target) return;
-    const { x, y, kind, targetI } = target;
-    const p=pathfind(sx,sy,x,y,pathLimit);
-    if(!p) return;
-    const score=p.length;
-    if(!best || score<best.score){
-      best={ path:p, score, kind, x, y, targetI };
-    }
-  };
-  if(storageTotals.food>0){
-    const storage=findNearestBuilding(sx,sy,'storage');
-    if(storage){
-      const entry=findEntryTileNear(storage, sx, sy) || {x:Math.round(buildingCenter(storage).x), y:Math.round(buildingCenter(storage).y)};
-      consider({x:entry.x,y:entry.y,kind:'storage'});
-    }
-  }
-  for(const it of itemsOnGround){
-    if(!it || it.type!==ITEM.FOOD) continue;
-    consider({x:it.x,y:it.y,kind:'ground'});
-  }
-  const clampX=(val)=>clamp(val,0,GRID_W-1);
-  const clampY=(val)=>clamp(val,0,GRID_H-1);
-  const x0=clampX(sx-radius), x1=clampX(sx+radius);
-  const y0=clampY(sy-radius), y1=clampY(sy+radius);
-  for(let y=y0;y<=y1;y++){
-    for(let x=x0;x<=x1;x++){
-      const i=idx(x,y);
-      if(i<0) continue;
-      if(world.berries[i]>0){
-        consider({x,y,kind:'berry',targetI:i});
-      }
-    }
-  }
-  return best;
-}
-function seekEmergencyFood(v,{radius=14,pathLimit=200}={}){
-  if(tick<v._nextPathTick) return false;
-  const target=nearestFoodTarget(v,{radius,pathLimit});
-  if(!target) return false;
-  v.path=target.path;
-  const cooldown=Math.max(8, Math.min(22, target.path.length+6));
-  v._nextPathTick=tick+cooldown;
-  if(target.kind==='berry'){
-    v.state='forage';
-    v.targetI=target.targetI;
-    v.thought=moodThought(v,'Foraging');
-  } else {
-    v.state='seek_food';
-    v.targetFood=target.kind;
-    v.targetFoodPos={x:target.x,y:target.y};
-    v.thought=moodThought(v,'Seeking food');
-  }
-  return true;
-}
-function getRallyPoint(){
-  const camp=buildings.find(b=>b.kind==='campfire' && b.built>=1);
-  if(camp){
-    const entry=findEntryTileNear(camp, camp.x, camp.y) || {x:Math.round(buildingCenter(camp).x), y:Math.round(buildingCenter(camp).y)};
-    return entry;
-  }
-  const storage=buildings.find(b=>b.kind==='storage' && b.built>=1);
-  if(storage){
-    const entry=findEntryTileNear(storage, storage.x, storage.y) || {x:Math.round(buildingCenter(storage).x), y:Math.round(buildingCenter(storage).y)};
-    return entry;
-  }
-  return null;
-}
-function countNearbyVillagers(v, radius=3){
-  const sx=v.x, sy=v.y;
-  let count=0;
-  for(const other of villagers){
-    if(other===v) continue;
-    if(Math.abs(other.x-sx)<=radius && Math.abs(other.y-sy)<=radius){
-      count++;
-    }
-  }
-  return count;
-}
-function housingCapacity(){
-  const huts=countBuildingsByKind('hut');
-  return Math.max(6, huts.built*2 + 4);
-}
-function populationLimit(availableFood){
-  const housingGate=housingCapacity()+POPULATION_SOFT_BUFFER;
-  const foodGate=Math.max(0, Math.floor((availableFood||0)/FOOD_HEADROOM_PER_VILLAGER));
-  const rawLimit=Math.min(housingGate, foodGate);
-  return Math.max(6, Math.min(POPULATION_HARD_CAP, rawLimit));
-}
-function canSupportBirth(){
-  const availableFood=storageTotals.food||0;
-  const projectedPop=villagers.length+pendingBirths.length;
-  const housingRoom=housingCapacity()-projectedPop;
-  if(housingRoom<=0) return false;
-  const underCap=projectedPop<populationLimit(availableFood);
-  const wellFed=availableFood>Math.max(4, projectedPop*0.8);
-  return underCap && wellFed;
-}
-function findBirthMate(v){
-  let best=null;
-  let bestDist=Infinity;
-  for(const other of villagers){
-    if(other===v) continue;
-    if(other.lifeStage!=='adult') continue;
-    if(other.pregnancyTimer>0) continue;
-    if((other.nextPregnancyTick||0)>tick) continue;
-    if((other.starveStage||0)>=2) continue;
-    if(other.condition!=='normal' && other.condition!=='hungry') continue;
-    const dist=Math.abs((other.x|0)-(v.x|0))+Math.abs((other.y|0)-(v.y|0));
-    if(dist<bestDist){ best=other; bestDist=dist; }
-  }
-  return best;
-}
-function tryStartPregnancy(v){
-  if(v.lifeStage!=='adult') return;
-  if(v.pregnancyTimer>0) return;
-  if((v.starveStage||0)>=1) return;
-  if(v.condition==='sick') return;
-  if(v.energy<0.4 || v.happy<0.35) return;
-  if(tick<(v.nextPregnancyTick||0)) return;
-  if(!canSupportBirth()){
-    v.nextPregnancyTick=Math.max(v.nextPregnancyTick||0, tick+Math.floor(PREGNANCY_ATTEMPT_COOLDOWN_TICKS*0.5));
-    return;
-  }
-  if(R()>PREGNANCY_ATTEMPT_CHANCE){
-    v.nextPregnancyTick=tick+PREGNANCY_ATTEMPT_COOLDOWN_TICKS;
-    return;
-  }
-  const mate=findBirthMate(v);
-  const cooldownUntil=tick+PREGNANCY_ATTEMPT_COOLDOWN_TICKS;
-  if(!mate){
-    v.nextPregnancyTick=cooldownUntil;
-    return;
-  }
-  v.pregnancyTimer=PREGNANCY_TICKS;
-  v.pregnancyMateId=mate.id;
-  v.thought=moodThought(v,'Expecting');
-  v.nextPregnancyTick=cooldownUntil;
-  mate.nextPregnancyTick=Math.max(mate.nextPregnancyTick||0, cooldownUntil);
-}
-function spawnChildNearParents(parent, mate){
-  const centerX=Math.round((parent.x + (mate?mate.x:parent.x))/2);
-  const centerY=Math.round((parent.y + (mate?mate.y:parent.y))/2);
-  const offsets=[{dx:0,dy:0},{dx:1,dy:0},{dx:-1,dy:0},{dx:0,dy:1},{dx:0,dy:-1},{dx:1,dy:1},{dx:-1,dy:1},{dx:1,dy:-1},{dx:-1,dy:-1}];
-  const parents=[parent.id];
-  if(mate?.id) parents.push(mate.id);
-  for(const off of offsets){
-    const x=clamp(centerX+off.dx,0,GRID_W-1);
-    const y=clamp(centerY+off.dy,0,GRID_H-1);
-    const i=idx(x,y);
-    if(i<0) continue;
-    if(tileOccupiedByBuilding(x,y)) continue;
-    if(world.tiles[i]===TILES.WATER) continue;
-    pendingBirths.push({x,y,parents});
-    return true;
-  }
-  return false;
-}
-function flushPendingBirths(){
-  if(pendingBirths.length===0) return;
-  for(const birth of pendingBirths){
-    villagers.push(newChildVillager(birth.x,birth.y,birth.parents));
-  }
-  pendingBirths.length=0;
-}
-function completePregnancy(v){
-  const mate=v.pregnancyMateId?villagers.find(o=>o.id===v.pregnancyMateId):null;
-  if(!spawnChildNearParents(v, mate)){
-    v.pregnancyTimer=10;
-    return;
-  }
-  v.pregnancyTimer=0;
-  v.pregnancyMateId=null;
-  v.thought=moodThought(v,'Newborn');
-}
-function promoteChildToAdult(v){
-  v.lifeStage='adult';
-  v.childhoodTimer=0;
-  assignAdultTraits(v);
-  v.nextPregnancyTick=Math.max(v.nextPregnancyTick||0, tick+PREGNANCY_ATTEMPT_COOLDOWN_TICKS);
-  v.thought=moodThought(v,'Grew up');
-}
-function collectFoodHubs(v, radius=12){
-  const hubs=[];
-  const sx=v.x|0, sy=v.y|0;
-  const radiusX=Math.max(1,radius);
-  const clampX=(val)=>clamp(val,0,GRID_W-1);
-  const clampY=(val)=>clamp(val,0,GRID_H-1);
-  if(storageTotals.food>0){
-    for(const b of buildings){
-      if(b.kind!=='storage' || b.built<1) continue;
-      const c=buildingCenter(b);
-      hubs.push({x:Math.round(c.x), y:Math.round(c.y), weight:2.5});
-    }
-  }
-  for(const b of buildings){
-    if(b.kind==='campfire' && b.built>=1){
-      const c=buildingCenter(b);
-      hubs.push({x:Math.round(c.x), y:Math.round(c.y), weight:1.5});
-    }
-  }
-  for(const it of itemsOnGround){
-    if(!it || it.type!==ITEM.FOOD) continue;
-    if(Math.abs(it.x-sx)<=radiusX && Math.abs(it.y-sy)<=radiusX){
-      hubs.push({x:it.x, y:it.y, weight:3});
-    }
-  }
-  const x0=clampX(sx-radiusX), x1=clampX(sx+radiusX);
-  const y0=clampY(sy-radiusX), y1=clampY(sy+radiusX);
-  for(let y=y0;y<=y1;y++){
-    for(let x=x0;x<=x1;x++){
-      const i=idx(x,y);
-      if(i<0) continue;
-      if(world.berries[i]>0){
-        hubs.push({x,y,weight:2});
-      }
-    }
-  }
-  return hubs;
-}
-function pickWeightedRandom(candidates){
-  if(!candidates || candidates.length===0) return null;
-  const total=candidates.reduce((sum,c)=>sum+(c.weight||1),0);
-  let r=R()*total;
-  for(const c of candidates){
-    r-=c.weight||1;
-    if(r<=0) return c;
-  }
-  return candidates[candidates.length-1];
-}
-function selectReachableWanderTarget(v,candidates,pathLimit,cooldown){
-  if(!candidates || candidates.length===0) return null;
-  for (const [key, until] of Array.from(v._wanderFailures.entries())) {
-    if (until <= tick) v._wanderFailures.delete(key);
-  }
-  const attempts=Math.min(8, candidates.length*2);
-  for(let n=0;n<attempts;n++){
-    const cand=pickWeightedRandom(candidates);
-    if(!cand) break;
-    const cx=clamp(cand.x|0,0,GRID_W-1);
-    const cy=clamp(cand.y|0,0,GRID_H-1);
-    const key=idx(cx,cy);
-    if(key<0) continue;
-    const failedUntil=v._wanderFailures.get(key);
-    if(failedUntil && failedUntil>tick) continue;
-    if(!passable(cx,cy)){
-      v._wanderFailures.set(key, tick+180);
-      continue;
-    }
-    const p=pathfind(v.x|0,v.y|0,cx,cy,pathLimit);
-    if(p){
-      return { path:p, cooldown };
-    }
-    v._wanderFailures.set(key, tick+240);
-  }
-  return null;
-}
-function handleIdleRoam(v,{stage, needsFood, urgentFood}){
-  const baseRange=stage===1?3:4;
-  const crowd=countNearbyVillagers(v, 3);
-  const crowdCooldown=Math.max(10, 12 + Math.max(0, crowd-2)*4 + irnd(0,4));
-  const adjustedRange=crowd>3 ? Math.max(1, baseRange-1) : baseRange;
-  if(urgentFood && seekEmergencyFood(v, { radius: 14, pathLimit: 220 })) return true;
-  const rally=(!needsFood && !urgentFood && !v.inv) ? getRallyPoint() : null;
-  const ready=tick>=v._nextPathTick;
-  if(rally && ready){
-    const rallyPath=pathfind(v.x|0,v.y|0,rally.x,rally.y,160);
-    if(rallyPath){
-      v.path=rallyPath;
-      v.thought=moodThought(v,'Regrouping');
-      v._nextPathTick=tick+crowdCooldown;
-      return true;
-    }
-  }
-  const hungry=needsFood || urgentFood;
-  const hubs=hungry?collectFoodHubs(v, 12):[];
-  const candidates=[];
-  if(hubs.length>0){
-    for(const hub of hubs){
-      candidates.push({
-        x:clamp(hub.x+irnd(-2,2),0,GRID_W-1),
-        y:clamp(hub.y+irnd(-2,2),0,GRID_H-1),
-        weight:hub.weight||1
-      });
-    }
-  }
-  const cx=v.x|0, cy=v.y|0;
-  for(let i=0;i<4;i++){
-    candidates.push({
-      x:clamp(cx+irnd(-adjustedRange,adjustedRange),0,GRID_W-1),
-      y:clamp(cy+irnd(-adjustedRange,adjustedRange),0,GRID_H-1),
-      weight:1
-    });
-  }
-  const pathLimit=hungry?120:80;
-  const wander=ready?selectReachableWanderTarget(v,candidates,pathLimit,crowdCooldown+irnd(0,4)):null;
-  v.thought=moodThought(v, urgentFood?'Starving':(stage===1?'Hungry':'Wandering'));
-  if(wander){
-    v.path=wander.path;
-    v._nextPathTick=tick+wander.cooldown;
-  } else if(tick>=v._nextPathTick){
-    v._nextPathTick=tick+crowdCooldown;
-  }
-  return true;
-}
-function foragingJob(v){
-  if(tick<v._nextPathTick) return false;
-  const style = policy?.style?.jobScoring || {};
-  const bb = gameState?.bb;
-  const famineSeverity = computeFamineSeverity(bb);
-  const baseRadius = 10;
-  const maxRadius = Number.isFinite(style.adaptiveForageMaxRadius) ? style.adaptiveForageMaxRadius : 18;
-  const radius = Math.max(baseRadius, Math.round(baseRadius + famineSeverity * Math.max(0, maxRadius - baseRadius)));
-  const basePathLimit = 120;
-  const maxPathLimit = Number.isFinite(style.adaptiveForageMaxPath) ? style.adaptiveForageMaxPath : 240;
-  const pathLimit = Math.max(basePathLimit, Math.round(basePathLimit + famineSeverity * Math.max(0, maxPathLimit - basePathLimit)));
-  const sx=v.x|0,sy=v.y|0; let best=null,bd=999;
-  for (const [key, until] of Array.from(v._forageFailures.entries())) {
-    if (until <= tick) v._forageFailures.delete(key);
-  }
-  for(let y=sy-radius;y<=sy+radius;y++){
-    for(let x=sx-radius;x<=sx+radius;x++){
-      const i=idx(x,y);
-      if(i<0) continue;
-      if(world.berries[i]>0){
-        if(v._forageFailures.has(i)) continue;
-        const d=Math.abs(x-sx)+Math.abs(y-sy);
-        if(d<bd){bd=d; best={x,y,i};}
-      }
-    }
-  }
-  if(best){
-    const p=pathfind(v.x|0,v.y|0,best.x,best.y,pathLimit);
-    if(p){ v.path=p; v.state='forage'; v.targetI=best.i; v.thought=moodThought(v,'Foraging'); v._nextPathTick=tick+12; return true; }
-    v._forageFailures.set(best.i, tick+180);
-  }
-  return false;
-}
-function goRest(v){ if(tick<v._nextPathTick) return false; const hut=findNearestBuilding(v.x|0,v.y|0,'hut')||buildings.find(b=>b.kind==='campfire'&&b.built>=1); if(hut){ const entry=findEntryTileNear(hut, v.x|0, v.y|0) || {x:Math.round(buildingCenter(hut).x), y:Math.round(buildingCenter(hut).y)}; const p=pathfind(v.x|0,v.y|0,entry.x,entry.y); if(p){ v.path=p; v.state='rest'; v.targetBuilding=hut; v.thought=moodThought(v,'Resting'); v._nextPathTick=tick+12; return true; } } return false; }
-function tryHydrateAtWell(v){
-  if(tick<v._nextPathTick) return false;
-  if(v.nextHydrateTick>tick) return false;
-  if(v.hydration>HYDRATION_VISIT_THRESHOLD) return false;
-  const well=findNearestBuilding(v.x|0,v.y|0,'well');
-  if(!well) return false;
-  const entry=findEntryTileNear(well, v.x|0, v.y|0) || {x:Math.round(buildingCenter(well).x), y:Math.round(buildingCenter(well).y)};
-  const p=pathfind(v.x|0,v.y|0,entry.x,entry.y);
-  if(p){
-    v.path=p;
-    v.state='hydrate';
-    v.targetBuilding=well;
-    v.thought=moodThought(v,'Fetching water');
-    v._nextPathTick=tick+12;
-    v.nextHydrateTick=tick+Math.floor(DAY_LEN*0.12);
-    return true;
-  }
-  v.nextHydrateTick=Math.max(v.nextHydrateTick||0, tick+60);
-  return false;
-}
-function tryCampfireSocial(v, { ambientNow = ambientAt(dayTime), forceNight = false } = {}){
-  if(tick<v._nextPathTick) return false;
-  if(v.nextSocialTick>tick) return false;
-  if((v.starveStage||0)>=1) return false;
-  const nightAmbient=isNightAmbient(ambientNow);
-  if(!nightAmbient && !forceNight) return false;
-  if(!nightAmbient && forceNight && !isNightTime()) return false;
-  if(isDawnAmbient(ambientNow)) return false;
-  const camp=findNearestBuilding(v.x|0,v.y|0,'campfire');
-  if(!camp) return false;
-  const entry=findEntryTileNear(camp, v.x|0, v.y|0) || {x:Math.round(buildingCenter(camp).x), y:Math.round(buildingCenter(camp).y)};
-  const p=pathfind(v.x|0,v.y|0,entry.x,entry.y);
-  if(p){
-    v.path=p;
-    v.state='socialize';
-    v.targetBuilding=camp;
-    v.thought=moodThought(v,'Gathering by fire');
-    v._nextPathTick=tick+12;
-    v.nextSocialTick=tick+Math.floor(SOCIAL_COOLDOWN_TICKS*0.25);
-    return true;
-  }
-  v.nextSocialTick=Math.max(v.nextSocialTick||0, tick+90);
-  return false;
-}
-function tryStorageIdle(v){
-  if(tick<v._nextPathTick) return false;
-  if(v.nextStorageIdleTick>tick) return false;
-  if(v.inv) return false;
-  if(v.targetJob) return false;
-  const storage=findNearestBuilding(v.x|0,v.y|0,'storage');
-  if(!storage) return false;
-  const entry=findEntryTileNear(storage, v.x|0, v.y|0) || {x:Math.round(buildingCenter(storage).x), y:Math.round(buildingCenter(storage).y)};
-  const p=pathfind(v.x|0,v.y|0,entry.x,entry.y);
-  if(p){
-    v.path=p;
-    v.state='storage_idle';
-    v.targetBuilding=storage;
-    v.thought=moodThought(v,'Checking storage');
-    v._nextPathTick=tick+12;
-    v.nextStorageIdleTick=tick+Math.floor(STORAGE_IDLE_COOLDOWN*0.4);
-    return true;
-  }
-  v.nextStorageIdleTick=Math.max(v.nextStorageIdleTick||0, tick+80);
-  return false;
-}
-
-function tryEquipBow(v){
-  if(v.lifeStage==='child') return false;
-  if(v.equippedBow) return false;
-  if(v.inv) return false;
-  if(v.state!=='idle') return false;
-  if(tick<v._nextPathTick) return false;
-  if(availableToReserve('bow')<=0) return false;
-  const storage=findNearestBuilding(v.x|0,v.y|0,'storage');
-  if(!storage) return false;
-  const entry=findEntryTileNear(storage, v.x|0, v.y|0) || {x:Math.round(buildingCenter(storage).x), y:Math.round(buildingCenter(storage).y)};
-  const p=pathfind(v.x|0,v.y|0,entry.x,entry.y);
-  if(!p) return false;
-  v.path=p;
-  v.state='equip_bow';
-  v.targetBuilding=storage;
-  v.thought=moodThought(v,'Fetching bow');
-  v._nextPathTick=tick+12;
-  return true;
-}
-function findNearestBuilding(x,y,kind){ let best=null,bd=Infinity; const list=buildingsByKind.get(kind); if(!list) return null; for(const b of list){ if(b.built<1) continue; const d=distanceToFootprint(x,y,b); if(d<bd){bd=d; best=b;} } return best; }
-function scoreExistingJobForVillager(j, v, blackboard){
-  if(!j) return -Infinity;
-  let supplyStatus=null;
-  let buildTarget=null;
-  if(j.type==='build'){
-    buildTarget=buildings.find(bb=>bb.id===j.bid);
-    if(!buildTarget || buildTarget.built>=1) return -Infinity;
-    supplyStatus=buildingSupplyStatus(buildTarget);
-    if(!supplyStatus.hasAnySupply){
-      j.waitingForMaterials=true;
-      return -Infinity;
-    }
-  }
-  const i=idx(j.x,j.y);
-  if(j.type==='chop'&&world.trees[i]===0) return -Infinity;
-  if(j.type==='mine'&&world.rocks[i]===0) return -Infinity;
-  if(j.type==='sow'&&world.growth[i]>0) return -Infinity;
-  if(j.type==='forage' && world.berries[j.targetI ?? i]<=0) return -Infinity;
-  let distance;
-  if(j.type==='build'){
-    distance=buildTarget?distanceToFootprint(v.x|0, v.y|0, buildTarget):Math.abs((v.x|0)-j.x)+Math.abs((v.y|0)-j.y);
-  } else {
-    distance=Math.abs((v.x|0)-j.x)+Math.abs((v.y|0)-j.y);
-  }
-  const jobView={
-    type:j.type,
-    prio:j.prio,
-    distance,
-    supply:supplyStatus
-  };
-  if(j.type==='build' && supplyStatus){
-    j.waitingForMaterials=!supplyStatus.fullyDelivered;
-  }
-  return scoreJob(jobView, v, policy, blackboard);
-}
-function maybeInterruptJob(v, { blackboard=null, margin=0 } = {}){
-  const currentJob = v.targetJob;
-  if(!currentJob) return false;
-  const bb = blackboard || gameState.bb;
-  const famineEmergency = bb?.famine === true && currentJob.type!=='harvest' && currentJob.type!=='sow' && currentJob.type!=='forage';
-  const jobStyle = policy?.style?.jobScoring || {};
-  const reprioritizeMargin = Number.isFinite(margin) ? margin : (Number.isFinite(jobStyle.reprioritizeMargin) ? jobStyle.reprioritizeMargin : 0);
-  if(!famineEmergency && reprioritizeMargin<=0) return false;
-
-  const wasAssigned = currentJob.assigned||0;
-  if(wasAssigned>0){ currentJob.assigned=Math.max(0, wasAssigned-1); }
-  const candidate = pickJobFor(v);
-  if(wasAssigned>0){ currentJob.assigned=wasAssigned; }
-  if(!candidate || candidate===currentJob) return false;
-
-  const currentScore = scoreExistingJobForVillager(currentJob, v, bb);
-  const candidateScore = scoreExistingJobForVillager(candidate, v, bb);
-  if(candidateScore>currentScore+reprioritizeMargin || famineEmergency){
-    finishJob(v);
-    if(v.path) v.path.length=0;
-    v.state='idle';
-    return true;
-  }
-  return false;
-}
-// Finds an open harvest job when food is tight and a villager is free.
-function findPanicHarvestJob(v){
-  const bb = gameState.bb;
-  let best=null, bestScore=-Infinity;
-  for(const j of jobs){
-    if(!j || j.type!=='harvest') continue;
-    if(j.assigned>=1) continue;
-    const i=idx(j.x,j.y);
-    if(world.growth[i]<=0) continue;
-    const distance=Math.abs((v.x|0)-j.x)+Math.abs((v.y|0)-j.y);
-    const jobView={ type:j.type, prio:j.prio, distance };
-    const jobScore=scoreJob(jobView, v, policy, bb);
-    if(jobScore>bestScore){ bestScore=jobScore; best=j; }
-  }
-  return best;
-}
-function pickJobFor(v){
-  if(v.lifeStage==='child') return null;
-  let best=null,bs=-Infinity;
-  const blackboard = gameState.bb;
-  const minScore = typeof policy?.style?.jobScoring?.minPickScore === 'number'
-    ? policy.style.jobScoring.minPickScore
-    : 0;
-  const jobStyle = policy?.style?.jobScoring || {};
-  for(const j of jobs){
-    let supplyStatus=null;
-    let buildTarget=null;
-    if(j.type==='hunt' && !v.equippedBow) continue;
-    if(j.type==='build'){
-      buildTarget=buildings.find(bb=>bb.id===j.bid);
-      if(!buildTarget || buildTarget.built>=1) continue;
-      supplyStatus=buildingSupplyStatus(buildTarget);
-      if(!supplyStatus.hasAnySupply){
-        j.waitingForMaterials=true;
-        requestBuildHauls(buildTarget);
-        const assistLimit = Number.isFinite(jobStyle.builderHaulAssistLimit) ? jobStyle.builderHaulAssistLimit : 1;
-        if(assistLimit>0){
-          const haulJobs=jobs.filter(h=>h.type==='haul' && h.bid===buildTarget.id && h.stage!=='deliver' && !h.cancelled);
-          const activeHaulers=haulJobs.reduce((sum,h)=>sum+(h.assigned||0),0);
-          if(activeHaulers<assistLimit){
-            const openHaul=haulJobs.find(h=>(h.assigned||0)===0);
-            if(openHaul){
-              const haulDistance=Math.abs((v.x|0)-openHaul.x)+Math.abs((v.y|0)-openHaul.y);
-              const haulView={ type:openHaul.type, prio:openHaul.prio, distance:haulDistance };
-              const haulScore=scoreJob(haulView, v, policy, blackboard);
-              if(haulScore>bs){ bs=haulScore; best=openHaul; }
-            }
-          }
-        }
-        continue;
-      }
-      if(j.assigned>=1 && !supplyStatus.fullyDelivered){
-        continue;
-      }
-    } else {
-      if(j.assigned>=1) continue;
-    }
-    const i=idx(j.x,j.y);
-    if(j.type==='chop'&&world.trees[i]===0) continue;
-    if(j.type==='mine'&&world.rocks[i]===0) continue;
-    if(j.type==='sow'&&world.growth[i]>0) continue;
-    if(j.type==='forage' && world.berries[j.targetI ?? i]<=0) continue;
-    let distance;
-    if(j.type==='build'){
-      distance=buildTarget?distanceToFootprint(v.x|0, v.y|0, buildTarget):Math.abs((v.x|0)-j.x)+Math.abs((v.y|0)-j.y);
-    } else if(j.type==='hunt'){
-      const targetAnimal=findAnimalById(j.targetAid);
-      const targetX=targetAnimal?.x ?? j.x;
-      const targetY=targetAnimal?.y ?? j.y;
-      distance=Math.abs((v.x|0)-Math.round(targetX))+Math.abs((v.y|0)-Math.round(targetY));
-    } else {
-      distance=Math.abs((v.x|0)-j.x)+Math.abs((v.y|0)-j.y);
-    }
-    const jobView={
-      type:j.type,
-      prio:j.prio,
-      distance,
-      supply:supplyStatus
-    };
-    const jobScore=scoreJob(jobView, v, policy, blackboard);
-    if(j.type==='build' && supplyStatus){
-      j.waitingForMaterials=!supplyStatus.fullyDelivered;
-    }
-    if(jobScore>bs){ bs=jobScore; best=j; }
-  }
-  return bs>minScore?best:null;
-}
-function stepAlong(v){ const next=v.path[0]; if(!next) return; const condition=v.condition||'normal'; const penalty=condition==='sick'?0.45:condition==='starving'?0.7:condition==='hungry'?0.85:condition==='recovering'?0.95:1; const moodSpeed=0.75+v.happy*0.5; const speedMultiplier=v.speed*penalty*moodSpeed*SPEEDS[speedIdx]; const stepPx=SPEED_PX_PER_SEC*speedMultiplier*SECONDS_PER_TICK; const step=stepPx/TILE; const dx=next.x-v.x, dy=next.y-v.y, dist=Math.hypot(dx,dy); if(dist<=step){ v.x=next.x; v.y=next.y; v.path.shift(); if(v.path.length===0) onArrive(v); } else { v.x+=(dx/dist)*step; v.y+=(dy/dist)*step; } }
-function onArrive(v){ const cx=v.x|0, cy=v.y|0, i=idx(cx,cy);
-if(v.state==='chop'){
-  let remove = world.trees[i]<=0;
-  if(world.trees[i]>0){
-    world.trees[i]--;
-    dropItem(cx,cy,ITEM.WOOD,1);
-    if(world.trees[i]===0){
-      world.tiles[i]=TILES.GRASS;
-      markStaticDirty();
-      remove = true;
-    }
-    v.thought=moodThought(v,'Chopped');
-  } else {
-    v.thought=moodThought(v,'Nothing to chop');
-  }
-  addJobExperience(v, 'chop', remove ? 2 : 1);
-  v.state='idle';
-  finishJob(v, remove);
-}
-else if(v.state==='mine'){
-  let remove = world.rocks[i]<=0;
-  if(world.rocks[i]>0){
-    world.rocks[i]--;
-    dropItem(cx,cy,ITEM.STONE,1);
-    if(world.rocks[i]===0){
-      world.tiles[i]=TILES.GRASS;
-      markStaticDirty();
-      remove = true;
-    }
-    v.thought=moodThought(v,'Mined');
-  } else {
-    v.thought=moodThought(v,'Nothing to mine');
-  }
-  v.state='idle';
-  applySkillGain(v, 'constructionSkill', 0.016, 0.88, 1);
-  addJobExperience(v, 'mine', remove ? 2 : 1);
-  finishJob(v, remove);
-}
-else if(v.state==='hunt'){
-  const job=v.targetJob;
-  const animal=job?findAnimalById(job.targetAid):null;
-  const lodge=job?buildings.find(bb=>bb.id===job.bid && bb.kind==='hunterLodge'):null;
-  if(!job || !animal || animal.state==='dead'){
-    v.thought=moodThought(v,'Lost prey');
-    v.state='idle';
-    finishJob(v, true);
-    return;
-  }
-  const dist=Math.hypot(animal.x-v.x, animal.y-v.y);
-  if(dist>HUNT_RANGE+0.2){
-    const approach=findHuntApproachPath(v, animal, { range:HUNT_RANGE });
-    if(approach?.path){
-      v.path=approach.path;
-      v.state='hunt';
-      v.thought=moodThought(v,'Stalking');
-      return;
-    }
-    suppressJob(job, HUNT_RETRY_COOLDOWN);
-    v.thought=moodThought(v,'Prey escaped');
-    v.state='idle';
-    finishJob(v, true);
-    return;
-  }
-  const behavior=ANIMAL_BEHAVIORS[animal.type] || {};
-  const skill=effectiveSkillFromExperience(v, 'constructionSkill', 0.5, 'hunt');
-  const moodFactor=clamp((v.happy-0.5)*0.5,-0.15,0.2);
-  const lodgeBonus=Number.isFinite(lodge?.effects?.gameYieldBonus)?lodge.effects.gameYieldBonus*0.2:0;
-  const successChance=clamp(0.55 + skill*0.25 + moodFactor + lodgeBonus, 0.25, 0.95);
-  if(R()<successChance){
-    const yieldResult=resolveHuntYield({ animal, lodge });
-    dropItem(animal.x|0, animal.y|0, ITEM.FOOD, yieldResult.meat);
-    if(yieldResult.pelts>0){
-      dropItem(animal.x|0, animal.y|0, 'pelt', yieldResult.pelts);
-    }
-    queueAnimalLabel('Taken', '#ffd27f', animal.x+0.1, animal.y-0.1);
-    removeAnimal(animal);
-    v.happy=clamp(v.happy+0.06,0,1);
-    applySkillGain(v, 'constructionSkill', 0.014, 0.9, 1);
-    addJobExperience(v, 'hunt', 2.5);
-    v.thought=moodThought(v,'Successful hunt');
-  } else {
-    animal.state='flee';
-    animal.target=chooseFleeTarget(animal, v, behavior, new Map());
-    animal.fleeTicks=Math.round((behavior.roamTicks?.[0]||40)*0.8);
-    v.happy=clamp(v.happy-0.015,0,1);
-    applySkillGain(v, 'constructionSkill', 0.008, 0.9, 1);
-    suppressJob(job, HUNT_RETRY_COOLDOWN);
-    addJobExperience(v, 'hunt', 1);
-    v.thought=moodThought(v,'Missed the shot');
-  }
-  v.state='idle';
-  finishJob(v, true);
-}
-else if(v.state==='forage'){
-  if(Number.isInteger(v.targetI) && world.berries[v.targetI]>0){
-    world.berries[v.targetI]--;
-    if((v.starveStage||0)>=2 || v.condition==='sick'){
-      v.hunger-=FOOD_HUNGER_RECOVERY;
-      if(v.hunger<0) v.hunger=0;
-      handleVillagerFed(v,'berries');
-      v.thought=moodThought(v,'Ate berries');
-    } else {
-      v.inv={type:ITEM.FOOD,qty:1};
-      v.thought=moodThought(v,'Got berries');
-    }
-  } else {
-    v.thought=moodThought(v,'Berries gone');
-  }
-  addJobExperience(v, 'forage', 1);
-  v.state='idle';
-  finishJob(v, true);
-}
-else if(v.state==='seek_food'){
-  if(!v.inv){
-    const itemKey=(cy*GRID_W)+cx;
-    const itemIndex=itemTileIndex.get(itemKey);
-    const it=itemIndex!==undefined?itemsOnGround[itemIndex]:null;
-    if(it && it.type===ITEM.FOOD){
-      v.inv={type:ITEM.FOOD,qty:it.qty};
-      removeItemAtIndex(itemIndex);
-    }
-  }
-  if(consumeFood(v)){
-    v.thought=moodThought(v,'Eating');
-  } else if(v.inv && v.inv.type===ITEM.FOOD){
-    v.thought=moodThought(v,'Holding food');
-  } else {
-    v.thought=moodThought(v,'No food found');
-  }
-  v.state='idle';
-}
-else if(v.state==='sow'){
-  if(world.tiles[i]!==TILES.WATER){
-    world.tiles[i]=TILES.FARMLAND;
-    world.growth[i]=1;
-    world.zone[i]=ZONES.FARM;
-    ensureRowMasksSize();
-    zoneRowMask[cy]=1;
-    markStaticDirty();
-    v.thought=moodThought(v,'Sowed');
-  } else {
-    v.thought=moodThought(v,'Too wet to sow');
-  }
-  v.state='idle';
-  applySkillGain(v, 'farmingSkill', 0.012, 0.9, 1);
-  addJobExperience(v, 'sow', 1);
-  finishJob(v, true);
-}
-else if(v.state==='harvest'){
-  if(world.growth[i]>0){
-    // Balance knob: base yield per crop tile.
-    let yieldAmount=2;
-    const { harvestBonus } = agricultureBonusesAt(cx,cy);
-    if(harvestBonus>0){
-      const whole=Math.floor(harvestBonus);
-      yieldAmount+=whole;
-      const frac=harvestBonus-whole;
-      if(frac>0 && R()<frac) yieldAmount+=1;
-    }
-    dropItem(cx,cy,ITEM.FOOD,yieldAmount);
-    const harvestThought=yieldAmount>1?'Bountiful harvest':'Harvested';
-    v.thought=moodThought(v,harvestThought);
-  } else {
-    v.thought=moodThought(v,'Nothing to harvest');
-  }
-  world.growth[i]=0;
-  v.state='idle';
-  applySkillGain(v, 'farmingSkill', 0.018, 0.9, 1);
-  addJobExperience(v, 'harvest', 2);
-  finishJob(v, true);
-}
-else if(v.state==='build'){
-  let remove=false;
-  const b=buildings.find(bb=>bb.id===v.targetJob?.bid);
-  if(b){
-    ensureBuildingData(b);
-    const def=BUILDINGS[b.kind]||{};
-    const cost=def.cost||((def.wood||0)+(def.stone||0));
-    if(b.built<1){
-      const store=b.store||{};
-      const spent=b.spent||{wood:0,stone:0};
-      let used=0;
-      if(def.wood){
-        const needWood=Math.max(0, (def.wood||0)-(spent.wood||0));
-        if(needWood>0 && (store.wood||0)>0){
-          const take=Math.min(needWood, store.wood);
-          store.wood-=take;
-          spent.wood=(spent.wood||0)+take;
-          used+=take;
-        }
-      }
-      if(def.stone){
-        const needStone=Math.max(0, (def.stone||0)-(spent.stone||0));
-        if(needStone>0 && (store.stone||0)>0){
-          const take=Math.min(needStone, store.stone);
-          store.stone-=take;
-          spent.stone=(spent.stone||0)+take;
-          used+=take;
-        }
-      }
-      b.progress=(spent.wood||0)+(spent.stone||0);
-      if(b.progress>=cost){
-        b.built=1;
-        spent.wood=def.wood||0;
-        spent.stone=def.stone||0;
-        b.progress=cost;
-        if(b.kind==='campfire') markEmittersDirty();
-        cancelHaulJobsForBuilding(b);
-        markStaticDirty();
-        v.thought=moodThought(v,'Built');
-        remove=true;
-      } else {
-        requestBuildHauls(b);
-        v.thought=moodThought(v, used>0 ? 'Building' : 'Needs supplies');
-      }
-    } else {
-      v.thought=moodThought(v,'Built');
-      cancelHaulJobsForBuilding(b);
-      remove=true;
-    }
-  } else {
-    const bid=v.targetJob?.bid;
-    if(bid){ cancelHaulJobsForBuilding({id:bid}); }
-    v.thought=moodThought(v,'Site missing');
-    remove=true;
-  }
-  applySkillGain(v, 'constructionSkill', remove ? 0.02 : 0.012, 0.9, 1);
-  addJobExperience(v, 'build', remove ? 3 : 1);
-  v.state='idle';
-  finishJob(v, remove);
-}
-else if(v.state==='haul_pickup'){
-  const job=v.targetJob;
-  const res=job?.resource;
-  const qty=job?.qty||0;
-  const b=job?buildings.find(bb=>bb.id===job.bid):null;
-  if(!job || job.type!=='haul' || !res || qty<=0){
-    if(job && job.type==='haul' && job.stage==='pickup'){ const r=job.resource; storageReserved[r]=Math.max(0,(storageReserved[r]||0)-qty); if(b){ ensureBuildingData(b); b.pending[r]=Math.max(0,(b.pending[r]||0)-qty); } }
-    v.thought=moodThought(v,'Idle');
-    v.state='idle';
-    finishJob(v, true);
-    return;
-  }
-  ensureBuildingData(b);
-  if(!b || b.built>=1){
-    storageReserved[res]=Math.max(0,(storageReserved[res]||0)-qty);
-    if(b){ b.pending[res]=Math.max(0,(b.pending[res]||0)-qty); }
-    v.thought=moodThought(v,'Site stocked');
-    v.state='idle';
-    finishJob(v, true);
-    return;
-  }
-  const available=storageTotals[res]||0;
-  if(available>=qty){
-    storageTotals[res]-=qty;
-    storageReserved[res]=Math.max(0,(storageReserved[res]||0)-qty);
-    v.inv={type:res,qty};
-    job.stage='deliver';
-    v.thought=moodThought(v,'Loaded supplies');
-    let dest=job.dest||{x:b.x,y:b.y};
-    const targetBuilding=job.dest?buildingAt(dest.x,dest.y):b;
-    if(targetBuilding){
-      const entry=findEntryTileNear(targetBuilding, cx, cy) || {x:Math.round(buildingCenter(targetBuilding).x), y:Math.round(buildingCenter(targetBuilding).y)};
-      dest=entry;
-    }
-    const p=pathfind(cx,cy,dest.x,dest.y);
-    if(p){
-      v.path=p;
-      v.state='haul_deliver';
-      return;
-    }
-    storageTotals[res]+=qty;
-    v.inv=null;
-    b.pending[res]=Math.max(0,(b.pending[res]||0)-qty);
-    v.thought=moodThought(v,'Path blocked');
-    v.state='idle';
-    finishJob(v, true);
-  } else {
-    storageReserved[res]=Math.max(0,(storageReserved[res]||0)-qty);
-    b.pending[res]=Math.max(0,(b.pending[res]||0)-qty);
-    v.thought=moodThought(v,'Needs supplies');
-    v.state='idle';
-    finishJob(v, true);
-  }
-}
-else if(v.state==='haul_deliver'){
-  const job=v.targetJob;
-  const res=job?.resource;
-  const carrying=v.inv;
-  const b=job?buildings.find(bb=>bb.id===job.bid):null;
-  v.thought=moodThought(v,'Idle');
-  if(job && job.type==='haul' && carrying && carrying.type===res){
-    const qty=carrying.qty||0;
-    v.inv=null;
-    if(b){ ensureBuildingData(b); }
-    if(b && b.built<1 && !job?.cancelled){
-      b.store[res]=(b.store[res]||0)+qty;
-      requestBuildHauls(b);
-      v.thought=moodThought(v,'Delivered supplies');
-    } else {
-      storageTotals[res]=(storageTotals[res]||0)+qty;
-      v.thought=moodThought(v,'Returned supplies');
-    }
-    if(b){ b.pending[res]=Math.max(0,(b.pending[res]||0)-qty); }
-    applySkillGain(v, 'constructionSkill', 0.01, 0.9, 1);
-    addJobExperience(v, 'haul', 1);
-  } else if(job && job.type==='haul' && job.stage==='pickup'){
-    const qty=job.qty||0;
-    if(res){
-      storageReserved[res]=Math.max(0,(storageReserved[res]||0)-qty);
-      if(b){ ensureBuildingData(b); b.pending[res]=Math.max(0,(b.pending[res]||0)-qty); }
-    }
-  }
-  v.state='idle';
-  finishJob(v, true);
-}
-else if(v.state==='craft_bow'){
-  const job=v.targetJob;
-  const recipe=job?.materials || CRAFTING_RECIPES.bow;
-  const lodge=job?buildings.find(bb=>bb.id===job.bid && bb.kind==='hunterLodge'):null;
-  if(!job || !lodge || lodge.built<1){
-    releaseReservedMaterials(recipe||{});
-    v.thought=moodThought(v,'No lodge');
-    v.state='idle';
-    finishJob(v, true);
-    return;
-  }
-  if(!spendCraftMaterials(recipe||{})){
-    v.thought=moodThought(v,'Missing supplies');
-    v.state='idle';
-    finishJob(v, true);
-    return;
-  }
-  const storage=findNearestBuilding(cx,cy,'storage');
-  if(storage){
-    storageTotals.bow=(storageTotals.bow||0)+1;
-    v.thought=moodThought(v,'Crafted bow');
-  } else if(!v.inv){
-    v.inv={ type:ITEM.BOW, qty:1 };
-    v.thought=moodThought(v,'Crafted bow');
-  } else {
-    dropItem(cx,cy,ITEM.BOW,1);
-    v.thought=moodThought(v,'Dropped bow');
-  }
-  applySkillGain(v, 'constructionSkill', 0.012, 0.9, 1);
-  addJobExperience(v, 'craft_bow', 2.5);
-  v.state='idle';
-  finishJob(v, true);
-}
-else if(v.state==='equip_bow'){
-  const storage=v.targetBuilding||findNearestBuilding(cx,cy,'storage');
-  if(storage && spendCraftMaterials({ bow:1 })){
-    v.equippedBow=true;
-    v.thought=moodThought(v,'Equipped bow');
-  } else {
-    v.thought=moodThought(v,'No bow available');
-  }
-  v.state='idle';
-  v.targetBuilding=null;
-}
-else if(v.state==='to_storage'){
-  if(v.inv){
-    if(v.inv.type===ITEM.FOOD && ((v.starveStage||0)>=2 || v.condition==='sick')){
-      consumeFood(v);
-      v.thought=moodThought(v,'Ate supplies');
-    } else {
-      if(v.inv.type===ITEM.WOOD) storageTotals.wood+=v.inv.qty;
-      if(v.inv.type===ITEM.STONE) storageTotals.stone+=v.inv.qty;
-      if(v.inv.type===ITEM.FOOD) storageTotals.food+=v.inv.qty;
-      if(v.inv.type===ITEM.BOW) storageTotals.bow+=v.inv.qty;
-      v.inv=null;
-      v.thought=moodThought(v,'Stored');
-    }
-  }
-  v.state='idle';
-}
-else if(v.state==='rest'){
-  const baseRest=REST_BASE_TICKS+Math.round(Math.max(0,1-v.energy)*REST_EXTRA_PER_ENERGY);
-  const b=v.targetBuilding||getBuildingById(v.activeBuildingId)||buildingAt(cx,cy);
-  if(b) setActiveBuilding(v,b);
-  if(b) noteBuildingActivity(b,'rest');
-  if(v.restTimer<baseRest) v.restTimer=baseRest;
-  v.state='resting';
-  v.thought=moodThought(v,'Resting');
-}
-else if(v.state==='hydrate'){
-  const b=v.targetBuilding||getBuildingById(v.activeBuildingId)||buildingAt(cx,cy);
-  if(b) setActiveBuilding(v,b);
-  if(b) noteBuildingActivity(b,'hydrate');
-  v.hydrationTimer=Math.max(v.hydrationTimer||0, Math.round(HYDRATION_BUFF_TICKS*0.25));
-  v.hydration=1;
-  v.hydrationBuffTicks=Math.max(v.hydrationBuffTicks, HYDRATION_BUFF_TICKS);
-  v.state='hydrating';
-  v.thought=moodThought(v,'Drinking');
-}
-else if(v.state==='socialize'){
-  const b=v.targetBuilding||getBuildingById(v.activeBuildingId)||buildingAt(cx,cy);
-  if(b) setActiveBuilding(v,b);
-  if(b) noteBuildingActivity(b,'social');
-  v.socialTimer=Math.max(v.socialTimer||0, SOCIAL_BASE_TICKS);
-  v.state='socializing';
-  v.thought=moodThought(v,'Gathering');
-}
-else if(v.state==='storage_idle'){
-  const b=v.targetBuilding||getBuildingById(v.activeBuildingId)||buildingAt(cx,cy);
-  if(b) setActiveBuilding(v,b);
-  if(b) noteBuildingActivity(b,'use');
-  v.storageIdleTimer=Math.max(v.storageIdleTimer||0, STORAGE_IDLE_BASE);
-  v.state='storage_linger';
-  v.thought=moodThought(v,'Tidying storage');
-} }
+// stepAlong and onArrive moved to src/app/onArrive.js — see _onArrive factory wiring below.
 
 /* ==================== Seasons/Growth ==================== */
 function seasonTick(){
@@ -3453,107 +1584,6 @@ function dropItem(x,y,type,qty){
   markItemsDirty();
 }
 
-function nocturnalAmbientStrength(ambient){
-  const usableRange = Math.max(0.0001, 1 - LIGHTING.nightFloor);
-  return clamp01((1 - ambient) / usableRange);
-}
-
-function spawnNocturnalEntity(nightStrength){
-  const slot = nocturnalEntities.find((entity) => !entity.active);
-  if (!slot) return false;
-
-  const margin = 1.25;
-  slot.active = true;
-  slot.x = rnd(margin, GRID_W - margin);
-  slot.y = rnd(margin, GRID_H - margin);
-  const angle = rnd(0, Math.PI * 2);
-  const speed = rnd(0.004, 0.018);
-  slot.vx = Math.cos(angle) * speed;
-  slot.vy = Math.sin(angle) * speed;
-  slot.radius = rnd(0.35, 0.65);
-  slot.energy = 0.5 + nightStrength * 0.45 + rnd(0, 0.15);
-  slot.fade = 0;
-  slot.wanderTicks = irnd(28, 90);
-  return true;
-}
-
-function updateNocturnalEntities(ambient){
-  const nightActive = isNightAmbient(ambient);
-  const nightStrength = nocturnalAmbientStrength(ambient);
-  const dawnFade = clamp01((DAWN_AMBIENT_THRESHOLD - ambient) / DAWN_AMBIENT_THRESHOLD);
-  let activeCount = 0;
-
-  for (const entity of nocturnalEntities){
-    if (!entity.active) continue;
-
-    entity.wanderTicks--;
-    if(entity.wanderTicks <= 0){
-      const angle = rnd(0, Math.PI * 2);
-      const speed = rnd(0.0035, 0.015);
-      entity.vx = Math.cos(angle) * speed;
-      entity.vy = Math.sin(angle) * speed;
-      entity.wanderTicks = irnd(30, 120);
-    }
-
-    entity.x = clamp(entity.x + entity.vx, 1.25, GRID_W - 1.25);
-    entity.y = clamp(entity.y + entity.vy, 1.25, GRID_H - 1.25);
-    if(entity.x <= 1.3 || entity.x >= GRID_W - 1.3) entity.vx *= -0.6;
-    if(entity.y <= 1.3 || entity.y >= GRID_H - 1.3) entity.vy *= -0.6;
-
-    const targetFade = nightActive ? 1 : dawnFade * 0.65;
-    const fadeDelta = targetFade - entity.fade;
-    entity.fade = clamp(entity.fade + fadeDelta * 0.08 - (nightActive ? 0 : 0.01), 0, 1);
-    entity.alpha = clamp(entity.energy * entity.fade * (0.45 + nightStrength * 0.6), 0, 1);
-
-    if(entity.alpha <= 0.02){
-      entity.active = false;
-      continue;
-    }
-    activeCount++;
-  }
-
-  if(nightActive){
-    if(nocturnalSpawnCooldown > 0) nocturnalSpawnCooldown--;
-    const targetPopulation = Math.max(4, Math.floor(nightStrength * nocturnalEntities.length * 0.8));
-    while(activeCount < targetPopulation && nocturnalSpawnCooldown <= 0){
-      if(!spawnNocturnalEntity(nightStrength)) break;
-      nocturnalSpawnCooldown = irnd(12, 26);
-      activeCount++;
-    }
-  } else {
-    nocturnalSpawnCooldown = Math.max(nocturnalSpawnCooldown, 6);
-  }
-}
-
-function drawNocturnalEntities(ambient){
-  const nightStrength = nocturnalAmbientStrength(ambient);
-  if(nightStrength <= 0 && !nocturnalEntities.some((e) => e.active)) return;
-
-  ctx.save();
-  ctx.globalCompositeOperation='lighter';
-  for(const entity of nocturnalEntities){
-    if(!entity.active || entity.alpha <= 0) continue;
-    const gx = tileToPxX(entity.x, cam);
-    const gy = tileToPxY(entity.y, cam);
-    const radiusPx = entity.radius * TILE * cam.z * (1.2 + nightStrength * 0.8);
-    const grd = ctx.createRadialGradient(gx, gy, 0, gx, gy, radiusPx);
-    const alpha = entity.alpha;
-    grd.addColorStop(0, `rgba(170,210,255,${0.6 * alpha})`);
-    grd.addColorStop(0.45, `rgba(140,190,255,${0.35 * alpha})`);
-    grd.addColorStop(1, 'rgba(120,170,240,0)');
-    ctx.fillStyle = grd;
-    ctx.beginPath();
-    ctx.arc(gx, gy, radiusPx, 0, Math.PI*2);
-    ctx.fill();
-  }
-  ctx.restore();
-}
-
-// SECONDS_PER_TICK and SPEED_PX_PER_SEC are read by stepAlong() in this file;
-// the rest of the per-frame timing is owned by createTickRunner.
-const TICKS_PER_SEC = policy.routine.ticksPerSecond || 6;
-const SECONDS_PER_TICK = 1 / TICKS_PER_SEC;
-const SPEED_PX_PER_SEC = 0.08 * 32 * TICKS_PER_SEC;
 
 function processVillagerItemPickup(v){
   if(itemTileIndexDirty) rebuildItemTileIndex();
@@ -3566,6 +1596,182 @@ function processVillagerItemPickup(v){
   v.inv = { type: it.type, qty: it.qty };
   removeItemAtIndex(itemIndex);
 }
+
+/* ==================== Factory wiring ==================== */
+// Order matters: each factory only depends on factories declared above it,
+// or uses thunks (arrow functions) for forward references.
+
+const _jobsSystem = createJobsSystem({
+  state: gameState,
+  policy
+});
+const {
+  activeZoneJobs,
+  clearActiveZoneJobs,
+  noteJobAssignmentChanged,
+  noteJobRemoved,
+  getJobCreationConfig,
+  jobKey: _jobKey,
+  isJobSuppressed: _isJobSuppressed,
+  suppressJob,
+  hasSimilarJob,
+  violatesSpacing,
+  addJob,
+  finishJob,
+  detachVillagersFromJob
+} = _jobsSystem;
+void _jobKey; void _isJobSuppressed;
+
+const _animalsSystem = createAnimalsSystem({
+  state: gameState,
+  pathfind,
+  tileOccupiedByBuilding,
+  idx,
+  dropItem
+});
+const {
+  spawnAnimalsForWorld,
+  queueAnimalLabel,
+  chooseFleeTarget,
+  findAnimalById,
+  removeAnimal,
+  resolveHuntYield,
+  findHuntApproachPath,
+  updateAnimals
+} = _animalsSystem;
+
+// findNearestBuilding lives on _villagerAI; thunk it so factories declared
+// before _villagerAI can still reach it.
+const findNearestBuilding = (x, y, kind) => _villagerAI.findNearestBuilding(x, y, kind);
+
+const _materialsSystem = createMaterials({
+  state: gameState,
+  policy,
+  addJob,
+  noteJobRemoved,
+  findNearestBuilding,
+  detachVillagersFromJob
+});
+const {
+  availableToReserve,
+  reserveMaterials,
+  releaseReservedMaterials,
+  spendCraftMaterials,
+  countBuildingsByKind,
+  scheduleHaul: _scheduleHaul,
+  requestBuildHauls,
+  cancelHaulJobsForBuilding
+} = _materialsSystem;
+void _scheduleHaul;
+
+const _populationSystem = createPopulation({
+  state: gameState,
+  countBuildingsByKind,
+  tileOccupiedByBuilding,
+  idx,
+  ensureVillagerNumber
+});
+const {
+  newVillager,
+  tryStartPregnancy,
+  completePregnancy,
+  promoteChildToAdult,
+  flushPendingBirths
+} = _populationSystem;
+
+const _villagerAI = createVillagerAI({
+  state: gameState,
+  policy,
+  pathfind,
+  passable,
+  Toast,
+  finishJob,
+  availableToReserve,
+  requestBuildHauls,
+  findAnimalById,
+  findEntryTileNear,
+  getBuildingById,
+  buildingsByKind,
+  idx,
+  ambientAt,
+  isNightTime
+});
+const {
+  nearbyWarmth,
+  issueStarveToast,
+  handleVillagerFed,
+  consumeFood,
+  seekEmergencyFood,
+  foragingJob,
+  goRest,
+  tryHydrateAtWell,
+  tryCampfireSocial,
+  tryStorageIdle,
+  tryEquipBow,
+  enterSickState,
+  maybeInterruptJob,
+  findPanicHarvestJob,
+  pickJobFor,
+  handleIdleRoam
+} = _villagerAI;
+
+const TICKS_PER_SEC = policy.routine.ticksPerSecond || 6;
+const SECONDS_PER_TICK = 1 / TICKS_PER_SEC;
+const SPEED_PX_PER_SEC = 0.08 * 32 * TICKS_PER_SEC;
+
+const _onArriveSystem = createOnArrive({
+  state: gameState,
+  pathfind,
+  idx,
+  finishJob,
+  suppressJob,
+  releaseReservedMaterials,
+  spendCraftMaterials,
+  requestBuildHauls,
+  cancelHaulJobsForBuilding,
+  findAnimalById,
+  removeAnimal,
+  resolveHuntYield,
+  chooseFleeTarget,
+  queueAnimalLabel,
+  findHuntApproachPath,
+  consumeFood,
+  handleVillagerFed,
+  findNearestBuilding,
+  agricultureBonusesAt,
+  findEntryTileNear,
+  getBuildingById,
+  setActiveBuilding,
+  noteBuildingActivity,
+  buildingAt,
+  dropItem,
+  removeItemAtIndex,
+  itemTileIndex,
+  markStaticDirty,
+  markEmittersDirty,
+  onZoneTileSown: (_cx, cy) => { ensureRowMasksSize(); zoneRowMask[cy] = 1; },
+  getSecondsPerTick: () => SECONDS_PER_TICK,
+  getSpeedPxPerSec: () => SPEED_PX_PER_SEC
+});
+const { stepAlong, onArrive: _onArrive } = _onArriveSystem;
+void _onArrive;
+
+const _debugKitBridge = createDebugKitBridge({
+  state: gameState,
+  ensureVillagerNumber,
+  applyShadingMode,
+  markStaticDirty
+});
+const { ensureDebugKitConfigured } = _debugKitBridge;
+_debugKitBridge.attachToWindow();
+
+const _nocturnalSystem = createNocturnalSystem({});
+const {
+  updateNocturnalEntities,
+  drawNocturnalEntities
+} = _nocturnalSystem;
+
+/* ==================== Planner & tick wiring ==================== */
 
 const planner = createPlanner({
   state: gameState,

--- a/src/app/animals.js
+++ b/src/app/animals.js
@@ -1,0 +1,415 @@
+import {
+  ANIMAL_BEHAVIORS,
+  ANIMAL_TYPES,
+  GRID_H,
+  GRID_SIZE,
+  GRID_W,
+  HUNT_RANGE,
+  ITEM,
+  TILES,
+  WALKABLE,
+  tileToPxX,
+  tileToPxY,
+} from './constants.js';
+import { cam } from './canvas.js';
+import { R, clamp, irnd, uid } from './rng.js';
+import { moodThought } from './simulation.js';
+
+const DEFAULT_ANIMAL_BEHAVIOR = {
+  roamRadius: 2,
+  idleTicks: [20, 60],
+  roamTicks: [40, 90],
+  speed: 0.12,
+  fleeSpeed: 0.16,
+  grazeChance: 0.1,
+  grazeRadius: 1,
+  fearRadius: 3,
+  fleeDistance: 3,
+  observeMood: 0.003,
+  idleBob: 1,
+};
+
+export function createAnimalsSystem(opts) {
+  const {
+    state,
+    pathfind,
+    tileOccupiedByBuilding,
+    idx,
+    dropItem,
+  } = opts;
+
+  const animals = state.units.animals;
+  const villagers = state.units.villagers;
+  const villagerLabels = state.queue.villagerLabels;
+
+  function getWorld() { return state.world; }
+  function getTick() { return state.time.tick; }
+
+  function desiredAnimalsForType(type) {
+    const def = ANIMAL_TYPES[type];
+    if (!def) return 0;
+    const density = typeof def.density === 'number' ? def.density : 0;
+    const baseCount = Math.round(GRID_SIZE * density);
+    const minCount = def.minCount || 0;
+    return Math.max(minCount, baseCount);
+  }
+
+  function isAnimalTileAllowed(tile, def, allowFallback) {
+    const preferred = Array.isArray(def?.preferred) ? def.preferred : [];
+    const fallback = Array.isArray(def?.fallback) ? def.fallback : preferred;
+    const allowedSet = allowFallback ? (fallback.length ? fallback : preferred) : preferred;
+    if (allowedSet.length === 0) {
+      return WALKABLE.has(tile);
+    }
+    return allowedSet.includes(tile);
+  }
+
+  function spawnAnimalsForWorld() {
+    const world = getWorld();
+    animals.length = 0;
+    const occupied = new Set();
+
+    const tileFree = (x, y) => {
+      if (x < 0 || y < 0 || x >= GRID_W || y >= GRID_H) return false;
+      const i = y * GRID_W + x;
+      if (occupied.has(i)) return false;
+      if (tileOccupiedByBuilding(x, y)) return false;
+      const tile = world.tiles[i];
+      if (tile === TILES.WATER) return false;
+      if (world.trees[i] > 0 || world.rocks[i] > 0) return false;
+      return WALKABLE.has(tile);
+    };
+
+    for (const [type, def] of Object.entries(ANIMAL_TYPES)) {
+      const target = desiredAnimalsForType(type);
+      if (target <= 0) continue;
+      let placed = 0;
+      let attempts = 0;
+      const maxAttempts = Math.max(target * 180, target * 24);
+      while (placed < target && attempts < maxAttempts) {
+        attempts++;
+        const x = irnd(0, GRID_W - 1);
+        const y = irnd(0, GRID_H - 1);
+        if (!tileFree(x, y)) continue;
+        const i = y * GRID_W + x;
+        const tile = world.tiles[i];
+        const allowFallback = attempts > target * 60;
+        if (!isAnimalTileAllowed(tile, def, allowFallback)) continue;
+        animals.push({ id: uid(), type, x, y, dir: R() < 0.5 ? 'left' : 'right' });
+        occupied.add(i);
+        placed++;
+      }
+    }
+  }
+
+  function behaviorForAnimal(a) {
+    return ANIMAL_BEHAVIORS[a.type] || DEFAULT_ANIMAL_BEHAVIOR;
+  }
+
+  function ensureAnimalDefaults(a) {
+    const tick = getTick();
+    if (!a.state) a.state = 'idle';
+    if (!Number.isFinite(a.nextActionTick)) a.nextActionTick = tick + irnd(12, 48);
+    if (!Number.isFinite(a.idlePhase)) a.idlePhase = irnd(0, 900);
+    if (!Number.isFinite(a.nextVillageTick)) a.nextVillageTick = 0;
+    if (!Number.isFinite(a.nextGrazeTick)) a.nextGrazeTick = 0;
+    if (!Number.isFinite(a.fleeTicks)) a.fleeTicks = 0;
+  }
+
+  function animalTileBlocked(x, y, occupancy, id) {
+    const world = getWorld();
+    const tx = x | 0, ty = y | 0;
+    if (tx < 0 || ty < 0 || tx >= GRID_W || ty >= GRID_H) return true;
+    const i = ty * GRID_W + tx;
+    if (world.tiles[i] === TILES.WATER) return true;
+    if (world.trees[i] > 0 || world.rocks[i] > 0) return true;
+    if (tileOccupiedByBuilding(tx, ty)) return true;
+    if (occupancy) {
+      const key = ty * GRID_W + tx;
+      const other = occupancy.get(key);
+      if (other && other !== id) return true;
+    }
+    return false;
+  }
+
+  function queueAnimalLabel(text, color, x, y) {
+    if (!text) return;
+    const fontSize = Math.max(6, 6 * cam.z);
+    const boxH = fontSize + 4 * cam.z;
+    villagerLabels.push({
+      text,
+      color,
+      cx: tileToPxX(x, cam),
+      cy: tileToPxY(y, cam) - 6 * cam.z,
+      fontSize,
+      boxH,
+      camZ: cam.z,
+    });
+  }
+
+  function nearestVillagerWithin(x, y, radius) {
+    let best = null, bd = radius + 0.001;
+    for (const v of villagers) {
+      const d = Math.hypot((v.x | 0) - x, (v.y | 0) - y);
+      if (d <= bd) { bd = d; best = v; }
+    }
+    return best;
+  }
+
+  function pickRoamTarget(a, behavior, occupancy) {
+    const world = getWorld();
+    const tries = 14;
+    for (let t = 0; t < tries; t++) {
+      const dx = irnd(-behavior.roamRadius, behavior.roamRadius);
+      const dy = irnd(-behavior.roamRadius, behavior.roamRadius);
+      const tx = clamp((a.x | 0) + dx, 0, GRID_W - 1);
+      const ty = clamp((a.y | 0) + dy, 0, GRID_H - 1);
+      const i = ty * GRID_W + tx;
+      const def = ANIMAL_TYPES[a.type];
+      if (!isAnimalTileAllowed(world.tiles[i], def, true)) continue;
+      if (animalTileBlocked(tx, ty, occupancy, a.id)) continue;
+      return { x: tx + 0.02 * R(), y: ty + 0.02 * R() };
+    }
+    return null;
+  }
+
+  function attemptGraze(animal, behavior) {
+    const tick = getTick();
+    const world = getWorld();
+    if (animal.nextGrazeTick > tick) return false;
+    if (R() > behavior.grazeChance) return false;
+    const radius = Math.max(1, behavior.grazeRadius || 1);
+    const ax = animal.x | 0, ay = animal.y | 0;
+    let target = null;
+    for (let y = ay - radius; y <= ay + radius; y++) {
+      for (let x = ax - radius; x <= ax + radius; x++) {
+        const i = idx(x, y);
+        if (i < 0) continue;
+        if (world.berries[i] > 0) { target = { x, y, i }; break; }
+      }
+      if (target) break;
+    }
+    if (!target) return false;
+    world.berries[target.i] = Math.max(0, world.berries[target.i] - 1);
+    animal.nextGrazeTick = tick + Math.round(60 + R() * 120);
+    queueAnimalLabel('Grazing', '#cde6b7', target.x + 0.1, target.y - 0.15);
+    return true;
+  }
+
+  function chooseFleeTarget(animal, from, behavior, occupancy) {
+    const fx = from?.x ?? animal.x;
+    const fy = from?.y ?? animal.y;
+    const dirX = animal.x - fx;
+    const dirY = animal.y - fy;
+    const mag = Math.hypot(dirX, dirY) || 1;
+    const dist = Math.max(behavior.fleeDistance || 3, 1.5);
+    const targetX = clamp(Math.round(animal.x + (dirX / mag) * dist), 0, GRID_W - 1);
+    const targetY = clamp(Math.round(animal.y + (dirY / mag) * dist), 0, GRID_H - 1);
+    if (!animalTileBlocked(targetX, targetY, occupancy, animal.id)) {
+      return { x: targetX + 0.12 * R(), y: targetY + 0.12 * R() };
+    }
+    return pickRoamTarget(animal, behavior, occupancy);
+  }
+
+  function findAnimalById(id) {
+    if (!id) return null;
+    for (const a of animals) {
+      if (a && a.id === id) { return a; }
+    }
+    return null;
+  }
+
+  function removeAnimal(animal) {
+    if (!animal) return false;
+    const i = animals.indexOf(animal);
+    if (i !== -1) { animals.splice(i, 1); return true; }
+    return false;
+  }
+
+  function resolveHuntYield({ animal: _animal, lodge }) {
+    const effects = lodge?.effects || {};
+    const gameBonus = Number.isFinite(effects.gameYieldBonus) ? effects.gameYieldBonus : 0;
+    const hideBonus = Number.isFinite(effects.hideYieldBonus) ? effects.hideYieldBonus : 0;
+    const baseMeat = 1 + (R() < 0.42 ? 1 : 0);
+    const meat = Math.max(1, Math.round(baseMeat * (1 + gameBonus)));
+    const hideChance = 0.35 + hideBonus * 0.5;
+    return { meat, pelts: R() < hideChance ? 1 : 0 };
+  }
+
+  function findHuntApproachPath(v, animal, { range = HUNT_RANGE, maxPath = 320 } = {}) {
+    if (!v || !animal) return null;
+    const world = getWorld();
+    const ax = Math.round(animal.x);
+    const ay = Math.round(animal.y);
+    const radius = Math.max(1, Math.ceil(range));
+    let best = null;
+    for (let dy = -radius; dy <= radius; dy++) {
+      for (let dx = -radius; dx <= radius; dx++) {
+        const tx = ax + dx, ty = ay + dy;
+        const dist = Math.hypot(tx - animal.x, ty - animal.y);
+        if (dist > range) continue;
+        if (tx < 0 || ty < 0 || tx >= GRID_W || ty >= GRID_H) continue;
+        if (tileOccupiedByBuilding(tx, ty)) continue;
+        const tile = world.tiles[idx(tx, ty)];
+        if (tile === TILES.WATER) continue;
+        if (!WALKABLE.has(tile)) continue;
+        const p = pathfind(v.x | 0, v.y | 0, tx, ty, maxPath);
+        if (!p) continue;
+        if (!best || p.length < best.score) {
+          best = { path: p, score: p.length, dest: { x: tx, y: ty } };
+        }
+      }
+    }
+    return best;
+  }
+
+  function interactWithVillage(animal, behavior, occupancy) {
+    const tick = getTick();
+    if (animal.nextVillageTick > tick) return;
+    const radius = Math.max(2, behavior.fearRadius || 3);
+    const villager = nearestVillagerWithin(animal.x, animal.y, radius);
+    if (!villager) return;
+    const hungry = (villager.starveStage || 0) >= 1 || villager.condition === 'hungry' || villager.condition === 'starving';
+    if (hungry && R() < 0.08) {
+      dropItem(animal.x | 0, animal.y | 0, ITEM.FOOD, 1);
+      villager.hunger = Math.max(0, villager.hunger - 0.12);
+      villager.thought = moodThought(villager, 'Hunted game');
+      queueAnimalLabel('Hunted', '#ffd27f', animal.x + 0.15, animal.y - 0.1);
+      animal.state = 'flee';
+      animal.target = chooseFleeTarget(animal, villager, behavior, occupancy);
+      animal.fleeTicks = Math.round(behavior.roamTicks ? behavior.roamTicks[0] : 40);
+      animal.nextVillageTick = tick + 280;
+      return;
+    }
+    if (R() < 0.16) {
+      villager.happy = clamp(villager.happy + (behavior.observeMood || 0.003), 0, 1);
+      villager.thought = moodThought(villager, 'Watching wildlife');
+      queueAnimalLabel('👀', '#d8e7ff', animal.x + 0.05, animal.y - 0.2);
+      animal.nextVillageTick = tick + Math.round(90 + R() * 120);
+    }
+  }
+
+  function stepAnimal(animal, behavior, occupancy) {
+    const tick = getTick();
+    const oldKey = (animal.y | 0) * GRID_W + (animal.x | 0);
+    let speed = behavior.speed || 0.12;
+    if (animal.state === 'flee') speed = behavior.fleeSpeed || speed * 1.3;
+    const target = animal.target;
+    if (!target) { return; }
+    const dx = target.x - animal.x;
+    const dy = target.y - animal.y;
+    const dist = Math.hypot(dx, dy);
+    if (dist < 0.001) { animal.state = 'idle'; animal.target = null; return; }
+    const step = Math.min(dist, speed);
+    const nx = animal.x + (dx / dist) * step;
+    const ny = animal.y + (dy / dist) * step;
+    const blocked = animalTileBlocked(nx, ny, occupancy, animal.id);
+    if (blocked) {
+      animal.state = 'idle';
+      animal.target = null;
+      animal.nextActionTick = tick + irnd(10, 40);
+      return;
+    }
+    const newKey = (ny | 0) * GRID_W + (nx | 0);
+    if (newKey !== oldKey) {
+      const occupant = occupancy.get(newKey);
+      if (occupant && occupant !== animal.id) {
+        animal.state = 'idle';
+        animal.target = null;
+        animal.nextActionTick = tick + irnd(8, 24);
+        return;
+      }
+      occupancy.delete(oldKey);
+      occupancy.set(newKey, animal.id);
+    }
+    animal.x = nx;
+    animal.y = ny;
+    if (dx < 0) animal.dir = 'left';
+    else if (dx > 0) animal.dir = 'right';
+    if (dist <= step + 0.01) {
+      animal.state = 'idle';
+      animal.target = null;
+      animal.nextActionTick = tick + irnd(behavior.idleTicks[0], behavior.idleTicks[1]);
+    }
+  }
+
+  function animalTick(animal, occupancy) {
+    const tick = getTick();
+    ensureAnimalDefaults(animal);
+    const behavior = behaviorForAnimal(animal);
+    animal.bobOffset = Math.sin((tick + animal.idlePhase) * 0.16) * (behavior.idleBob || 1);
+    const blocked = animalTileBlocked(animal.x, animal.y, occupancy, animal.id);
+    if (blocked) {
+      const target = pickRoamTarget(animal, behavior, occupancy);
+      if (target) {
+        animal.x = target.x;
+        animal.y = target.y;
+        const k = (animal.y | 0) * GRID_W + (animal.x | 0);
+        occupancy.set(k, animal.id);
+      }
+    }
+
+    if (animal.state === 'idle' && attemptGraze(animal, behavior)) {
+      animal.nextActionTick = Math.max(animal.nextActionTick || tick, tick + behavior.idleTicks[0]);
+    }
+    interactWithVillage(animal, behavior, occupancy);
+
+    if (animal.state === 'idle' && tick >= animal.nextActionTick) {
+      const target = pickRoamTarget(animal, behavior, occupancy);
+      if (target) {
+        animal.state = 'roam';
+        animal.target = target;
+        animal.nextActionTick = tick + irnd(behavior.roamTicks[0], behavior.roamTicks[1]);
+      } else {
+        animal.nextActionTick = tick + irnd(behavior.idleTicks[0], behavior.idleTicks[1]);
+      }
+    }
+    if (animal.state === 'flee') {
+      animal.fleeTicks = Math.max(0, (animal.fleeTicks | 0) - 1);
+      if (!animal.target) {
+        animal.target = pickRoamTarget(animal, behavior, occupancy);
+      }
+      if (animal.fleeTicks <= 0 && animal.target) {
+        animal.state = 'roam';
+      }
+    }
+    if (animal.state === 'roam' || animal.state === 'flee') {
+      if (!animal.target) { animal.state = 'idle'; return; }
+      stepAnimal(animal, behavior, occupancy);
+    } else if (animal.state === 'idle' && R() < 0.015) {
+      animal.dir = animal.dir === 'left' ? 'right' : 'left';
+    }
+  }
+
+  function updateAnimals() {
+    if (animals.length === 0) return;
+    const occupancy = new Map();
+    for (const a of animals) {
+      const key = (a.y | 0) * GRID_W + (a.x | 0);
+      if (!occupancy.has(key)) occupancy.set(key, a.id);
+    }
+    for (const a of animals) {
+      animalTick(a, occupancy);
+    }
+  }
+
+  return {
+    spawnAnimalsForWorld,
+    behaviorForAnimal,
+    ensureAnimalDefaults,
+    animalTileBlocked,
+    queueAnimalLabel,
+    nearestVillagerWithin,
+    pickRoamTarget,
+    attemptGraze,
+    chooseFleeTarget,
+    findAnimalById,
+    removeAnimal,
+    resolveHuntYield,
+    findHuntApproachPath,
+    interactWithVillage,
+    stepAnimal,
+    animalTick,
+    updateAnimals,
+  };
+}

--- a/src/app/debugkit.js
+++ b/src/app/debugkit.js
@@ -1,0 +1,258 @@
+import { LIGHTING } from './lighting.js';
+import { clamp } from './rng.js';
+
+export function createDebugKitBridge(opts) {
+  const {
+    state,
+    ensureVillagerNumber,
+    applyShadingMode,
+    markStaticDirty,
+  } = opts;
+
+  let debugKitInstance = null;
+  let debugKitWatcherInstalled = false;
+
+  function getWorld() { return state.world; }
+  function getDayTime() { return state.time.dayTime; }
+  function getVillagers() { return state.units.villagers; }
+
+  function debugKitGetPipeline() {
+    const world = getWorld();
+    const pipe = world?.__debug?.pipeline;
+    if (!Array.isArray(pipe) || pipe.length === 0) {
+      return [];
+    }
+    return pipe.map((entry) => {
+      if (!entry) return entry;
+      return {
+        name: entry.name || '',
+        ok: entry.ok === true,
+        extra: entry.extra === undefined ? null : entry.extra,
+      };
+    });
+  }
+
+  function describeCanvasContext(ctx) {
+    if (!ctx || !ctx.canvas) {
+      return null;
+    }
+    const canvas = ctx.canvas;
+    let type = 'unknown';
+    if (typeof ctx.getContextAttributes === 'function') {
+      type = 'webgl';
+    } else if (typeof ctx.getImageData === 'function') {
+      type = '2d';
+    }
+    return {
+      type,
+      size: {
+        width: Number.isFinite(canvas.width) ? canvas.width : null,
+        height: Number.isFinite(canvas.height) ? canvas.height : null,
+      },
+    };
+  }
+
+  function debugKitGetLightingProbe() {
+    const world = getWorld();
+    const mode = LIGHTING?.mode ?? 'unknown';
+    const useMultiply = LIGHTING?.useMultiplyComposite === true;
+    const scale = Number.isFinite(LIGHTING?.lightmapScale) ? LIGHTING.lightmapScale : null;
+    const hillshadeQ = world?.hillshadeQ || null;
+    const lightmapQ = world?.lightmapQ || null;
+    const statsFn = (debugKitInstance && typeof debugKitInstance.arrMinMax === 'function')
+      ? debugKitInstance.arrMinMax
+      : null;
+    const hillshadeStats = statsFn && hillshadeQ ? statsFn(hillshadeQ) : null;
+    const lightmapStats = statsFn && lightmapQ ? statsFn(lightmapQ) : null;
+    const reasons = [];
+    let canMultiply = useMultiply;
+
+    if (!world) {
+      reasons.push('World not initialized');
+      canMultiply = false;
+    } else {
+      if (mode === 'off') {
+        reasons.push('Lighting mode set to off');
+        canMultiply = false;
+      }
+      if (!world.lightmapCtx) {
+        reasons.push('lightmapCtx missing');
+        canMultiply = false;
+      }
+      if (!lightmapQ) {
+        reasons.push('lightmapQ not built');
+        canMultiply = false;
+      }
+    }
+
+    return {
+      mode,
+      useMultiplyComposite: useMultiply,
+      lightmapScale: scale,
+      contexts: {
+        lightmap: describeCanvasContext(world?.lightmapCtx || null),
+        albedo: describeCanvasContext(world?.staticAlbedoCtx || null),
+      },
+      hillshadeQ,
+      lightmapQ,
+      HqMin: hillshadeStats ? hillshadeStats.min : null,
+      HqMax: hillshadeStats ? hillshadeStats.max : null,
+      LqMin: lightmapStats ? lightmapStats.min : null,
+      LqMax: lightmapStats ? lightmapStats.max : null,
+      canMultiply,
+      reasons,
+    };
+  }
+
+  function debugKitEnterSafeMode() {
+    const world = getWorld();
+    try {
+      if (typeof applyShadingMode === 'function') {
+        applyShadingMode('off');
+      } else if (LIGHTING) {
+        LIGHTING.mode = 'off';
+        LIGHTING.useMultiplyComposite = false;
+      }
+      if (world) {
+        world.lightmapQ = null;
+        if (world.lightmapCtx && world.lightmapCanvas) {
+          try {
+            world.lightmapCtx.clearRect(0, 0, world.lightmapCanvas.width, world.lightmapCanvas.height);
+          } catch (_err) {
+            /* ignore */
+          }
+        }
+        if (typeof markStaticDirty === 'function') {
+          markStaticDirty();
+        }
+      }
+    } catch (err) {
+      console.warn('DebugKit safe mode failed', err);
+    }
+  }
+
+  function debugKitGetState() {
+    const world = getWorld();
+    const villagers = getVillagers();
+    const villagerCount = Array.isArray(villagers) ? villagers.length : 0;
+    let snapshotTime = null;
+    if (world?.clock && Number.isFinite(world.clock.timeOfDay)) {
+      snapshotTime = world.clock.timeOfDay;
+    } else if (Number.isFinite(getDayTime())) {
+      snapshotTime = getDayTime();
+    }
+    const villagerDetails = Array.isArray(villagers)
+      ? villagers.map((v) => ({
+          id: v.id,
+          number: ensureVillagerNumber(v),
+          role: v.role,
+          lifeStage: v.lifeStage,
+          state: v.state,
+          thought: v.thought,
+          condition: v.condition,
+          hunger: clamp(Number.isFinite(v.hunger) ? v.hunger : 0, 0, 1),
+          energy: clamp(Number.isFinite(v.energy) ? v.energy : 0, 0, 1),
+          hydration: clamp(Number.isFinite(v.hydration) ? v.hydration : 0, 0, 1),
+          happy: clamp(Number.isFinite(v.happy) ? v.happy : 0, 0, 1),
+          position: { x: v.x, y: v.y },
+          targetJob: v.targetJob
+            ? { type: v.targetJob.type, x: v.targetJob.x, y: v.targetJob.y, bid: v.targetJob.bid ?? null }
+            : null,
+          carrying: v.inv ? { type: v.inv.type, qty: v.inv.qty ?? 1 } : null,
+          activeBuildingId: v.activeBuildingId ?? null,
+        }))
+      : [];
+    return {
+      frame: world?.__debug?.lastFrame ?? 0,
+      timeOfDay: snapshotTime,
+      villagers: villagerCount,
+      lightingMode: LIGHTING?.mode ?? 'unknown',
+      multiplyComposite: LIGHTING?.useMultiplyComposite === true,
+      villagerDetails,
+    };
+  }
+
+  function configureDebugKitBridge(instance) {
+    if (!instance || typeof instance.configure !== 'function') {
+      return;
+    }
+    debugKitInstance = instance;
+    try {
+      instance.configure({
+        getPipeline: debugKitGetPipeline,
+        getLightingProbe: debugKitGetLightingProbe,
+        onSafeMode: debugKitEnterSafeMode,
+        getState: debugKitGetState,
+      });
+    } catch (err) {
+      console.warn('DebugKit configure failed', err);
+    }
+  }
+
+  function installDebugKitWatcher() {
+    if (debugKitWatcherInstalled || typeof window === 'undefined') {
+      return;
+    }
+    debugKitWatcherInstalled = true;
+    let currentKit = window.DebugKit;
+    const descriptor = Object.getOwnPropertyDescriptor(window, 'DebugKit');
+    const canRedefine = !descriptor || descriptor.configurable === true;
+    if (canRedefine) {
+      Object.defineProperty(window, 'DebugKit', {
+        configurable: true,
+        enumerable: true,
+        get() {
+          return currentKit;
+        },
+        set(value) {
+          currentKit = value;
+          if (value && typeof value.configure === 'function') {
+            configureDebugKitBridge(value);
+          }
+        },
+      });
+    }
+    if (currentKit && typeof currentKit.configure === 'function') {
+      configureDebugKitBridge(currentKit);
+    }
+  }
+
+  function ensureDebugKitConfigured() {
+    if (debugKitInstance) {
+      configureDebugKitBridge(debugKitInstance);
+    } else if (typeof window !== 'undefined' && window.DebugKit != null) {
+      configureDebugKitBridge(window.DebugKit);
+    }
+  }
+
+  function attachToWindow() {
+    if (typeof window === 'undefined') return;
+    installDebugKitWatcher();
+    if (window.DebugKit != null) {
+      configureDebugKitBridge(window.DebugKit);
+    }
+    const prevReady = typeof window.__AIV_DEBUGKIT_READY__ === 'function'
+      ? window.__AIV_DEBUGKIT_READY__
+      : null;
+    window.__AIV_DEBUGKIT_READY__ = function (kit) {
+      try {
+        configureDebugKitBridge(kit);
+      } finally {
+        if (prevReady && prevReady !== window.__AIV_DEBUGKIT_READY__) {
+          try { prevReady(kit); } catch (err) { console.warn('DebugKit ready hook failed', err); }
+        }
+      }
+    };
+  }
+
+  return {
+    debugKitGetPipeline,
+    debugKitGetLightingProbe,
+    debugKitEnterSafeMode,
+    debugKitGetState,
+    configureDebugKitBridge,
+    installDebugKitWatcher,
+    ensureDebugKitConfigured,
+    attachToWindow,
+  };
+}

--- a/src/app/jobs.js
+++ b/src/app/jobs.js
@@ -1,0 +1,134 @@
+import { GRID_W } from './constants.js';
+import { uid } from './rng.js';
+
+export function createJobsSystem(opts) {
+  const {
+    state,
+    policy,
+  } = opts;
+
+  const jobs = state.units.jobs;
+  const villagers = state.units.villagers;
+
+  const jobSuppression = new Map();
+  const activeZoneJobs = { sow: new Set(), chop: new Set(), mine: new Set() };
+
+  function clearActiveZoneJobs() {
+    activeZoneJobs.sow.clear();
+    activeZoneJobs.chop.clear();
+    activeZoneJobs.mine.clear();
+  }
+
+  function noteJobAssignmentChanged(j) {
+    if (!j) return;
+    const set = activeZoneJobs[j.type];
+    if (!set) return;
+    const key = j.y * GRID_W + j.x;
+    if ((j.assigned || 0) > 0) set.add(key);
+    else set.delete(key);
+  }
+
+  function noteJobRemoved(j) {
+    if (!j) return;
+    const set = activeZoneJobs[j.type];
+    if (!set) return;
+    set.delete(j.y * GRID_W + j.x);
+  }
+
+  function getJobCreationConfig() {
+    return policy?.style?.jobCreation || {};
+  }
+
+  function jobKey(job) {
+    if (!job || !job.type) return null;
+    const base = `${job.type}:${Number.isFinite(job.x) ? job.x : '?'},${Number.isFinite(job.y) ? job.y : '?'}`;
+    if (job.bid !== undefined) {
+      return `${base}:b${job.bid}`;
+    }
+    return base;
+  }
+
+  function isJobSuppressed(job) {
+    const key = jobKey(job);
+    if (!key) return false;
+    const until = jobSuppression.get(key);
+    if (until === undefined) return false;
+    if (until <= state.time.tick) {
+      jobSuppression.delete(key);
+      return false;
+    }
+    return true;
+  }
+
+  function suppressJob(job, duration = 0) {
+    const key = jobKey(job);
+    if (!key || duration <= 0) return;
+    jobSuppression.set(key, state.time.tick + duration);
+  }
+
+  function hasSimilarJob(job) {
+    return jobs.some(j => j && j.type === job.type && j.x === job.x && j.y === job.y && (j.bid || null) === (job.bid || null));
+  }
+
+  function violatesSpacing(x, y, type, cfg) {
+    const spacing = cfg?.minSpacing?.[type];
+    if (!Number.isFinite(spacing) || spacing <= 0) return false;
+    for (const j of jobs) {
+      if (!j || j.type !== type) continue;
+      const dist = Math.abs((j.x || 0) - x) + Math.abs((j.y || 0) - y);
+      if (dist <= spacing) return true;
+    }
+    return false;
+  }
+
+  function addJob(job) {
+    if (!job || !job.type) return null;
+    if (hasSimilarJob(job) || isJobSuppressed(job)) return null;
+    job.id = uid();
+    job.assigned = 0;
+    jobs.push(job);
+    return job;
+  }
+
+  function finishJob(v, remove = false) {
+    const job = v.targetJob;
+    if (job) {
+      job.assigned = Math.max(0, (job.assigned || 0) - 1);
+      noteJobAssignmentChanged(job);
+      if (remove) {
+        const ji = jobs.indexOf(job);
+        if (ji !== -1) {
+          noteJobRemoved(job);
+          jobs.splice(ji, 1);
+        }
+      }
+    }
+    v.targetJob = null;
+  }
+
+  function detachVillagersFromJob(job) {
+    for (const villager of villagers) {
+      if (villager.targetJob === job) {
+        villager.targetJob = null;
+        if (villager.path) villager.path.length = 0;
+        villager.state = 'idle';
+      }
+    }
+  }
+
+  return {
+    activeZoneJobs,
+    clearActiveZoneJobs,
+    noteJobAssignmentChanged,
+    noteJobRemoved,
+    getJobCreationConfig,
+    jobKey,
+    isJobSuppressed,
+    suppressJob,
+    hasSimilarJob,
+    violatesSpacing,
+    addJob,
+    finishJob,
+    detachVillagersFromJob,
+  };
+}

--- a/src/app/materials.js
+++ b/src/app/materials.js
@@ -1,0 +1,150 @@
+import { ITEM } from './constants.js';
+import {
+  buildingCenter,
+  buildingResourceNeed,
+  ensureBuildingData,
+} from './world.js';
+
+export function createMaterials(opts) {
+  const {
+    state,
+    policy,
+    addJob,
+    noteJobRemoved,
+    findNearestBuilding,
+    detachVillagersFromJob,
+  } = opts;
+
+  const buildings = state.units.buildings;
+  const jobs = state.units.jobs;
+  const storageTotals = state.stocks.totals;
+  const storageReserved = state.stocks.reserved;
+
+  function availableToReserve(resource) {
+    return (storageTotals[resource] || 0) - (storageReserved[resource] || 0);
+  }
+
+  function canReserveMaterials(cost = {}) {
+    for (const [key, qty] of Object.entries(cost)) {
+      if (qty > 0 && availableToReserve(key) < qty) return false;
+    }
+    return true;
+  }
+
+  function reserveMaterials(cost = {}) {
+    if (!canReserveMaterials(cost)) return false;
+    for (const [key, qty] of Object.entries(cost)) {
+      if (qty > 0) {
+        storageReserved[key] = (storageReserved[key] || 0) + qty;
+      }
+    }
+    return true;
+  }
+
+  function releaseReservedMaterials(cost = {}) {
+    for (const [key, qty] of Object.entries(cost)) {
+      if (qty > 0) {
+        storageReserved[key] = Math.max(0, (storageReserved[key] || 0) - qty);
+      }
+    }
+  }
+
+  function spendCraftMaterials(cost = {}) {
+    for (const [key, qty] of Object.entries(cost)) {
+      if (qty > 0 && (storageTotals[key] || 0) < qty) {
+        releaseReservedMaterials(cost);
+        return false;
+      }
+    }
+    for (const [key, qty] of Object.entries(cost)) {
+      if (qty > 0) {
+        storageTotals[key] = Math.max(0, (storageTotals[key] || 0) - qty);
+        releaseReservedMaterials({ [key]: qty });
+      }
+    }
+    return true;
+  }
+
+  function countBuildingsByKind(kind) {
+    let built = 0, planned = 0;
+    for (const b of buildings) {
+      if (!b || b.kind !== kind) continue;
+      if (b.built >= 1) built++;
+      else planned++;
+    }
+    return { built, planned, total: built + planned };
+  }
+
+  function scheduleHaul(b, resource, amount) {
+    if (!b || amount <= 0) return;
+    ensureBuildingData(b);
+    const available = availableToReserve(resource);
+    if (available <= 0) return;
+    const qty = Math.min(Math.ceil(amount), available);
+    if (qty <= 0) return;
+    const center = buildingCenter(b);
+    const storageBuilding = findNearestBuilding(center.x, center.y, 'storage');
+    if (!storageBuilding) return;
+    const job = addJob({
+      type: 'haul',
+      bid: b.id,
+      resource,
+      qty,
+      prio: 0.6 + (policy.sliders.build || 0) * 0.5,
+      x: storageBuilding.x,
+      y: storageBuilding.y,
+    });
+    if (!job) return;
+    job.src = { x: storageBuilding.x, y: storageBuilding.y };
+    job.dest = { x: b.x, y: b.y };
+    job.stage = 'pickup';
+    storageReserved[resource] = (storageReserved[resource] || 0) + qty;
+    b.pending[resource] = (b.pending[resource] || 0) + qty;
+  }
+
+  function requestBuildHauls(b) {
+    if (!b || b.built >= 1) return;
+    ensureBuildingData(b);
+    const store = b.store || {};
+    const pending = b.pending || {};
+    const woodNeed = buildingResourceNeed(b, 'wood');
+    const stoneNeed = buildingResourceNeed(b, 'stone');
+    const woodShort = Math.max(0, woodNeed - ((store.wood || 0) + (pending.wood || 0)));
+    const stoneShort = Math.max(0, stoneNeed - ((store.stone || 0) + (pending.stone || 0)));
+    if (woodShort > 0) scheduleHaul(b, ITEM.WOOD, woodShort);
+    if (stoneShort > 0) scheduleHaul(b, ITEM.STONE, stoneShort);
+  }
+
+  function cancelHaulJobsForBuilding(b) {
+    if (!b || !b.id) return;
+    ensureBuildingData(b);
+    for (let i = jobs.length - 1; i >= 0; i--) {
+      const job = jobs[i];
+      if (job.type === 'haul' && job.bid === b.id) {
+        if (job.stage === 'deliver') {
+          job.cancelled = true;
+          continue;
+        }
+        const res = job.resource;
+        const qty = job.qty || 0;
+        storageReserved[res] = Math.max(0, (storageReserved[res] || 0) - qty);
+        b.pending[res] = Math.max(0, (b.pending[res] || 0) - qty);
+        detachVillagersFromJob(job);
+        noteJobRemoved(job);
+        jobs.splice(i, 1);
+      }
+    }
+  }
+
+  return {
+    availableToReserve,
+    canReserveMaterials,
+    reserveMaterials,
+    releaseReservedMaterials,
+    spendCraftMaterials,
+    countBuildingsByKind,
+    scheduleHaul,
+    requestBuildHauls,
+    cancelHaulJobsForBuilding,
+  };
+}

--- a/src/app/nocturnal.js
+++ b/src/app/nocturnal.js
@@ -1,0 +1,125 @@
+import { GRID_H, GRID_W, TILE, tileToPxX, tileToPxY } from './constants.js';
+import { LIGHTING, clamp01 } from './lighting.js';
+import { cam, ctx } from './canvas.js';
+import { clamp, irnd, rnd } from './rng.js';
+import { DAWN_AMBIENT_THRESHOLD, isNightAmbient } from './simulation.js';
+
+export function createNocturnalSystem(_opts) {
+  const nocturnalEntities = new Array(28).fill(null).map(() => ({
+    active: false,
+    x: 0,
+    y: 0,
+    vx: 0,
+    vy: 0,
+    radius: 0.45,
+    alpha: 0,
+    energy: 1,
+    fade: 0,
+    wanderTicks: 0,
+  }));
+  let nocturnalSpawnCooldown = 0;
+
+  function nocturnalAmbientStrength(ambient) {
+    const usableRange = Math.max(0.0001, 1 - LIGHTING.nightFloor);
+    return clamp01((1 - ambient) / usableRange);
+  }
+
+  function spawnNocturnalEntity(nightStrength) {
+    const slot = nocturnalEntities.find((entity) => !entity.active);
+    if (!slot) return false;
+
+    const margin = 1.25;
+    slot.active = true;
+    slot.x = rnd(margin, GRID_W - margin);
+    slot.y = rnd(margin, GRID_H - margin);
+    const angle = rnd(0, Math.PI * 2);
+    const speed = rnd(0.004, 0.018);
+    slot.vx = Math.cos(angle) * speed;
+    slot.vy = Math.sin(angle) * speed;
+    slot.radius = rnd(0.35, 0.65);
+    slot.energy = 0.5 + nightStrength * 0.45 + rnd(0, 0.15);
+    slot.fade = 0;
+    slot.wanderTicks = irnd(28, 90);
+    return true;
+  }
+
+  function updateNocturnalEntities(ambient) {
+    const nightActive = isNightAmbient(ambient);
+    const nightStrength = nocturnalAmbientStrength(ambient);
+    const dawnFade = clamp01((DAWN_AMBIENT_THRESHOLD - ambient) / DAWN_AMBIENT_THRESHOLD);
+    let activeCount = 0;
+
+    for (const entity of nocturnalEntities) {
+      if (!entity.active) continue;
+
+      entity.wanderTicks--;
+      if (entity.wanderTicks <= 0) {
+        const angle = rnd(0, Math.PI * 2);
+        const speed = rnd(0.0035, 0.015);
+        entity.vx = Math.cos(angle) * speed;
+        entity.vy = Math.sin(angle) * speed;
+        entity.wanderTicks = irnd(30, 120);
+      }
+
+      entity.x = clamp(entity.x + entity.vx, 1.25, GRID_W - 1.25);
+      entity.y = clamp(entity.y + entity.vy, 1.25, GRID_H - 1.25);
+      if (entity.x <= 1.3 || entity.x >= GRID_W - 1.3) entity.vx *= -0.6;
+      if (entity.y <= 1.3 || entity.y >= GRID_H - 1.3) entity.vy *= -0.6;
+
+      const targetFade = nightActive ? 1 : dawnFade * 0.65;
+      const fadeDelta = targetFade - entity.fade;
+      entity.fade = clamp(entity.fade + fadeDelta * 0.08 - (nightActive ? 0 : 0.01), 0, 1);
+      entity.alpha = clamp(entity.energy * entity.fade * (0.45 + nightStrength * 0.6), 0, 1);
+
+      if (entity.alpha <= 0.02) {
+        entity.active = false;
+        continue;
+      }
+      activeCount++;
+    }
+
+    if (nightActive) {
+      if (nocturnalSpawnCooldown > 0) nocturnalSpawnCooldown--;
+      const targetPopulation = Math.max(4, Math.floor(nightStrength * nocturnalEntities.length * 0.8));
+      while (activeCount < targetPopulation && nocturnalSpawnCooldown <= 0) {
+        if (!spawnNocturnalEntity(nightStrength)) break;
+        nocturnalSpawnCooldown = irnd(12, 26);
+        activeCount++;
+      }
+    } else {
+      nocturnalSpawnCooldown = Math.max(nocturnalSpawnCooldown, 6);
+    }
+  }
+
+  function drawNocturnalEntities(ambient) {
+    const nightStrength = nocturnalAmbientStrength(ambient);
+    if (nightStrength <= 0 && !nocturnalEntities.some((e) => e.active)) return;
+
+    ctx.save();
+    ctx.globalCompositeOperation = 'lighter';
+    for (const entity of nocturnalEntities) {
+      if (!entity.active || entity.alpha <= 0) continue;
+      const gx = tileToPxX(entity.x, cam);
+      const gy = tileToPxY(entity.y, cam);
+      const radiusPx = entity.radius * TILE * cam.z * (1.2 + nightStrength * 0.8);
+      const grd = ctx.createRadialGradient(gx, gy, 0, gx, gy, radiusPx);
+      const alpha = entity.alpha;
+      grd.addColorStop(0, `rgba(170,210,255,${0.6 * alpha})`);
+      grd.addColorStop(0.45, `rgba(140,190,255,${0.35 * alpha})`);
+      grd.addColorStop(1, 'rgba(120,170,240,0)');
+      ctx.fillStyle = grd;
+      ctx.beginPath();
+      ctx.arc(gx, gy, radiusPx, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.restore();
+  }
+
+  return {
+    nocturnalEntities,
+    nocturnalAmbientStrength,
+    spawnNocturnalEntity,
+    updateNocturnalEntities,
+    drawNocturnalEntities,
+  };
+}

--- a/src/app/onArrive.js
+++ b/src/app/onArrive.js
@@ -1,0 +1,521 @@
+import {
+  ANIMAL_BEHAVIORS,
+  CRAFTING_RECIPES,
+  GRID_W,
+  HUNT_RANGE,
+  HUNT_RETRY_COOLDOWN,
+  ITEM,
+  SPEEDS,
+  TILE,
+  TILES,
+  ZONES,
+} from './constants.js';
+import { BUILDINGS, buildingCenter, ensureBuildingData } from './world.js';
+import { R, clamp } from './rng.js';
+import {
+  addJobExperience,
+  applySkillGain,
+  effectiveSkillFromExperience,
+  moodThought,
+} from './simulation.js';
+import {
+  FOOD_HUNGER_RECOVERY,
+  HYDRATION_BUFF_TICKS,
+  REST_BASE_TICKS,
+  REST_EXTRA_PER_ENERGY,
+  SOCIAL_BASE_TICKS,
+  STORAGE_IDLE_BASE,
+} from './villagerAI.js';
+
+export function createOnArrive(opts) {
+  const {
+    state,
+    pathfind,
+    idx,
+    finishJob,
+    suppressJob,
+    releaseReservedMaterials,
+    spendCraftMaterials,
+    requestBuildHauls,
+    cancelHaulJobsForBuilding,
+    findAnimalById,
+    removeAnimal,
+    resolveHuntYield,
+    chooseFleeTarget,
+    queueAnimalLabel,
+    findHuntApproachPath,
+    consumeFood,
+    handleVillagerFed,
+    findNearestBuilding,
+    agricultureBonusesAt,
+    findEntryTileNear,
+    getBuildingById,
+    setActiveBuilding,
+    noteBuildingActivity,
+    buildingAt,
+    dropItem,
+    removeItemAtIndex,
+    itemTileIndex,
+    markStaticDirty,
+    markEmittersDirty,
+    onZoneTileSown,
+    getSecondsPerTick,
+    getSpeedPxPerSec,
+  } = opts;
+
+  const buildings = state.units.buildings;
+  const itemsOnGround = state.units.itemsOnGround;
+  const storageTotals = state.stocks.totals;
+  const storageReserved = state.stocks.reserved;
+
+  function getWorld() { return state.world; }
+  function getTick() { return state.time.tick; }
+  function getSpeedIdx() { return state.time.speedIdx; }
+
+  function stepAlong(v) {
+    const next = v.path[0];
+    if (!next) return;
+    const condition = v.condition || 'normal';
+    const penalty = condition === 'sick' ? 0.45
+      : condition === 'starving' ? 0.7
+      : condition === 'hungry' ? 0.85
+      : condition === 'recovering' ? 0.95
+      : 1;
+    const moodSpeed = 0.75 + v.happy * 0.5;
+    const speedMultiplier = v.speed * penalty * moodSpeed * SPEEDS[getSpeedIdx()];
+    const stepPx = getSpeedPxPerSec() * speedMultiplier * getSecondsPerTick();
+    const step = stepPx / TILE;
+    const dx = next.x - v.x, dy = next.y - v.y, dist = Math.hypot(dx, dy);
+    if (dist <= step) {
+      v.x = next.x;
+      v.y = next.y;
+      v.path.shift();
+      if (v.path.length === 0) onArrive(v);
+    } else {
+      v.x += (dx / dist) * step;
+      v.y += (dy / dist) * step;
+    }
+  }
+
+  function onArrive(v) {
+    const world = getWorld();
+    const cx = v.x | 0, cy = v.y | 0, i = idx(cx, cy);
+
+    if (v.state === 'chop') {
+      let remove = world.trees[i] <= 0;
+      if (world.trees[i] > 0) {
+        world.trees[i]--;
+        dropItem(cx, cy, ITEM.WOOD, 1);
+        if (world.trees[i] === 0) {
+          world.tiles[i] = TILES.GRASS;
+          markStaticDirty();
+          remove = true;
+        }
+        v.thought = moodThought(v, 'Chopped');
+      } else {
+        v.thought = moodThought(v, 'Nothing to chop');
+      }
+      addJobExperience(v, 'chop', remove ? 2 : 1);
+      v.state = 'idle';
+      finishJob(v, remove);
+    }
+    else if (v.state === 'mine') {
+      let remove = world.rocks[i] <= 0;
+      if (world.rocks[i] > 0) {
+        world.rocks[i]--;
+        dropItem(cx, cy, ITEM.STONE, 1);
+        if (world.rocks[i] === 0) {
+          world.tiles[i] = TILES.GRASS;
+          markStaticDirty();
+          remove = true;
+        }
+        v.thought = moodThought(v, 'Mined');
+      } else {
+        v.thought = moodThought(v, 'Nothing to mine');
+      }
+      v.state = 'idle';
+      applySkillGain(v, 'constructionSkill', 0.016, 0.88, 1);
+      addJobExperience(v, 'mine', remove ? 2 : 1);
+      finishJob(v, remove);
+    }
+    else if (v.state === 'hunt') {
+      const job = v.targetJob;
+      const animal = job ? findAnimalById(job.targetAid) : null;
+      const lodge = job ? buildings.find(bb => bb.id === job.bid && bb.kind === 'hunterLodge') : null;
+      if (!job || !animal || animal.state === 'dead') {
+        v.thought = moodThought(v, 'Lost prey');
+        v.state = 'idle';
+        finishJob(v, true);
+        return;
+      }
+      const dist = Math.hypot(animal.x - v.x, animal.y - v.y);
+      if (dist > HUNT_RANGE + 0.2) {
+        const approach = findHuntApproachPath(v, animal, { range: HUNT_RANGE });
+        if (approach?.path) {
+          v.path = approach.path;
+          v.state = 'hunt';
+          v.thought = moodThought(v, 'Stalking');
+          return;
+        }
+        suppressJob(job, HUNT_RETRY_COOLDOWN);
+        v.thought = moodThought(v, 'Prey escaped');
+        v.state = 'idle';
+        finishJob(v, true);
+        return;
+      }
+      const behavior = ANIMAL_BEHAVIORS[animal.type] || {};
+      const skill = effectiveSkillFromExperience(v, 'constructionSkill', 0.5, 'hunt');
+      const moodFactor = clamp((v.happy - 0.5) * 0.5, -0.15, 0.2);
+      const lodgeBonus = Number.isFinite(lodge?.effects?.gameYieldBonus) ? lodge.effects.gameYieldBonus * 0.2 : 0;
+      const successChance = clamp(0.55 + skill * 0.25 + moodFactor + lodgeBonus, 0.25, 0.95);
+      if (R() < successChance) {
+        const yieldResult = resolveHuntYield({ animal, lodge });
+        dropItem(animal.x | 0, animal.y | 0, ITEM.FOOD, yieldResult.meat);
+        if (yieldResult.pelts > 0) {
+          dropItem(animal.x | 0, animal.y | 0, 'pelt', yieldResult.pelts);
+        }
+        queueAnimalLabel('Taken', '#ffd27f', animal.x + 0.1, animal.y - 0.1);
+        removeAnimal(animal);
+        v.happy = clamp(v.happy + 0.06, 0, 1);
+        applySkillGain(v, 'constructionSkill', 0.014, 0.9, 1);
+        addJobExperience(v, 'hunt', 2.5);
+        v.thought = moodThought(v, 'Successful hunt');
+      } else {
+        animal.state = 'flee';
+        animal.target = chooseFleeTarget(animal, v, behavior, new Map());
+        animal.fleeTicks = Math.round((behavior.roamTicks?.[0] || 40) * 0.8);
+        v.happy = clamp(v.happy - 0.015, 0, 1);
+        applySkillGain(v, 'constructionSkill', 0.008, 0.9, 1);
+        suppressJob(job, HUNT_RETRY_COOLDOWN);
+        addJobExperience(v, 'hunt', 1);
+        v.thought = moodThought(v, 'Missed the shot');
+      }
+      v.state = 'idle';
+      finishJob(v, true);
+    }
+    else if (v.state === 'forage') {
+      if (Number.isInteger(v.targetI) && world.berries[v.targetI] > 0) {
+        world.berries[v.targetI]--;
+        if ((v.starveStage || 0) >= 2 || v.condition === 'sick') {
+          v.hunger -= FOOD_HUNGER_RECOVERY;
+          if (v.hunger < 0) v.hunger = 0;
+          handleVillagerFed(v, 'berries');
+          v.thought = moodThought(v, 'Ate berries');
+        } else {
+          v.inv = { type: ITEM.FOOD, qty: 1 };
+          v.thought = moodThought(v, 'Got berries');
+        }
+      } else {
+        v.thought = moodThought(v, 'Berries gone');
+      }
+      addJobExperience(v, 'forage', 1);
+      v.state = 'idle';
+      finishJob(v, true);
+    }
+    else if (v.state === 'seek_food') {
+      if (!v.inv) {
+        const itemKey = (cy * GRID_W) + cx;
+        const itemIndex = itemTileIndex.get(itemKey);
+        const it = itemIndex !== undefined ? itemsOnGround[itemIndex] : null;
+        if (it && it.type === ITEM.FOOD) {
+          v.inv = { type: ITEM.FOOD, qty: it.qty };
+          removeItemAtIndex(itemIndex);
+        }
+      }
+      if (consumeFood(v)) {
+        v.thought = moodThought(v, 'Eating');
+      } else if (v.inv && v.inv.type === ITEM.FOOD) {
+        v.thought = moodThought(v, 'Holding food');
+      } else {
+        v.thought = moodThought(v, 'No food found');
+      }
+      v.state = 'idle';
+    }
+    else if (v.state === 'sow') {
+      if (world.tiles[i] !== TILES.WATER) {
+        world.tiles[i] = TILES.FARMLAND;
+        world.growth[i] = 1;
+        world.zone[i] = ZONES.FARM;
+        if (typeof onZoneTileSown === 'function') onZoneTileSown(cx, cy);
+        markStaticDirty();
+        v.thought = moodThought(v, 'Sowed');
+      } else {
+        v.thought = moodThought(v, 'Too wet to sow');
+      }
+      v.state = 'idle';
+      applySkillGain(v, 'farmingSkill', 0.012, 0.9, 1);
+      addJobExperience(v, 'sow', 1);
+      finishJob(v, true);
+    }
+    else if (v.state === 'harvest') {
+      if (world.growth[i] > 0) {
+        let yieldAmount = 2;
+        const { harvestBonus } = agricultureBonusesAt(cx, cy);
+        if (harvestBonus > 0) {
+          const whole = Math.floor(harvestBonus);
+          yieldAmount += whole;
+          const frac = harvestBonus - whole;
+          if (frac > 0 && R() < frac) yieldAmount += 1;
+        }
+        dropItem(cx, cy, ITEM.FOOD, yieldAmount);
+        const harvestThought = yieldAmount > 1 ? 'Bountiful harvest' : 'Harvested';
+        v.thought = moodThought(v, harvestThought);
+      } else {
+        v.thought = moodThought(v, 'Nothing to harvest');
+      }
+      world.growth[i] = 0;
+      v.state = 'idle';
+      applySkillGain(v, 'farmingSkill', 0.018, 0.9, 1);
+      addJobExperience(v, 'harvest', 2);
+      finishJob(v, true);
+    }
+    else if (v.state === 'build') {
+      let remove = false;
+      const b = buildings.find(bb => bb.id === v.targetJob?.bid);
+      if (b) {
+        ensureBuildingData(b);
+        const def = BUILDINGS[b.kind] || {};
+        const cost = def.cost || ((def.wood || 0) + (def.stone || 0));
+        if (b.built < 1) {
+          const store = b.store || {};
+          const spent = b.spent || { wood: 0, stone: 0 };
+          let used = 0;
+          if (def.wood) {
+            const needWood = Math.max(0, (def.wood || 0) - (spent.wood || 0));
+            if (needWood > 0 && (store.wood || 0) > 0) {
+              const take = Math.min(needWood, store.wood);
+              store.wood -= take;
+              spent.wood = (spent.wood || 0) + take;
+              used += take;
+            }
+          }
+          if (def.stone) {
+            const needStone = Math.max(0, (def.stone || 0) - (spent.stone || 0));
+            if (needStone > 0 && (store.stone || 0) > 0) {
+              const take = Math.min(needStone, store.stone);
+              store.stone -= take;
+              spent.stone = (spent.stone || 0) + take;
+              used += take;
+            }
+          }
+          b.progress = (spent.wood || 0) + (spent.stone || 0);
+          if (b.progress >= cost) {
+            b.built = 1;
+            spent.wood = def.wood || 0;
+            spent.stone = def.stone || 0;
+            b.progress = cost;
+            if (b.kind === 'campfire') markEmittersDirty();
+            cancelHaulJobsForBuilding(b);
+            markStaticDirty();
+            v.thought = moodThought(v, 'Built');
+            remove = true;
+          } else {
+            requestBuildHauls(b);
+            v.thought = moodThought(v, used > 0 ? 'Building' : 'Needs supplies');
+          }
+        } else {
+          v.thought = moodThought(v, 'Built');
+          cancelHaulJobsForBuilding(b);
+          remove = true;
+        }
+      } else {
+        const bid = v.targetJob?.bid;
+        if (bid) { cancelHaulJobsForBuilding({ id: bid }); }
+        v.thought = moodThought(v, 'Site missing');
+        remove = true;
+      }
+      applySkillGain(v, 'constructionSkill', remove ? 0.02 : 0.012, 0.9, 1);
+      addJobExperience(v, 'build', remove ? 3 : 1);
+      v.state = 'idle';
+      finishJob(v, remove);
+    }
+    else if (v.state === 'haul_pickup') {
+      const job = v.targetJob;
+      const res = job?.resource;
+      const qty = job?.qty || 0;
+      const b = job ? buildings.find(bb => bb.id === job.bid) : null;
+      if (!job || job.type !== 'haul' || !res || qty <= 0) {
+        if (job && job.type === 'haul' && job.stage === 'pickup') {
+          const r = job.resource;
+          storageReserved[r] = Math.max(0, (storageReserved[r] || 0) - qty);
+          if (b) { ensureBuildingData(b); b.pending[r] = Math.max(0, (b.pending[r] || 0) - qty); }
+        }
+        v.thought = moodThought(v, 'Idle');
+        v.state = 'idle';
+        finishJob(v, true);
+        return;
+      }
+      ensureBuildingData(b);
+      if (!b || b.built >= 1) {
+        storageReserved[res] = Math.max(0, (storageReserved[res] || 0) - qty);
+        if (b) { b.pending[res] = Math.max(0, (b.pending[res] || 0) - qty); }
+        v.thought = moodThought(v, 'Site stocked');
+        v.state = 'idle';
+        finishJob(v, true);
+        return;
+      }
+      const available = storageTotals[res] || 0;
+      if (available >= qty) {
+        storageTotals[res] -= qty;
+        storageReserved[res] = Math.max(0, (storageReserved[res] || 0) - qty);
+        v.inv = { type: res, qty };
+        job.stage = 'deliver';
+        v.thought = moodThought(v, 'Loaded supplies');
+        let dest = job.dest || { x: b.x, y: b.y };
+        const targetBuilding = job.dest ? buildingAt(dest.x, dest.y) : b;
+        if (targetBuilding) {
+          const entry = findEntryTileNear(targetBuilding, cx, cy) || { x: Math.round(buildingCenter(targetBuilding).x), y: Math.round(buildingCenter(targetBuilding).y) };
+          dest = entry;
+        }
+        const p = pathfind(cx, cy, dest.x, dest.y);
+        if (p) {
+          v.path = p;
+          v.state = 'haul_deliver';
+          return;
+        }
+        storageTotals[res] += qty;
+        v.inv = null;
+        b.pending[res] = Math.max(0, (b.pending[res] || 0) - qty);
+        v.thought = moodThought(v, 'Path blocked');
+        v.state = 'idle';
+        finishJob(v, true);
+      } else {
+        storageReserved[res] = Math.max(0, (storageReserved[res] || 0) - qty);
+        b.pending[res] = Math.max(0, (b.pending[res] || 0) - qty);
+        v.thought = moodThought(v, 'Needs supplies');
+        v.state = 'idle';
+        finishJob(v, true);
+      }
+    }
+    else if (v.state === 'haul_deliver') {
+      const job = v.targetJob;
+      const res = job?.resource;
+      const carrying = v.inv;
+      const b = job ? buildings.find(bb => bb.id === job.bid) : null;
+      v.thought = moodThought(v, 'Idle');
+      if (job && job.type === 'haul' && carrying && carrying.type === res) {
+        const qty = carrying.qty || 0;
+        v.inv = null;
+        if (b) { ensureBuildingData(b); }
+        if (b && b.built < 1 && !job?.cancelled) {
+          b.store[res] = (b.store[res] || 0) + qty;
+          requestBuildHauls(b);
+          v.thought = moodThought(v, 'Delivered supplies');
+        } else {
+          storageTotals[res] = (storageTotals[res] || 0) + qty;
+          v.thought = moodThought(v, 'Returned supplies');
+        }
+        if (b) { b.pending[res] = Math.max(0, (b.pending[res] || 0) - qty); }
+        applySkillGain(v, 'constructionSkill', 0.01, 0.9, 1);
+        addJobExperience(v, 'haul', 1);
+      } else if (job && job.type === 'haul' && job.stage === 'pickup') {
+        const qty = job.qty || 0;
+        if (res) {
+          storageReserved[res] = Math.max(0, (storageReserved[res] || 0) - qty);
+          if (b) { ensureBuildingData(b); b.pending[res] = Math.max(0, (b.pending[res] || 0) - qty); }
+        }
+      }
+      v.state = 'idle';
+      finishJob(v, true);
+    }
+    else if (v.state === 'craft_bow') {
+      const job = v.targetJob;
+      const recipe = job?.materials || CRAFTING_RECIPES.bow;
+      const lodge = job ? buildings.find(bb => bb.id === job.bid && bb.kind === 'hunterLodge') : null;
+      if (!job || !lodge || lodge.built < 1) {
+        releaseReservedMaterials(recipe || {});
+        v.thought = moodThought(v, 'No lodge');
+        v.state = 'idle';
+        finishJob(v, true);
+        return;
+      }
+      if (!spendCraftMaterials(recipe || {})) {
+        v.thought = moodThought(v, 'Missing supplies');
+        v.state = 'idle';
+        finishJob(v, true);
+        return;
+      }
+      const storage = findNearestBuilding(cx, cy, 'storage');
+      if (storage) {
+        storageTotals.bow = (storageTotals.bow || 0) + 1;
+        v.thought = moodThought(v, 'Crafted bow');
+      } else if (!v.inv) {
+        v.inv = { type: ITEM.BOW, qty: 1 };
+        v.thought = moodThought(v, 'Crafted bow');
+      } else {
+        dropItem(cx, cy, ITEM.BOW, 1);
+        v.thought = moodThought(v, 'Dropped bow');
+      }
+      applySkillGain(v, 'constructionSkill', 0.012, 0.9, 1);
+      addJobExperience(v, 'craft_bow', 2.5);
+      v.state = 'idle';
+      finishJob(v, true);
+    }
+    else if (v.state === 'equip_bow') {
+      const storage = v.targetBuilding || findNearestBuilding(cx, cy, 'storage');
+      if (storage && spendCraftMaterials({ bow: 1 })) {
+        v.equippedBow = true;
+        v.thought = moodThought(v, 'Equipped bow');
+      } else {
+        v.thought = moodThought(v, 'No bow available');
+      }
+      v.state = 'idle';
+      v.targetBuilding = null;
+    }
+    else if (v.state === 'to_storage') {
+      if (v.inv) {
+        if (v.inv.type === ITEM.FOOD && ((v.starveStage || 0) >= 2 || v.condition === 'sick')) {
+          consumeFood(v);
+          v.thought = moodThought(v, 'Ate supplies');
+        } else {
+          if (v.inv.type === ITEM.WOOD) storageTotals.wood += v.inv.qty;
+          if (v.inv.type === ITEM.STONE) storageTotals.stone += v.inv.qty;
+          if (v.inv.type === ITEM.FOOD) storageTotals.food += v.inv.qty;
+          if (v.inv.type === ITEM.BOW) storageTotals.bow += v.inv.qty;
+          v.inv = null;
+          v.thought = moodThought(v, 'Stored');
+        }
+      }
+      v.state = 'idle';
+    }
+    else if (v.state === 'rest') {
+      const baseRest = REST_BASE_TICKS + Math.round(Math.max(0, 1 - v.energy) * REST_EXTRA_PER_ENERGY);
+      const b = v.targetBuilding || getBuildingById(v.activeBuildingId) || buildingAt(cx, cy);
+      if (b) setActiveBuilding(v, b);
+      if (b) noteBuildingActivity(b, 'rest');
+      if (v.restTimer < baseRest) v.restTimer = baseRest;
+      v.state = 'resting';
+      v.thought = moodThought(v, 'Resting');
+    }
+    else if (v.state === 'hydrate') {
+      const b = v.targetBuilding || getBuildingById(v.activeBuildingId) || buildingAt(cx, cy);
+      if (b) setActiveBuilding(v, b);
+      if (b) noteBuildingActivity(b, 'hydrate');
+      v.hydrationTimer = Math.max(v.hydrationTimer || 0, Math.round(HYDRATION_BUFF_TICKS * 0.25));
+      v.hydration = 1;
+      v.hydrationBuffTicks = Math.max(v.hydrationBuffTicks, HYDRATION_BUFF_TICKS);
+      v.state = 'hydrating';
+      v.thought = moodThought(v, 'Drinking');
+    }
+    else if (v.state === 'socialize') {
+      const b = v.targetBuilding || getBuildingById(v.activeBuildingId) || buildingAt(cx, cy);
+      if (b) setActiveBuilding(v, b);
+      if (b) noteBuildingActivity(b, 'social');
+      v.socialTimer = Math.max(v.socialTimer || 0, SOCIAL_BASE_TICKS);
+      v.state = 'socializing';
+      v.thought = moodThought(v, 'Gathering');
+    }
+    else if (v.state === 'storage_idle') {
+      const b = v.targetBuilding || getBuildingById(v.activeBuildingId) || buildingAt(cx, cy);
+      if (b) setActiveBuilding(v, b);
+      if (b) noteBuildingActivity(b, 'use');
+      v.storageIdleTimer = Math.max(v.storageIdleTimer || 0, STORAGE_IDLE_BASE);
+      v.state = 'storage_linger';
+      v.thought = moodThought(v, 'Tidying storage');
+    }
+
+    void getTick;
+  }
+
+  return { stepAlong, onArrive };
+}

--- a/src/app/population.js
+++ b/src/app/population.js
@@ -1,0 +1,239 @@
+import { DAY_LENGTH, GRID_H, GRID_W, TILES } from './constants.js';
+import { R, clamp, rnd, uid } from './rng.js';
+import { createExperienceLedger, moodThought } from './simulation.js';
+
+export const PREGNANCY_TICKS = DAY_LENGTH * 2;
+export const CHILDHOOD_TICKS = DAY_LENGTH * 5;
+export const PREGNANCY_ATTEMPT_COOLDOWN_TICKS = Math.floor(DAY_LENGTH * 1.1);
+export const PREGNANCY_ATTEMPT_CHANCE = 0.12;
+export const POPULATION_SOFT_BUFFER = 2;
+export const POPULATION_HARD_CAP = 80;
+export const FOOD_HEADROOM_PER_VILLAGER = 1.25;
+
+export function createPopulation(opts) {
+  const {
+    state,
+    countBuildingsByKind,
+    tileOccupiedByBuilding,
+    idx,
+    ensureVillagerNumber,
+  } = opts;
+
+  const villagers = state.units.villagers;
+  const storageTotals = state.stocks.totals;
+  const pendingBirths = [];
+
+  function getWorld() { return state.world; }
+  function getTick() { return state.time.tick; }
+
+  function rollAdultRole() {
+    const r = R();
+    return r < 0.25 ? 'farmer' : r < 0.5 ? 'worker' : r < 0.75 ? 'explorer' : 'sleepy';
+  }
+
+  function assignAdultTraits(v, role = rollAdultRole()) {
+    const farmingSkill = Math.min(1, Math.max(0, rnd(0.35, 0.75) + (role === 'farmer' ? 0.1 : 0)));
+    const constructionSkill = Math.min(1, Math.max(0, rnd(0.35, 0.7) + (role === 'worker' ? 0.12 : 0)));
+    v.role = role;
+    v.speed = 2 + rnd(-0.2, 0.2);
+    v.farmingSkill = farmingSkill;
+    v.constructionSkill = constructionSkill;
+  }
+
+  function newVillager(x, y) {
+    const v = {
+      id: uid(),
+      x, y,
+      path: [],
+      hunger: rnd(0.2, 0.5),
+      energy: rnd(0.5, 0.9),
+      happy: rnd(0.4, 0.8),
+      hydration: 0.7,
+      hydrationBuffTicks: 0,
+      nextHydrateTick: 0,
+      inv: null,
+      state: 'idle',
+      thought: 'Wandering',
+      _nextPathTick: 0,
+      _wanderFailures: new Map(),
+      _forageFailures: new Map(),
+      condition: 'normal',
+      starveStage: 0,
+      nextStarveWarning: 0,
+      sickTimer: 0,
+      recoveryTimer: 0,
+      ageTicks: 0,
+      lifeStage: 'adult',
+      pregnancyTimer: 0,
+      pregnancyMateId: null,
+      childhoodTimer: 0,
+      parents: [],
+      nextPregnancyTick: 0,
+      socialTimer: 0,
+      nextSocialTick: 0,
+      storageIdleTimer: 0,
+      nextStorageIdleTick: 0,
+      hydrationTimer: 0,
+      activeBuildingId: null,
+      equippedBow: false,
+      experience: createExperienceLedger(),
+    };
+    assignAdultTraits(v);
+    ensureVillagerNumber(v);
+    return v;
+  }
+
+  function newChildVillager(x, y, parents) {
+    const v = newVillager(x, y);
+    v.role = 'child';
+    v.speed = 1.6 + rnd(-0.1, 0.1);
+    v.hunger = rnd(0.1, 0.3);
+    v.energy = rnd(0.55, 0.85);
+    v.happy = rnd(0.45, 0.85);
+    v.lifeStage = 'child';
+    v.childhoodTimer = CHILDHOOD_TICKS;
+    v.pregnancyTimer = 0;
+    v.pregnancyMateId = null;
+    v.farmingSkill = Math.max(0, v.farmingSkill - 0.2);
+    v.constructionSkill = Math.max(0, v.constructionSkill - 0.2);
+    v.parents = Array.isArray(parents) ? parents.slice(0, 2) : [];
+    return v;
+  }
+
+  function housingCapacity() {
+    const huts = countBuildingsByKind('hut');
+    return Math.max(6, huts.built * 2 + 4);
+  }
+
+  function populationLimit(availableFood) {
+    const housingGate = housingCapacity() + POPULATION_SOFT_BUFFER;
+    const foodGate = Math.max(0, Math.floor((availableFood || 0) / FOOD_HEADROOM_PER_VILLAGER));
+    const rawLimit = Math.min(housingGate, foodGate);
+    return Math.max(6, Math.min(POPULATION_HARD_CAP, rawLimit));
+  }
+
+  function canSupportBirth() {
+    const availableFood = storageTotals.food || 0;
+    const projectedPop = villagers.length + pendingBirths.length;
+    const housingRoom = housingCapacity() - projectedPop;
+    if (housingRoom <= 0) return false;
+    const underCap = projectedPop < populationLimit(availableFood);
+    const wellFed = availableFood > Math.max(4, projectedPop * 0.8);
+    return underCap && wellFed;
+  }
+
+  function findBirthMate(v) {
+    const tick = getTick();
+    let best = null;
+    let bestDist = Infinity;
+    for (const other of villagers) {
+      if (other === v) continue;
+      if (other.lifeStage !== 'adult') continue;
+      if (other.pregnancyTimer > 0) continue;
+      if ((other.nextPregnancyTick || 0) > tick) continue;
+      if ((other.starveStage || 0) >= 2) continue;
+      if (other.condition !== 'normal' && other.condition !== 'hungry') continue;
+      const dist = Math.abs((other.x | 0) - (v.x | 0)) + Math.abs((other.y | 0) - (v.y | 0));
+      if (dist < bestDist) { best = other; bestDist = dist; }
+    }
+    return best;
+  }
+
+  function tryStartPregnancy(v) {
+    const tick = getTick();
+    if (v.lifeStage !== 'adult') return;
+    if (v.pregnancyTimer > 0) return;
+    if ((v.starveStage || 0) >= 1) return;
+    if (v.condition === 'sick') return;
+    if (v.energy < 0.4 || v.happy < 0.35) return;
+    if (tick < (v.nextPregnancyTick || 0)) return;
+    if (!canSupportBirth()) {
+      v.nextPregnancyTick = Math.max(v.nextPregnancyTick || 0, tick + Math.floor(PREGNANCY_ATTEMPT_COOLDOWN_TICKS * 0.5));
+      return;
+    }
+    if (R() > PREGNANCY_ATTEMPT_CHANCE) {
+      v.nextPregnancyTick = tick + PREGNANCY_ATTEMPT_COOLDOWN_TICKS;
+      return;
+    }
+    const mate = findBirthMate(v);
+    const cooldownUntil = tick + PREGNANCY_ATTEMPT_COOLDOWN_TICKS;
+    if (!mate) {
+      v.nextPregnancyTick = cooldownUntil;
+      return;
+    }
+    v.pregnancyTimer = PREGNANCY_TICKS;
+    v.pregnancyMateId = mate.id;
+    v.thought = moodThought(v, 'Expecting');
+    v.nextPregnancyTick = cooldownUntil;
+    mate.nextPregnancyTick = Math.max(mate.nextPregnancyTick || 0, cooldownUntil);
+  }
+
+  function spawnChildNearParents(parent, mate) {
+    const world = getWorld();
+    const centerX = Math.round((parent.x + (mate ? mate.x : parent.x)) / 2);
+    const centerY = Math.round((parent.y + (mate ? mate.y : parent.y)) / 2);
+    const offsets = [
+      { dx: 0, dy: 0 }, { dx: 1, dy: 0 }, { dx: -1, dy: 0 }, { dx: 0, dy: 1 },
+      { dx: 0, dy: -1 }, { dx: 1, dy: 1 }, { dx: -1, dy: 1 }, { dx: 1, dy: -1 },
+      { dx: -1, dy: -1 },
+    ];
+    const parents = [parent.id];
+    if (mate?.id) parents.push(mate.id);
+    for (const off of offsets) {
+      const x = clamp(centerX + off.dx, 0, GRID_W - 1);
+      const y = clamp(centerY + off.dy, 0, GRID_H - 1);
+      const i = idx(x, y);
+      if (i < 0) continue;
+      if (tileOccupiedByBuilding(x, y)) continue;
+      if (world.tiles[i] === TILES.WATER) continue;
+      pendingBirths.push({ x, y, parents });
+      return true;
+    }
+    return false;
+  }
+
+  function flushPendingBirths() {
+    if (pendingBirths.length === 0) return;
+    for (const birth of pendingBirths) {
+      villagers.push(newChildVillager(birth.x, birth.y, birth.parents));
+    }
+    pendingBirths.length = 0;
+  }
+
+  function completePregnancy(v) {
+    const mate = v.pregnancyMateId ? villagers.find(o => o.id === v.pregnancyMateId) : null;
+    if (!spawnChildNearParents(v, mate)) {
+      v.pregnancyTimer = 10;
+      return;
+    }
+    v.pregnancyTimer = 0;
+    v.pregnancyMateId = null;
+    v.thought = moodThought(v, 'Newborn');
+  }
+
+  function promoteChildToAdult(v) {
+    const tick = getTick();
+    v.lifeStage = 'adult';
+    v.childhoodTimer = 0;
+    assignAdultTraits(v);
+    v.nextPregnancyTick = Math.max(v.nextPregnancyTick || 0, tick + PREGNANCY_ATTEMPT_COOLDOWN_TICKS);
+    v.thought = moodThought(v, 'Grew up');
+  }
+
+  return {
+    pendingBirths,
+    rollAdultRole,
+    assignAdultTraits,
+    newVillager,
+    newChildVillager,
+    housingCapacity,
+    populationLimit,
+    canSupportBirth,
+    findBirthMate,
+    tryStartPregnancy,
+    spawnChildNearParents,
+    flushPendingBirths,
+    completePregnancy,
+    promoteChildToAdult,
+  };
+}

--- a/src/app/villagerAI.js
+++ b/src/app/villagerAI.js
@@ -1,0 +1,700 @@
+import {
+  DAY_LENGTH,
+  GRID_H,
+  GRID_W,
+  ITEM,
+} from './constants.js';
+import { CAMPFIRE_EFFECT_RADIUS, buildingCenter, buildingSupplyStatus, distanceToFootprint } from './world.js';
+import { R, clamp, irnd } from './rng.js';
+import {
+  isDawnAmbient,
+  isNightAmbient,
+  moodThought,
+} from './simulation.js';
+import { score as scoreJob, computeFamineSeverity } from '../ai/scoring.js';
+
+// Single source of truth for villager-tuning constants. villagerTick.js,
+// onArrive.js, and this module all read from here.
+export const STARVE_THRESH = { hungry: 0.82, starving: 1.08, sick: 1.22 };
+export const STARVE_COLLAPSE_TICKS = 140;
+export const STARVE_RECOVERY_TICKS = 280;
+export const STARVE_TOAST_COOLDOWN = 420;
+export const FOOD_HUNGER_RECOVERY = 0.65;
+export const REST_BASE_TICKS = 90;
+export const REST_EXTRA_PER_ENERGY = 110;
+export const HYDRATION_VISIT_THRESHOLD = 0.46;
+export const HYDRATION_BUFF_TICKS = 320;
+export const SOCIAL_BASE_TICKS = 88;
+export const SOCIAL_COOLDOWN_TICKS = DAY_LENGTH * 0.2;
+export const STORAGE_IDLE_BASE = 70;
+export const STORAGE_IDLE_COOLDOWN = DAY_LENGTH * 0.12;
+
+export function createVillagerAI(opts) {
+  const {
+    state,
+    policy,
+    pathfind,
+    passable,
+    Toast,
+    addJob: _addJob, // unused but kept for symmetry; pickJobFor doesn't add jobs directly
+    finishJob,
+    noteJobAssignmentChanged: _noteJobAssignmentChanged,
+    availableToReserve,
+    requestBuildHauls,
+    findAnimalById,
+    findEntryTileNear,
+    getBuildingById: _getBuildingById,
+    buildingsByKind,
+    idx,
+    ambientAt,
+    isNightTime,
+  } = opts;
+
+  void _addJob;
+  void _noteJobAssignmentChanged;
+  void _getBuildingById;
+
+  const buildings = state.units.buildings;
+  const jobs = state.units.jobs;
+  const villagers = state.units.villagers;
+  const itemsOnGround = state.units.itemsOnGround;
+  const storageTotals = state.stocks.totals;
+
+  function getWorld() { return state.world; }
+  function getTick() { return state.time.tick; }
+  function getDayTime() { return state.time.dayTime; }
+
+  function findNearestBuilding(x, y, kind) {
+    let best = null, bd = Infinity;
+    const list = buildingsByKind.get(kind);
+    if (!list) return null;
+    for (const b of list) {
+      if (b.built < 1) continue;
+      const d = distanceToFootprint(x, y, b);
+      if (d < bd) { bd = d; best = b; }
+    }
+    return best;
+  }
+
+  function nearbyWarmth(x, y) {
+    return buildings.some(b => b.kind === 'campfire' && distanceToFootprint(x, y, b) <= CAMPFIRE_EFFECT_RADIUS);
+  }
+
+  function issueStarveToast(v, text, force = false) {
+    const tick = getTick();
+    const ready = (v.nextStarveWarning || 0) <= tick;
+    if (force || ready) {
+      Toast.show(text);
+      v.nextStarveWarning = tick + STARVE_TOAST_COOLDOWN;
+    }
+  }
+
+  function enterSickState(v) {
+    if (v.condition === 'sick') return;
+    v.condition = 'sick';
+    v.sickTimer = STARVE_COLLAPSE_TICKS;
+    v.starveStage = Math.max(3, v.starveStage || 0);
+    finishJob(v);
+    if (v.path) v.path.length = 0;
+    v.state = 'sick';
+    v.thought = moodThought(v, 'Collapsed');
+    issueStarveToast(v, 'A villager collapsed from hunger! They need food now.', true);
+  }
+
+  function handleVillagerFed(v, source = 'food') {
+    const tick = getTick();
+    const wasCritical = (v.condition === 'sick') || ((v.starveStage || 0) >= 2);
+    v.sickTimer = 0;
+    v.starveStage = 0;
+    if (wasCritical) {
+      v.condition = 'recovering';
+      v.recoveryTimer = STARVE_RECOVERY_TICKS;
+    } else {
+      v.condition = 'normal';
+      v.recoveryTimer = Math.max(v.recoveryTimer, Math.floor(STARVE_RECOVERY_TICKS / 3));
+    }
+    v.nextStarveWarning = tick + Math.floor(STARVE_TOAST_COOLDOWN * 0.6);
+    if (v.state === 'sick') v.state = 'idle';
+    v.thought = moodThought(v, wasCritical ? 'Recovering' : 'Content');
+    v.happy = clamp(v.happy + 0.05, 0, 1);
+    if (wasCritical) {
+      const detail = source === 'camp' ? 'camp stores'
+        : source === 'pack' ? 'their pack'
+        : source === 'berries' ? 'wild berries'
+        : source;
+      issueStarveToast(v, `Villager recovered after eating ${detail}.`, true);
+    }
+  }
+
+  function consumeFood(v) {
+    let source = null;
+    if (v.inv && v.inv.type === ITEM.FOOD) {
+      v.hunger -= FOOD_HUNGER_RECOVERY;
+      v.inv = null;
+      source = 'pack';
+    } else if (storageTotals.food > 0) {
+      storageTotals.food--;
+      v.hunger -= FOOD_HUNGER_RECOVERY;
+      source = 'camp';
+    }
+    if (source) {
+      if (v.hunger < 0) v.hunger = 0;
+      handleVillagerFed(v, source);
+      return true;
+    }
+    return false;
+  }
+
+  function nearestFoodTarget(v, { radius = 12, pathLimit = 200 } = {}) {
+    const world = getWorld();
+    const sx = v.x | 0, sy = v.y | 0;
+    let best = null;
+    const consider = (target) => {
+      if (!target) return;
+      const { x, y, kind, targetI } = target;
+      const p = pathfind(sx, sy, x, y, pathLimit);
+      if (!p) return;
+      const score = p.length;
+      if (!best || score < best.score) {
+        best = { path: p, score, kind, x, y, targetI };
+      }
+    };
+    if (storageTotals.food > 0) {
+      const storage = findNearestBuilding(sx, sy, 'storage');
+      if (storage) {
+        const entry = findEntryTileNear(storage, sx, sy) || { x: Math.round(buildingCenter(storage).x), y: Math.round(buildingCenter(storage).y) };
+        consider({ x: entry.x, y: entry.y, kind: 'storage' });
+      }
+    }
+    for (const it of itemsOnGround) {
+      if (!it || it.type !== ITEM.FOOD) continue;
+      consider({ x: it.x, y: it.y, kind: 'ground' });
+    }
+    const clampX = (val) => clamp(val, 0, GRID_W - 1);
+    const clampY = (val) => clamp(val, 0, GRID_H - 1);
+    const x0 = clampX(sx - radius), x1 = clampX(sx + radius);
+    const y0 = clampY(sy - radius), y1 = clampY(sy + radius);
+    for (let y = y0; y <= y1; y++) {
+      for (let x = x0; x <= x1; x++) {
+        const i = idx(x, y);
+        if (i < 0) continue;
+        if (world.berries[i] > 0) {
+          consider({ x, y, kind: 'berry', targetI: i });
+        }
+      }
+    }
+    return best;
+  }
+
+  function seekEmergencyFood(v, { radius = 14, pathLimit = 200 } = {}) {
+    const tick = getTick();
+    if (tick < v._nextPathTick) return false;
+    const target = nearestFoodTarget(v, { radius, pathLimit });
+    if (!target) return false;
+    v.path = target.path;
+    const cooldown = Math.max(8, Math.min(22, target.path.length + 6));
+    v._nextPathTick = tick + cooldown;
+    if (target.kind === 'berry') {
+      v.state = 'forage';
+      v.targetI = target.targetI;
+      v.thought = moodThought(v, 'Foraging');
+    } else {
+      v.state = 'seek_food';
+      v.targetFood = target.kind;
+      v.targetFoodPos = { x: target.x, y: target.y };
+      v.thought = moodThought(v, 'Seeking food');
+    }
+    return true;
+  }
+
+  function getRallyPoint() {
+    const camp = buildings.find(b => b.kind === 'campfire' && b.built >= 1);
+    if (camp) {
+      const entry = findEntryTileNear(camp, camp.x, camp.y) || { x: Math.round(buildingCenter(camp).x), y: Math.round(buildingCenter(camp).y) };
+      return entry;
+    }
+    const storage = buildings.find(b => b.kind === 'storage' && b.built >= 1);
+    if (storage) {
+      const entry = findEntryTileNear(storage, storage.x, storage.y) || { x: Math.round(buildingCenter(storage).x), y: Math.round(buildingCenter(storage).y) };
+      return entry;
+    }
+    return null;
+  }
+
+  function countNearbyVillagers(v, radius = 3) {
+    const sx = v.x, sy = v.y;
+    let count = 0;
+    for (const other of villagers) {
+      if (other === v) continue;
+      if (Math.abs(other.x - sx) <= radius && Math.abs(other.y - sy) <= radius) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  function collectFoodHubs(v, radius = 12) {
+    const world = getWorld();
+    const hubs = [];
+    const sx = v.x | 0, sy = v.y | 0;
+    const radiusX = Math.max(1, radius);
+    const clampX = (val) => clamp(val, 0, GRID_W - 1);
+    const clampY = (val) => clamp(val, 0, GRID_H - 1);
+    if (storageTotals.food > 0) {
+      for (const b of buildings) {
+        if (b.kind !== 'storage' || b.built < 1) continue;
+        const c = buildingCenter(b);
+        hubs.push({ x: Math.round(c.x), y: Math.round(c.y), weight: 2.5 });
+      }
+    }
+    for (const b of buildings) {
+      if (b.kind === 'campfire' && b.built >= 1) {
+        const c = buildingCenter(b);
+        hubs.push({ x: Math.round(c.x), y: Math.round(c.y), weight: 1.5 });
+      }
+    }
+    for (const it of itemsOnGround) {
+      if (!it || it.type !== ITEM.FOOD) continue;
+      if (Math.abs(it.x - sx) <= radiusX && Math.abs(it.y - sy) <= radiusX) {
+        hubs.push({ x: it.x, y: it.y, weight: 3 });
+      }
+    }
+    const x0 = clampX(sx - radiusX), x1 = clampX(sx + radiusX);
+    const y0 = clampY(sy - radiusX), y1 = clampY(sy + radiusX);
+    for (let y = y0; y <= y1; y++) {
+      for (let x = x0; x <= x1; x++) {
+        const i = idx(x, y);
+        if (i < 0) continue;
+        if (world.berries[i] > 0) {
+          hubs.push({ x, y, weight: 2 });
+        }
+      }
+    }
+    return hubs;
+  }
+
+  function pickWeightedRandom(candidates) {
+    if (!candidates || candidates.length === 0) return null;
+    const total = candidates.reduce((sum, c) => sum + (c.weight || 1), 0);
+    let r = R() * total;
+    for (const c of candidates) {
+      r -= c.weight || 1;
+      if (r <= 0) return c;
+    }
+    return candidates[candidates.length - 1];
+  }
+
+  function selectReachableWanderTarget(v, candidates, pathLimit, cooldown) {
+    if (!candidates || candidates.length === 0) return null;
+    const tick = getTick();
+    for (const [key, until] of Array.from(v._wanderFailures.entries())) {
+      if (until <= tick) v._wanderFailures.delete(key);
+    }
+    const attempts = Math.min(8, candidates.length * 2);
+    for (let n = 0; n < attempts; n++) {
+      const cand = pickWeightedRandom(candidates);
+      if (!cand) break;
+      const cx = clamp(cand.x | 0, 0, GRID_W - 1);
+      const cy = clamp(cand.y | 0, 0, GRID_H - 1);
+      const key = idx(cx, cy);
+      if (key < 0) continue;
+      const failedUntil = v._wanderFailures.get(key);
+      if (failedUntil && failedUntil > tick) continue;
+      if (!passable(cx, cy)) {
+        v._wanderFailures.set(key, tick + 180);
+        continue;
+      }
+      const p = pathfind(v.x | 0, v.y | 0, cx, cy, pathLimit);
+      if (p) {
+        return { path: p, cooldown };
+      }
+      v._wanderFailures.set(key, tick + 240);
+    }
+    return null;
+  }
+
+  function handleIdleRoam(v, { stage, needsFood, urgentFood }) {
+    const tick = getTick();
+    const baseRange = stage === 1 ? 3 : 4;
+    const crowd = countNearbyVillagers(v, 3);
+    const crowdCooldown = Math.max(10, 12 + Math.max(0, crowd - 2) * 4 + irnd(0, 4));
+    const adjustedRange = crowd > 3 ? Math.max(1, baseRange - 1) : baseRange;
+    if (urgentFood && seekEmergencyFood(v, { radius: 14, pathLimit: 220 })) return true;
+    const rally = (!needsFood && !urgentFood && !v.inv) ? getRallyPoint() : null;
+    const ready = tick >= v._nextPathTick;
+    if (rally && ready) {
+      const rallyPath = pathfind(v.x | 0, v.y | 0, rally.x, rally.y, 160);
+      if (rallyPath) {
+        v.path = rallyPath;
+        v.thought = moodThought(v, 'Regrouping');
+        v._nextPathTick = tick + crowdCooldown;
+        return true;
+      }
+    }
+    const hungry = needsFood || urgentFood;
+    const hubs = hungry ? collectFoodHubs(v, 12) : [];
+    const candidates = [];
+    if (hubs.length > 0) {
+      for (const hub of hubs) {
+        candidates.push({
+          x: clamp(hub.x + irnd(-2, 2), 0, GRID_W - 1),
+          y: clamp(hub.y + irnd(-2, 2), 0, GRID_H - 1),
+          weight: hub.weight || 1,
+        });
+      }
+    }
+    const cx = v.x | 0, cy = v.y | 0;
+    for (let i = 0; i < 4; i++) {
+      candidates.push({
+        x: clamp(cx + irnd(-adjustedRange, adjustedRange), 0, GRID_W - 1),
+        y: clamp(cy + irnd(-adjustedRange, adjustedRange), 0, GRID_H - 1),
+        weight: 1,
+      });
+    }
+    const pathLimit = hungry ? 120 : 80;
+    const wander = ready ? selectReachableWanderTarget(v, candidates, pathLimit, crowdCooldown + irnd(0, 4)) : null;
+    v.thought = moodThought(v, urgentFood ? 'Starving' : (stage === 1 ? 'Hungry' : 'Wandering'));
+    if (wander) {
+      v.path = wander.path;
+      v._nextPathTick = tick + wander.cooldown;
+    } else if (tick >= v._nextPathTick) {
+      v._nextPathTick = tick + crowdCooldown;
+    }
+    return true;
+  }
+
+  function foragingJob(v) {
+    const tick = getTick();
+    const world = getWorld();
+    if (tick < v._nextPathTick) return false;
+    const style = policy?.style?.jobScoring || {};
+    const bb = state?.bb;
+    const famineSeverity = computeFamineSeverity(bb);
+    const baseRadius = 10;
+    const maxRadius = Number.isFinite(style.adaptiveForageMaxRadius) ? style.adaptiveForageMaxRadius : 18;
+    const radius = Math.max(baseRadius, Math.round(baseRadius + famineSeverity * Math.max(0, maxRadius - baseRadius)));
+    const basePathLimit = 120;
+    const maxPathLimit = Number.isFinite(style.adaptiveForageMaxPath) ? style.adaptiveForageMaxPath : 240;
+    const pathLimit = Math.max(basePathLimit, Math.round(basePathLimit + famineSeverity * Math.max(0, maxPathLimit - basePathLimit)));
+    const sx = v.x | 0, sy = v.y | 0;
+    let best = null, bd = 999;
+    for (const [key, until] of Array.from(v._forageFailures.entries())) {
+      if (until <= tick) v._forageFailures.delete(key);
+    }
+    for (let y = sy - radius; y <= sy + radius; y++) {
+      for (let x = sx - radius; x <= sx + radius; x++) {
+        const i = idx(x, y);
+        if (i < 0) continue;
+        if (world.berries[i] > 0) {
+          if (v._forageFailures.has(i)) continue;
+          const d = Math.abs(x - sx) + Math.abs(y - sy);
+          if (d < bd) { bd = d; best = { x, y, i }; }
+        }
+      }
+    }
+    if (best) {
+      const p = pathfind(v.x | 0, v.y | 0, best.x, best.y, pathLimit);
+      if (p) {
+        v.path = p;
+        v.state = 'forage';
+        v.targetI = best.i;
+        v.thought = moodThought(v, 'Foraging');
+        v._nextPathTick = tick + 12;
+        return true;
+      }
+      v._forageFailures.set(best.i, tick + 180);
+    }
+    return false;
+  }
+
+  function goRest(v) {
+    const tick = getTick();
+    if (tick < v._nextPathTick) return false;
+    const hut = findNearestBuilding(v.x | 0, v.y | 0, 'hut') || buildings.find(b => b.kind === 'campfire' && b.built >= 1);
+    if (hut) {
+      const entry = findEntryTileNear(hut, v.x | 0, v.y | 0) || { x: Math.round(buildingCenter(hut).x), y: Math.round(buildingCenter(hut).y) };
+      const p = pathfind(v.x | 0, v.y | 0, entry.x, entry.y);
+      if (p) {
+        v.path = p;
+        v.state = 'rest';
+        v.targetBuilding = hut;
+        v.thought = moodThought(v, 'Resting');
+        v._nextPathTick = tick + 12;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function tryHydrateAtWell(v) {
+    const tick = getTick();
+    if (tick < v._nextPathTick) return false;
+    if (v.nextHydrateTick > tick) return false;
+    if (v.hydration > HYDRATION_VISIT_THRESHOLD) return false;
+    const well = findNearestBuilding(v.x | 0, v.y | 0, 'well');
+    if (!well) return false;
+    const entry = findEntryTileNear(well, v.x | 0, v.y | 0) || { x: Math.round(buildingCenter(well).x), y: Math.round(buildingCenter(well).y) };
+    const p = pathfind(v.x | 0, v.y | 0, entry.x, entry.y);
+    if (p) {
+      v.path = p;
+      v.state = 'hydrate';
+      v.targetBuilding = well;
+      v.thought = moodThought(v, 'Fetching water');
+      v._nextPathTick = tick + 12;
+      v.nextHydrateTick = tick + Math.floor(DAY_LENGTH * 0.12);
+      return true;
+    }
+    v.nextHydrateTick = Math.max(v.nextHydrateTick || 0, tick + 60);
+    return false;
+  }
+
+  function tryCampfireSocial(v, { ambientNow = ambientAt(getDayTime()), forceNight = false } = {}) {
+    const tick = getTick();
+    if (tick < v._nextPathTick) return false;
+    if (v.nextSocialTick > tick) return false;
+    if ((v.starveStage || 0) >= 1) return false;
+    const nightAmbient = isNightAmbient(ambientNow);
+    if (!nightAmbient && !forceNight) return false;
+    if (!nightAmbient && forceNight && !isNightTime()) return false;
+    if (isDawnAmbient(ambientNow)) return false;
+    const camp = findNearestBuilding(v.x | 0, v.y | 0, 'campfire');
+    if (!camp) return false;
+    const entry = findEntryTileNear(camp, v.x | 0, v.y | 0) || { x: Math.round(buildingCenter(camp).x), y: Math.round(buildingCenter(camp).y) };
+    const p = pathfind(v.x | 0, v.y | 0, entry.x, entry.y);
+    if (p) {
+      v.path = p;
+      v.state = 'socialize';
+      v.targetBuilding = camp;
+      v.thought = moodThought(v, 'Gathering by fire');
+      v._nextPathTick = tick + 12;
+      v.nextSocialTick = tick + Math.floor(SOCIAL_COOLDOWN_TICKS * 0.25);
+      return true;
+    }
+    v.nextSocialTick = Math.max(v.nextSocialTick || 0, tick + 90);
+    return false;
+  }
+
+  function tryStorageIdle(v) {
+    const tick = getTick();
+    if (tick < v._nextPathTick) return false;
+    if (v.nextStorageIdleTick > tick) return false;
+    if (v.inv) return false;
+    if (v.targetJob) return false;
+    const storage = findNearestBuilding(v.x | 0, v.y | 0, 'storage');
+    if (!storage) return false;
+    const entry = findEntryTileNear(storage, v.x | 0, v.y | 0) || { x: Math.round(buildingCenter(storage).x), y: Math.round(buildingCenter(storage).y) };
+    const p = pathfind(v.x | 0, v.y | 0, entry.x, entry.y);
+    if (p) {
+      v.path = p;
+      v.state = 'storage_idle';
+      v.targetBuilding = storage;
+      v.thought = moodThought(v, 'Checking storage');
+      v._nextPathTick = tick + 12;
+      v.nextStorageIdleTick = tick + Math.floor(STORAGE_IDLE_COOLDOWN * 0.4);
+      return true;
+    }
+    v.nextStorageIdleTick = Math.max(v.nextStorageIdleTick || 0, tick + 80);
+    return false;
+  }
+
+  function tryEquipBow(v) {
+    const tick = getTick();
+    if (v.lifeStage === 'child') return false;
+    if (v.equippedBow) return false;
+    if (v.inv) return false;
+    if (v.state !== 'idle') return false;
+    if (tick < v._nextPathTick) return false;
+    if (availableToReserve('bow') <= 0) return false;
+    const storage = findNearestBuilding(v.x | 0, v.y | 0, 'storage');
+    if (!storage) return false;
+    const entry = findEntryTileNear(storage, v.x | 0, v.y | 0) || { x: Math.round(buildingCenter(storage).x), y: Math.round(buildingCenter(storage).y) };
+    const p = pathfind(v.x | 0, v.y | 0, entry.x, entry.y);
+    if (!p) return false;
+    v.path = p;
+    v.state = 'equip_bow';
+    v.targetBuilding = storage;
+    v.thought = moodThought(v, 'Fetching bow');
+    v._nextPathTick = tick + 12;
+    return true;
+  }
+
+  function scoreExistingJobForVillager(j, v, blackboard) {
+    const world = getWorld();
+    if (!j) return -Infinity;
+    let supplyStatus = null;
+    let buildTarget = null;
+    if (j.type === 'build') {
+      buildTarget = buildings.find(bb => bb.id === j.bid);
+      if (!buildTarget || buildTarget.built >= 1) return -Infinity;
+      supplyStatus = buildingSupplyStatus(buildTarget);
+      if (!supplyStatus.hasAnySupply) {
+        j.waitingForMaterials = true;
+        return -Infinity;
+      }
+    }
+    const i = idx(j.x, j.y);
+    if (j.type === 'chop' && world.trees[i] === 0) return -Infinity;
+    if (j.type === 'mine' && world.rocks[i] === 0) return -Infinity;
+    if (j.type === 'sow' && world.growth[i] > 0) return -Infinity;
+    if (j.type === 'forage' && world.berries[j.targetI ?? i] <= 0) return -Infinity;
+    let distance;
+    if (j.type === 'build') {
+      distance = buildTarget ? distanceToFootprint(v.x | 0, v.y | 0, buildTarget) : Math.abs((v.x | 0) - j.x) + Math.abs((v.y | 0) - j.y);
+    } else {
+      distance = Math.abs((v.x | 0) - j.x) + Math.abs((v.y | 0) - j.y);
+    }
+    const jobView = {
+      type: j.type,
+      prio: j.prio,
+      distance,
+      supply: supplyStatus,
+    };
+    if (j.type === 'build' && supplyStatus) {
+      j.waitingForMaterials = !supplyStatus.fullyDelivered;
+    }
+    return scoreJob(jobView, v, policy, blackboard);
+  }
+
+  function maybeInterruptJob(v, { blackboard = null, margin = 0 } = {}) {
+    const currentJob = v.targetJob;
+    if (!currentJob) return false;
+    const bb = blackboard || state.bb;
+    const famineEmergency = bb?.famine === true && currentJob.type !== 'harvest' && currentJob.type !== 'sow' && currentJob.type !== 'forage';
+    const jobStyle = policy?.style?.jobScoring || {};
+    const reprioritizeMargin = Number.isFinite(margin) ? margin : (Number.isFinite(jobStyle.reprioritizeMargin) ? jobStyle.reprioritizeMargin : 0);
+    if (!famineEmergency && reprioritizeMargin <= 0) return false;
+
+    const wasAssigned = currentJob.assigned || 0;
+    if (wasAssigned > 0) { currentJob.assigned = Math.max(0, wasAssigned - 1); }
+    const candidate = pickJobFor(v);
+    if (wasAssigned > 0) { currentJob.assigned = wasAssigned; }
+    if (!candidate || candidate === currentJob) return false;
+
+    const currentScore = scoreExistingJobForVillager(currentJob, v, bb);
+    const candidateScore = scoreExistingJobForVillager(candidate, v, bb);
+    if (candidateScore > currentScore + reprioritizeMargin || famineEmergency) {
+      finishJob(v);
+      if (v.path) v.path.length = 0;
+      v.state = 'idle';
+      return true;
+    }
+    return false;
+  }
+
+  function findPanicHarvestJob(v) {
+    const world = getWorld();
+    const bb = state.bb;
+    let best = null, bestScore = -Infinity;
+    for (const j of jobs) {
+      if (!j || j.type !== 'harvest') continue;
+      if (j.assigned >= 1) continue;
+      const i = idx(j.x, j.y);
+      if (world.growth[i] <= 0) continue;
+      const distance = Math.abs((v.x | 0) - j.x) + Math.abs((v.y | 0) - j.y);
+      const jobView = { type: j.type, prio: j.prio, distance };
+      const jobScore = scoreJob(jobView, v, policy, bb);
+      if (jobScore > bestScore) { bestScore = jobScore; best = j; }
+    }
+    return best;
+  }
+
+  function pickJobFor(v) {
+    const world = getWorld();
+    if (v.lifeStage === 'child') return null;
+    let best = null, bs = -Infinity;
+    const blackboard = state.bb;
+    const minScore = typeof policy?.style?.jobScoring?.minPickScore === 'number'
+      ? policy.style.jobScoring.minPickScore
+      : 0;
+    const jobStyle = policy?.style?.jobScoring || {};
+    for (const j of jobs) {
+      let supplyStatus = null;
+      let buildTarget = null;
+      if (j.type === 'hunt' && !v.equippedBow) continue;
+      if (j.type === 'build') {
+        buildTarget = buildings.find(bb => bb.id === j.bid);
+        if (!buildTarget || buildTarget.built >= 1) continue;
+        supplyStatus = buildingSupplyStatus(buildTarget);
+        if (!supplyStatus.hasAnySupply) {
+          j.waitingForMaterials = true;
+          requestBuildHauls(buildTarget);
+          const assistLimit = Number.isFinite(jobStyle.builderHaulAssistLimit) ? jobStyle.builderHaulAssistLimit : 1;
+          if (assistLimit > 0) {
+            const haulJobs = jobs.filter(h => h.type === 'haul' && h.bid === buildTarget.id && h.stage !== 'deliver' && !h.cancelled);
+            const activeHaulers = haulJobs.reduce((sum, h) => sum + (h.assigned || 0), 0);
+            if (activeHaulers < assistLimit) {
+              const openHaul = haulJobs.find(h => (h.assigned || 0) === 0);
+              if (openHaul) {
+                const haulDistance = Math.abs((v.x | 0) - openHaul.x) + Math.abs((v.y | 0) - openHaul.y);
+                const haulView = { type: openHaul.type, prio: openHaul.prio, distance: haulDistance };
+                const haulScore = scoreJob(haulView, v, policy, blackboard);
+                if (haulScore > bs) { bs = haulScore; best = openHaul; }
+              }
+            }
+          }
+          continue;
+        }
+        if (j.assigned >= 1 && !supplyStatus.fullyDelivered) {
+          continue;
+        }
+      } else {
+        if (j.assigned >= 1) continue;
+      }
+      const i = idx(j.x, j.y);
+      if (j.type === 'chop' && world.trees[i] === 0) continue;
+      if (j.type === 'mine' && world.rocks[i] === 0) continue;
+      if (j.type === 'sow' && world.growth[i] > 0) continue;
+      if (j.type === 'forage' && world.berries[j.targetI ?? i] <= 0) continue;
+      let distance;
+      if (j.type === 'build') {
+        distance = buildTarget ? distanceToFootprint(v.x | 0, v.y | 0, buildTarget) : Math.abs((v.x | 0) - j.x) + Math.abs((v.y | 0) - j.y);
+      } else if (j.type === 'hunt') {
+        const targetAnimal = findAnimalById(j.targetAid);
+        const targetX = targetAnimal?.x ?? j.x;
+        const targetY = targetAnimal?.y ?? j.y;
+        distance = Math.abs((v.x | 0) - Math.round(targetX)) + Math.abs((v.y | 0) - Math.round(targetY));
+      } else {
+        distance = Math.abs((v.x | 0) - j.x) + Math.abs((v.y | 0) - j.y);
+      }
+      const jobView = {
+        type: j.type,
+        prio: j.prio,
+        distance,
+        supply: supplyStatus,
+      };
+      const jobScore = scoreJob(jobView, v, policy, blackboard);
+      if (j.type === 'build' && supplyStatus) {
+        j.waitingForMaterials = !supplyStatus.fullyDelivered;
+      }
+      if (jobScore > bs) { bs = jobScore; best = j; }
+    }
+    return bs > minScore ? best : null;
+  }
+
+  return {
+    findNearestBuilding,
+    nearbyWarmth,
+    issueStarveToast,
+    enterSickState,
+    handleVillagerFed,
+    consumeFood,
+    nearestFoodTarget,
+    seekEmergencyFood,
+    getRallyPoint,
+    countNearbyVillagers,
+    collectFoodHubs,
+    pickWeightedRandom,
+    selectReachableWanderTarget,
+    handleIdleRoam,
+    foragingJob,
+    goRest,
+    tryHydrateAtWell,
+    tryCampfireSocial,
+    tryStorageIdle,
+    tryEquipBow,
+    scoreExistingJobForVillager,
+    maybeInterruptJob,
+    findPanicHarvestJob,
+    pickJobFor,
+  };
+}

--- a/src/app/villagerTick.js
+++ b/src/app/villagerTick.js
@@ -7,16 +7,25 @@ import {
   moodThought
 } from './simulation.js';
 import { DAY_LENGTH, HUNT_RANGE, HUNT_RETRY_COOLDOWN } from './constants.js';
+import { CHILDHOOD_TICKS } from './population.js';
+import {
+  HYDRATION_BUFF_TICKS,
+  REST_BASE_TICKS,
+  REST_EXTRA_PER_ENERGY,
+  SOCIAL_BASE_TICKS,
+  SOCIAL_COOLDOWN_TICKS,
+  STARVE_THRESH,
+  STORAGE_IDLE_BASE,
+  STORAGE_IDLE_COOLDOWN
+} from './villagerAI.js';
 
-const STARVE_THRESH = { hungry: 0.82, starving: 1.08, sick: 1.22 };
-
+// Tick-only knobs (decay rates / per-frame deltas) live next to the function
+// that reads them. The shared villager-tuning constants (STARVE_*, REST_*,
+// HYDRATION_*, SOCIAL_*, STORAGE_IDLE_*, CHILDHOOD_TICKS) are now imported
+// from villagerAI.js / population.js so there's a single source of truth.
 const HUNGER_RATE = 0.00095;
 const ENERGY_DRAIN_BASE = 0.0011;
 
-const CHILDHOOD_TICKS = DAY_LENGTH * 5;
-
-const REST_BASE_TICKS = 90;
-const REST_EXTRA_PER_ENERGY = 110;
 const REST_ENERGY_RECOVERY = 0.0024;
 const REST_MOOD_TICK = 0.0009;
 const REST_FINISH_MOOD = 0.05;
@@ -24,22 +33,16 @@ const REST_HUNGER_MULT = 0.42;
 
 const HYDRATION_DECAY = 0.00018;
 const HYDRATION_LOW = 0.28;
-const HYDRATION_BUFF_TICKS = 320;
 const HYDRATION_HUNGER_MULT = 0.9;
 const HYDRATION_FATIGUE_BONUS = 0.8;
 const HYDRATION_DEHYDRATED_PENALTY = 1.12;
 const HYDRATION_MOOD_TICK = 0.00035;
 
-const SOCIAL_BASE_TICKS = 88;
-const SOCIAL_COOLDOWN_TICKS = DAY_LENGTH * 0.2;
 const SOCIAL_MOOD_TICK = 0.0013;
 const SOCIAL_ENERGY_TICK = 0.00055;
 
 const NIGHT_CAMPFIRE_MOOD_TICK = 0.0012;
 const NIGHT_CAMPFIRE_XP_TICK = 0.15;
-
-const STORAGE_IDLE_BASE = 70;
-const STORAGE_IDLE_COOLDOWN = DAY_LENGTH * 0.12;
 
 export function createVillagerTick(opts) {
   const {


### PR DESCRIPTION
src/app.js drops from 3,706 → 1,912 lines (-48%) by carving out:

- src/app/jobs.js — job lifecycle (jobKey/suppress/addJob/finishJob,
  jobSuppression Map, activeZoneJobs indices)
- src/app/animals.js — full animal lifecycle (spawn/behavior/tick/draw)
- src/app/nocturnal.js — nocturnal entity state + spawn/update/draw
- src/app/debugkit.js — DebugKit bridge + window watcher
- src/app/materials.js — reservation, haul scheduling, building counts
- src/app/population.js — birth/pregnancy + villager constructors,
  owns CHILDHOOD_TICKS and the population/pregnancy constants
- src/app/villagerAI.js — pickJobFor + every villager action helper,
  owns the shared villager-tuning constants (STARVE_THRESH, REST_*,
  HYDRATION_*, SOCIAL_*, STORAGE_IDLE_*)
- src/app/onArrive.js — per-job arrival dispatcher and stepAlong

src/app/villagerTick.js now imports the villager-tuning constants from
villagerAI.js (and CHILDHOOD_TICKS from population.js) instead of
redefining them locally, closing the cross-cutting duplication tracked
in the prior AUDIT.

Each new module follows the existing createX(deps) factory pattern from
planner.js / tick.js / villagerTick.js. Cross-factory dependencies are
wired via thunks where needed (notably findNearestBuilding, which lives
on villagerAI but is consumed by materials).

AUDIT.md refreshed: the eight extractions move to Resolved with their
new file paths, the constants-duplication cross-cutting cleanup closes,
and the High-severity entry's line count + remaining-in-file inventory
are updated. The render body (~700 lines: render(), drawBuildingAt,
drawAnimal, drawVillager + overlay/cache helpers) is now the singular
remaining extraction target.

Verification: npm run lint clean, npm run build clean.

https://claude.ai/code/session_013YqzUts5dGkeYreUouc8xY