### PR TITLE
Audit phase 2: pelt as first-class resource + storage helper unification

### DIFF
--- a/AI_Village_Agent_Audit.md
+++ b/AI_Village_Agent_Audit.md
@@ -263,6 +263,12 @@ Better long-term: make pickup explicit haul work instead of spontaneous intercep
 
 ## 6. Pelts are generated but cannot be stored or persisted
 
+**Resolved (Phase 2, commit `b3ef1df`).** Added `ITEM.PELT`, `RESOURCE_TYPES`,
+`ITEM_COLORS`. Storage totals/reserved, `newWorld`, save/load, deposit, and
+rendering all flow through the resource list now. Pelts deposit, persist, and
+render with a dedicated color.
+
+
 **Files/lines**
 
 - `src/app/onArrive.js:173-176`
@@ -445,6 +451,11 @@ Deeper model:
 
 ## 12. Bow pickup is not reserved before villagers travel to storage
 
+**Resolved (Phase 2, commit `b3ef1df`).** `tryEquipBow` now calls
+`reserveMaterials({ bow: 1 })` on intent and releases on every early-return
+(no storage / no path). `v.reservedPickup` tracks the outstanding claim.
+
+
 **Files/lines**
 
 - `src/app/villagerAI.js:500-518`
@@ -470,6 +481,16 @@ Release reservation if cancelled.
 ---
 
 ## 13. `spendCraftMaterials()` is used for unreserved bow pickup, corrupting reservations
+
+**Resolved (Phase 2, commit `b3ef1df`).** Bow pickup now owns its own
+reservation (see #12), so `spendCraftMaterials` is closing a real reservation
+rather than someone else's. A new `takeFromStorage(resource, qty)` helper was
+added to `materials.js` for any future direct-take callers, alongside doc
+comments separating the four helper roles. Also fixed a related double-release:
+`spendCraftMaterials` already releases on insufficient-stock failure, so the
+arrival path only releases explicitly when storage vanished mid-trip and
+`spendCraftMaterials` was never called.
+
 
 **Files/lines**
 
@@ -1159,6 +1180,17 @@ Tasks:
 8. Add save/load smoke tests.
 
 ## Phase 2: Repair resource registry and storage helpers
+
+**Status: Done (commit `b3ef1df`).** Pelt is now a first-class resource;
+`RESOURCE_TYPES` and `ITEM_COLORS` in `constants.js` are the single source of
+truth used by `state.js`, `newWorld()`, save/load, deposit, and rendering.
+`materials.js` exposes the four helpers below. `tryEquipBow` reserves on
+intent, and `onArrive` closes the bow reservation through
+`spendCraftMaterials` (only releases explicitly when storage vanishes
+mid-trip, so it can't double-release another villager's reservation).
+This addresses critical issues **#6**, **#12**, and **#13**. Issue **#38**
+(starting-stock duplication between `state.js` and `newWorld()`) is
+explicitly deferred and tagged with a comment in `app.js`.
 
 Goal: every resource type has one consistent lifecycle.
 

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ import {
   GRID_H,
   GRID_SIZE,
   GRID_W,
+  RESOURCE_TYPES,
   TILE,
   TILES,
   ZONES,
@@ -326,14 +327,13 @@ function newWorld(seed=Date.now()|0){
   if(typeof tickRunner !== 'undefined') tickRunner.reset();
   markEmittersDirty();
   villagerNumberCounter = 1;
+  // audit #38: starting stocks duplicated with state.js — defer consolidation.
+  for (const r of RESOURCE_TYPES) {
+    storageTotals[r] = 0;
+    storageReserved[r] = 0;
+  }
   storageTotals.food = 24;
   storageTotals.wood = 12;
-  storageTotals.stone = 0;
-  storageTotals.bow = 0;
-  storageReserved.food = 0;
-  storageReserved.wood = 0;
-  storageReserved.stone = 0;
-  storageReserved.bow = 0;
   time.tick = 0;
   time.dayTime = 0;
   const terrain = generateTerrain(seed, WORLDGEN_DEFAULTS, { w: GRID_W, h: GRID_H });
@@ -852,12 +852,14 @@ const {
   reserveMaterials,
   releaseReservedMaterials,
   spendCraftMaterials,
+  takeFromStorage: _takeFromStorage,
   countBuildingsByKind,
   scheduleHaul: _scheduleHaul,
   requestBuildHauls,
   cancelHaulJobsForBuilding
 } = _materialsSystem;
 void _scheduleHaul;
+void _takeFromStorage;
 
 const _populationSystem = createPopulation({
   state: gameState,
@@ -882,6 +884,8 @@ const _villagerAI = createVillagerAI({
   Toast,
   finishJob,
   availableToReserve,
+  reserveMaterials,
+  releaseReservedMaterials,
   requestBuildHauls,
   findAnimalById,
   findEntryTileNear,

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -131,7 +131,17 @@ const ANIMAL_BEHAVIORS = {
     idleBob: 1.2
   }
 };
-const ITEM = { FOOD:'food', WOOD:'wood', STONE:'stone', BOW:'bow' };
+const ITEM = { FOOD:'food', WOOD:'wood', STONE:'stone', BOW:'bow', PELT:'pelt' };
+// Explicit list (not Object.values(ITEM)) so future non-stored ITEM entries
+// don't silently join the storage/save pipeline.
+const RESOURCE_TYPES = Object.freeze(['food', 'wood', 'stone', 'bow', 'pelt']);
+const ITEM_COLORS = Object.freeze({
+  food: '#b6d97a',
+  wood: '#b48a52',
+  stone: '#aeb7c3',
+  bow: '#d4c08a',
+  pelt: '#8a6a3f'
+});
 const CRAFTING_RECIPES = {
   bow: Object.freeze({ wood: 2, stone: 1 })
 };
@@ -169,9 +179,11 @@ export {
   HUNT_RANGE,
   HUNT_RETRY_COOLDOWN,
   ITEM,
+  ITEM_COLORS,
   LIGHT_VECTOR,
   LIGHT_VECTOR_LENGTH,
   LAYER_ORDER,
+  RESOURCE_TYPES,
   SAVE_KEY,
   SAVE_MIGRATIONS,
   SAVE_VERSION,

--- a/src/app/materials.js
+++ b/src/app/materials.js
@@ -20,6 +20,11 @@ export function createMaterials(opts) {
   const storageTotals = state.stocks.totals;
   const storageReserved = state.stocks.reserved;
 
+  // Storage helpers — four roles:
+  //   reserveMaterials(cost)         — claim future use; gates allocation, increments storageReserved.
+  //   releaseReservedMaterials(cost) — undo a reservation; decrements storageReserved.
+  //   spendCraftMaterials(cost)      — close out a held reservation; decrements both totals and reserved.
+  //   takeFromStorage(resource, qty) — direct withdrawal that never touches reservations.
   function availableToReserve(resource) {
     return (storageTotals[resource] || 0) - (storageReserved[resource] || 0);
   }
@@ -62,6 +67,13 @@ export function createMaterials(opts) {
         releaseReservedMaterials({ [key]: qty });
       }
     }
+    return true;
+  }
+
+  function takeFromStorage(resource, qty) {
+    if (qty <= 0) return true;
+    if ((storageTotals[resource] || 0) < qty) return false;
+    storageTotals[resource] = Math.max(0, (storageTotals[resource] || 0) - qty);
     return true;
   }
 
@@ -142,6 +154,7 @@ export function createMaterials(opts) {
     reserveMaterials,
     releaseReservedMaterials,
     spendCraftMaterials,
+    takeFromStorage,
     countBuildingsByKind,
     scheduleHaul,
     requestBuildHauls,

--- a/src/app/onArrive.js
+++ b/src/app/onArrive.js
@@ -5,6 +5,7 @@ import {
   HUNT_RANGE,
   HUNT_RETRY_COOLDOWN,
   ITEM,
+  RESOURCE_TYPES,
   SPEEDS,
   TILE,
   TILES,
@@ -172,7 +173,7 @@ export function createOnArrive(opts) {
         const yieldResult = resolveHuntYield({ animal, lodge });
         dropItem(animal.x | 0, animal.y | 0, ITEM.FOOD, yieldResult.meat);
         if (yieldResult.pelts > 0) {
-          dropItem(animal.x | 0, animal.y | 0, 'pelt', yieldResult.pelts);
+          dropItem(animal.x | 0, animal.y | 0, ITEM.PELT, yieldResult.pelts);
         }
         queueAnimalLabel('Taken', '#ffd27f', animal.x + 0.1, animal.y - 0.1);
         removeAnimal(animal);
@@ -452,13 +453,24 @@ export function createOnArrive(opts) {
       finishJob(v, true);
     }
     else if (v.state === 'equip_bow') {
+      // tryEquipBow reserved 1 bow on intent. spendCraftMaterials closes the
+      // reservation on success AND releases it on insufficient-stock failure,
+      // so we only need an explicit release when we never reach that call
+      // (e.g. the storage building disappeared mid-trip). Audit #12, #13.
       const storage = v.targetBuilding || findNearestBuilding(cx, cy, 'storage');
-      if (storage && spendCraftMaterials({ bow: 1 })) {
+      let equipped = false;
+      if (storage) {
+        equipped = spendCraftMaterials({ bow: 1 });
+      } else {
+        releaseReservedMaterials({ bow: 1 });
+      }
+      if (equipped) {
         v.equippedBow = true;
         v.thought = moodThought(v, 'Equipped bow');
       } else {
         v.thought = moodThought(v, 'No bow available');
       }
+      v.reservedPickup = null;
       v.state = 'idle';
       v.targetBuilding = null;
     }
@@ -468,10 +480,9 @@ export function createOnArrive(opts) {
           consumeFood(v);
           v.thought = moodThought(v, 'Ate supplies');
         } else {
-          if (v.inv.type === ITEM.WOOD) storageTotals.wood += v.inv.qty;
-          if (v.inv.type === ITEM.STONE) storageTotals.stone += v.inv.qty;
-          if (v.inv.type === ITEM.FOOD) storageTotals.food += v.inv.qty;
-          if (v.inv.type === ITEM.BOW) storageTotals.bow += v.inv.qty;
+          if (RESOURCE_TYPES.includes(v.inv.type)) {
+            storageTotals[v.inv.type] = (storageTotals[v.inv.type] || 0) + v.inv.qty;
+          }
           v.inv = null;
           v.thought = moodThought(v, 'Stored');
         }

--- a/src/app/render.js
+++ b/src/app/render.js
@@ -3,7 +3,7 @@ import {
   GRID_H,
   GRID_SIZE,
   GRID_W,
-  ITEM,
+  ITEM_COLORS,
   LAYER_ORDER,
   SHADOW_DIRECTION,
   SHADOW_DIRECTION_ANGLE,
@@ -792,6 +792,8 @@ export function createRenderSystem(deps) {
       g.fillStyle = shadeFillColorLit('#3b2b1a', shade);
       g.fillRect(gx + 6 * s, gy + 10 * s, 20 * s, 1 * s);
       const totals = storageTotals || { food: 0, wood: 0, stone: 0 };
+      // audit Phase 2: pelt intentionally excluded from this fill heuristic
+      // (visualizes building-material/food fullness, not craft-resource stocks).
       const storedLevel = Math.min(1, (totals.food * 0.5 + totals.wood * 0.35 + totals.stone * 0.35) / 40);
       if (storedLevel > 0.02) {
         const fillH = Math.max(2 * s, Math.floor(12 * storedLevel) * s);
@@ -907,13 +909,7 @@ export function createRenderSystem(deps) {
     ctx.drawImage(f, 0, 0, 16, 16, gx, gy, spriteSize, spriteSize);
     applySpriteShadeLit(ctx, gx, gy, spriteSize, spriteSize, light);
     if (v.inv) {
-      const packColor = v.inv.type === ITEM.WOOD
-        ? '#b48a52'
-        : v.inv.type === ITEM.STONE
-          ? '#aeb7c3'
-          : v.inv.type === ITEM.BOW
-            ? '#d4c08a'
-            : '#b6d97a';
+      const packColor = ITEM_COLORS[v.inv.type] || ITEM_COLORS.food;
       ctx.fillStyle = shadeFillColorLit(packColor, light);
       ctx.fillRect(gx + spriteSize - 4 * s, gy + 2 * s, 3 * s, 3 * s);
     }
@@ -1202,13 +1198,7 @@ export function createRenderSystem(deps) {
         const spriteRect = { x: centerX - half, y: centerY - half, w: size, h: size };
         drawShadow(it.x, it.y, 1, 1, spriteRect);
         ctx.save();
-        const baseColor = it.type === ITEM.WOOD
-          ? '#b48a52'
-          : it.type === ITEM.STONE
-            ? '#aeb7c3'
-            : it.type === ITEM.BOW
-              ? '#d4c08a'
-              : '#b6d97a';
+        const baseColor = ITEM_COLORS[it.type] || ITEM_COLORS.food;
         ctx.fillStyle = shadeFillColorLit(baseColor, light);
         ctx.fillRect(spriteRect.x, spriteRect.y, spriteRect.w, spriteRect.h);
         ctx.restore();

--- a/src/app/save.js
+++ b/src/app/save.js
@@ -3,6 +3,7 @@ import {
   COARSE_SAVE_SIZE,
   GRID_H,
   GRID_W,
+  RESOURCE_TYPES,
   SAVE_KEY,
   SAVE_MIGRATIONS,
   SAVE_VERSION,
@@ -168,15 +169,11 @@ export function createSaveSystem(deps) {
       reindexAllBuildings();
       markEmittersDirty();
       const savedTotals = d.storageTotals || {};
-      storageTotals.food = Number.isFinite(savedTotals.food) ? savedTotals.food : 0;
-      storageTotals.wood = Number.isFinite(savedTotals.wood) ? savedTotals.wood : 0;
-      storageTotals.stone = Number.isFinite(savedTotals.stone) ? savedTotals.stone : 0;
-      storageTotals.bow = Number.isFinite(savedTotals.bow) ? savedTotals.bow : 0;
       const savedReserved = d.storageReserved || {};
-      storageReserved.food = Number.isFinite(savedReserved.food) ? savedReserved.food : 0;
-      storageReserved.wood = Number.isFinite(savedReserved.wood) ? savedReserved.wood : 0;
-      storageReserved.stone = Number.isFinite(savedReserved.stone) ? savedReserved.stone : 0;
-      storageReserved.bow = Number.isFinite(savedReserved.bow) ? savedReserved.bow : 0;
+      for (const r of RESOURCE_TYPES) {
+        storageTotals[r] = Number.isFinite(savedTotals[r]) ? savedTotals[r] : 0;
+        storageReserved[r] = Number.isFinite(savedReserved[r]) ? savedReserved[r] : 0;
+      }
       villagers.length = 0;
       const tickNow = getTick();
       (d.villagers || []).forEach(v => {

--- a/src/app/villagerAI.js
+++ b/src/app/villagerAI.js
@@ -39,7 +39,9 @@ export function createVillagerAI(opts) {
     addJob: _addJob, // unused but kept for symmetry; pickJobFor doesn't add jobs directly
     finishJob,
     noteJobAssignmentChanged: _noteJobAssignmentChanged,
-    availableToReserve,
+    availableToReserve: _availableToReserve,
+    reserveMaterials,
+    releaseReservedMaterials,
     requestBuildHauls,
     findAnimalById,
     findEntryTileNear,
@@ -52,6 +54,7 @@ export function createVillagerAI(opts) {
 
   void _addJob;
   void _noteJobAssignmentChanged;
+  void _availableToReserve;
   void _getBuildingById;
 
   const buildings = state.units.buildings;
@@ -504,15 +507,17 @@ export function createVillagerAI(opts) {
     if (v.inv) return false;
     if (v.state !== 'idle') return false;
     if (tick < v._nextPathTick) return false;
-    if (availableToReserve('bow') <= 0) return false;
+    // Reserve on intent so two villagers can't race for the same bow (audit #12).
+    if (!reserveMaterials({ bow: 1 })) return false;
     const storage = findNearestBuilding(v.x | 0, v.y | 0, 'storage');
-    if (!storage) return false;
+    if (!storage) { releaseReservedMaterials({ bow: 1 }); return false; }
     const entry = findEntryTileNear(storage, v.x | 0, v.y | 0) || { x: Math.round(buildingCenter(storage).x), y: Math.round(buildingCenter(storage).y) };
     const p = pathfind(v.x | 0, v.y | 0, entry.x, entry.y);
-    if (!p) return false;
+    if (!p) { releaseReservedMaterials({ bow: 1 }); return false; }
     v.path = p;
     v.state = 'equip_bow';
     v.targetBuilding = storage;
+    v.reservedPickup = { type: ITEM.BOW, qty: 1 };
     v.thought = moodThought(v, 'Fetching bow');
     v._nextPathTick = tick + 12;
     return true;

--- a/src/state.js
+++ b/src/state.js
@@ -1,3 +1,5 @@
+import { RESOURCE_TYPES } from './app/constants.js';
+
 export function createInitialState({ seed, cfg } = {}) {
   const baseSeed = Number.isFinite(seed) ? seed >>> 0 : (Date.now() | 0);
   const config = cfg && typeof cfg === 'object' ? cfg : {};
@@ -28,9 +30,11 @@ export function createInitialState({ seed, cfg } = {}) {
     generator: typeof (config.rng && config.rng.generator) === 'function' ? config.rng.generator : Math.random
   };
 
+  const baseTotals = Object.fromEntries(RESOURCE_TYPES.map(r => [r, 0]));
+  const baseReserved = Object.fromEntries(RESOURCE_TYPES.map(r => [r, 0]));
   const stocks = {
-    totals: Object.assign({ food: 24, wood: 0, stone: 0, bow: 0 }, stocksConfig.totals),
-    reserved: Object.assign({ food: 0, wood: 0, stone: 0, bow: 0 }, stocksConfig.reserved)
+    totals: Object.assign(baseTotals, { food: 24 }, stocksConfig.totals),
+    reserved: Object.assign(baseReserved, stocksConfig.reserved)
   };
 
   const queue = {


### PR DESCRIPTION
Makes every resource share one consistent lifecycle. Adds ITEM.PELT,
RESOURCE_TYPES, and ITEM_COLORS in constants and routes per-type forks
through them in state init, newWorld, save/load, deposit, and rendering.
Pelts dropped by hunting now survive deposit and round-trip through saves.

Adds takeFromStorage to materials.js so the four storage roles are clearly
separated (reserve / release / spend-reserved / take-direct) and documents
the intent on each helper.

Fixes audit issues #12 and #13: tryEquipBow now reserves on intent so
two villagers can't race for the same bow. The arrival path lets
spendCraftMaterials close the reservation; explicit release only runs
when storage disappeared mid-trip (avoids the double-release that would
corrupt other villagers' bow reservations).

Defers issue #38 (consolidating starting-stock sources) — left a comment
in app.js.

https://claude.ai/code/session_0197Ld3iGiVffWwzyCUs9H8S