### PR TITLE
Audit phase 3: per-type job identity for dedupe and suppression

### DIFF
--- a/AI_Village_Agent_Audit.md
+++ b/AI_Village_Agent_Audit.md
@@ -191,6 +191,14 @@ Restore time before recreating villagers/animals.
 
 ## 4. Haul job duplicate detection ignores resource type and quantity
 
+**Resolved (Phase 3, commit `7d7cc5a`).** `getJobIdentity(job)` in
+`src/app/jobs.js` now keys haul jobs as `haul:b${bid}:r${resource}`, so
+wood and stone hauls for the same building no longer collapse.
+`hasSimilarJob` and the suppression Map both route through the new
+identity. Cancelled tombstones are skipped in `hasSimilarJob` so a
+deliver-stage cancellation cannot block its replacement (touches #29).
+
+
 **Files/lines**
 
 - `src/app/jobs.js:69-70`
@@ -808,6 +816,12 @@ if (!uiRefs.sheetPrior) return;
 
 ## 26. Job suppression keys ignore resource/stage/target identity
 
+**Resolved (Phase 3, commit `7d7cc5a`).** `suppressJob` and
+`isJobSuppressed` now use `getJobIdentity`, so suppression follows the
+work being suppressed. Hunt suppression keys on `targetAid`, so a
+fleeing animal cannot evade `HUNT_RETRY_COOLDOWN` by changing position.
+
+
 **Files/lines**
 
 - `src/app/jobs.js:42-67`
@@ -827,6 +841,15 @@ Use per-job identity keys, same as issue #4.
 ---
 
 ## 27. `hasSimilarJob()` ignores meaningful identity
+
+**Resolved (Phase 3, commit `7d7cc5a`).** `hasSimilarJob` now routes
+through `getJobIdentity` and skips cancelled jobs, so distinct work no
+longer collapses into one slot. Identity per type:
+`haul:b${bid}:r${resource}`, `hunt:a${targetAid}`, `build:b${bid}`,
+`craft_bow:b${bid}`, and `${type}:${x},${y}` for sow/chop/mine/forage.
+Unknown types return `null` so a future job type without identity
+support fails loudly rather than silently aliasing.
+
 
 **Files/lines**
 
@@ -1207,6 +1230,23 @@ Tasks:
 5. Fix bow pickup to reserve or directly take stock safely.
 
 ## Phase 3: Repair job identity, dedupe, and suppression
+
+**Status: Done (commit `7d7cc5a`).** `getJobIdentity(job)` in
+`src/app/jobs.js` is the single source of truth for job identity, used
+by `hasSimilarJob`, `isJobSuppressed`, and `suppressJob`. Identity
+fields are chosen per type: hauls include `bid+resource`, hunts key on
+`targetAid`, build/craft jobs key on `bid`, and zone work keys on
+`x,y`. `hasSimilarJob` skips `cancelled` jobs so deliver-stage
+tombstones no longer block their replacements (partial fix for #29 —
+full lifecycle redesign deferred). The dead `jobKey` export was
+removed from `src/app.js`. Resolves critical issues **#4**, **#26**,
+and **#27**.
+
+Tests live in `tests/jobs.identity.test.js` and run via `npm test`
+(Node's built-in test runner, no new dependencies). Coverage includes
+the wood+stone case the audit explicitly asked for, hunt suppression
+across position changes, cancelled-tombstone replacement, and dedupe
+by bid/coords.
 
 Goal: different jobs should not collapse into the same key.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "node --test tests/**/*.test.js"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/src/app.js
+++ b/src/app.js
@@ -806,7 +806,6 @@ const {
   noteJobAssignmentChanged,
   noteJobRemoved,
   getJobCreationConfig,
-  jobKey: _jobKey,
   isJobSuppressed: _isJobSuppressed,
   suppressJob,
   hasSimilarJob,
@@ -815,7 +814,7 @@ const {
   finishJob,
   detachVillagersFromJob
 } = _jobsSystem;
-void _jobKey; void _isJobSuppressed;
+void _isJobSuppressed;
 
 const _animalsSystem = createAnimalsSystem({
   state: gameState,

--- a/src/app/jobs.js
+++ b/src/app/jobs.js
@@ -39,17 +39,35 @@ export function createJobsSystem(opts) {
     return policy?.style?.jobCreation || {};
   }
 
-  function jobKey(job) {
+  // Identity keys must include the fields that distinguish one unit of work
+  // from another. Same tile does not mean same work — wood vs stone hauls
+  // for one building share type/x/y/bid but are different jobs, and a hunt
+  // on a fleeing animal moves but is still the same hunt.
+  function getJobIdentity(job) {
     if (!job || !job.type) return null;
-    const base = `${job.type}:${Number.isFinite(job.x) ? job.x : '?'},${Number.isFinite(job.y) ? job.y : '?'}`;
-    if (job.bid !== undefined) {
-      return `${base}:b${job.bid}`;
+    switch (job.type) {
+      case 'haul':
+        return `haul:b${job.bid}:r${job.resource}`;
+      case 'hunt':
+        return job.targetAid != null
+          ? `hunt:a${job.targetAid}`
+          : `hunt:noaid:${job.x},${job.y}:b${job.bid}`;
+      case 'build':
+        return `build:b${job.bid}`;
+      case 'craft_bow':
+        return `craft_bow:b${job.bid}`;
+      case 'sow':
+      case 'chop':
+      case 'mine':
+      case 'forage':
+        return `${job.type}:${job.x},${job.y}`;
+      default:
+        return null;
     }
-    return base;
   }
 
   function isJobSuppressed(job) {
-    const key = jobKey(job);
+    const key = getJobIdentity(job);
     if (!key) return false;
     const until = jobSuppression.get(key);
     if (until === undefined) return false;
@@ -61,13 +79,15 @@ export function createJobsSystem(opts) {
   }
 
   function suppressJob(job, duration = 0) {
-    const key = jobKey(job);
+    const key = getJobIdentity(job);
     if (!key || duration <= 0) return;
     jobSuppression.set(key, state.time.tick + duration);
   }
 
   function hasSimilarJob(job) {
-    return jobs.some(j => j && j.type === job.type && j.x === job.x && j.y === job.y && (j.bid || null) === (job.bid || null));
+    const id = getJobIdentity(job);
+    if (!id) return false;
+    return jobs.some(j => j && !j.cancelled && getJobIdentity(j) === id);
   }
 
   function violatesSpacing(x, y, type, cfg) {
@@ -122,7 +142,7 @@ export function createJobsSystem(opts) {
     noteJobAssignmentChanged,
     noteJobRemoved,
     getJobCreationConfig,
-    jobKey,
+    getJobIdentity,
     isJobSuppressed,
     suppressJob,
     hasSimilarJob,

--- a/tests/jobs.identity.test.js
+++ b/tests/jobs.identity.test.js
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { createJobsSystem } from '../src/app/jobs.js';
+
+function makeSystem() {
+  const state = {
+    units: { jobs: [], villagers: [] },
+    time: { tick: 0 },
+    stocks: { totals: {}, reserved: {} }
+  };
+  const policy = { style: {}, sliders: {} };
+  const sys = createJobsSystem({ state, policy });
+  return { state, sys };
+}
+
+test('haul jobs for the same building but different resources both persist', () => {
+  const { state, sys } = makeSystem();
+  const wood = sys.addJob({ type: 'haul', bid: 1, resource: 'wood', qty: 5, x: 0, y: 0 });
+  const stone = sys.addJob({ type: 'haul', bid: 1, resource: 'stone', qty: 3, x: 0, y: 0 });
+  assert.ok(wood, 'wood haul should be added');
+  assert.ok(stone, 'stone haul should be added');
+  assert.equal(state.units.jobs.length, 2);
+});
+
+test('duplicate same-resource haul for the same building collapses', () => {
+  const { state, sys } = makeSystem();
+  const first = sys.addJob({ type: 'haul', bid: 1, resource: 'wood', qty: 5, x: 0, y: 0 });
+  const second = sys.addJob({ type: 'haul', bid: 1, resource: 'wood', qty: 2, x: 0, y: 0 });
+  assert.ok(first);
+  assert.equal(second, null);
+  assert.equal(state.units.jobs.length, 1);
+});
+
+test('cancelled haul tombstone does not block a fresh haul of the same kind', () => {
+  const { state, sys } = makeSystem();
+  const first = sys.addJob({ type: 'haul', bid: 1, resource: 'wood', qty: 5, x: 0, y: 0 });
+  assert.ok(first);
+  first.cancelled = true;
+  const replacement = sys.addJob({ type: 'haul', bid: 1, resource: 'wood', qty: 5, x: 0, y: 0 });
+  assert.ok(replacement, 'fresh haul should succeed when prior is cancelled');
+  assert.equal(state.units.jobs.length, 2);
+});
+
+test('hunt suppression follows the animal id, not its position', () => {
+  const { sys, state } = makeSystem();
+  sys.suppressJob({ type: 'hunt', targetAid: 7, x: 1, y: 1, bid: 1 }, 100);
+  const blocked = sys.addJob({ type: 'hunt', targetAid: 7, x: 5, y: 9, bid: 1 });
+  assert.equal(blocked, null, 'suppression should follow targetAid across position changes');
+  assert.equal(state.units.jobs.length, 0);
+});
+
+test('hunt suppression expires once the tick deadline passes', () => {
+  const { state, sys } = makeSystem();
+  sys.suppressJob({ type: 'hunt', targetAid: 7, x: 1, y: 1, bid: 1 }, 100);
+  state.time.tick = 101;
+  const job = sys.addJob({ type: 'hunt', targetAid: 7, x: 5, y: 9, bid: 1 });
+  assert.ok(job, 'expired suppression should not block new hunt');
+});
+
+test('build jobs dedupe by building id', () => {
+  const { state, sys } = makeSystem();
+  const a = sys.addJob({ type: 'build', bid: 42, x: 3, y: 4 });
+  const b = sys.addJob({ type: 'build', bid: 42, x: 3, y: 4 });
+  assert.ok(a);
+  assert.equal(b, null);
+  assert.equal(state.units.jobs.length, 1);
+});
+
+test('craft_bow jobs dedupe by lodge id', () => {
+  const { state, sys } = makeSystem();
+  const a = sys.addJob({ type: 'craft_bow', bid: 9, x: 2, y: 2, materials: { wood: 2 } });
+  const b = sys.addJob({ type: 'craft_bow', bid: 9, x: 2, y: 2, materials: { wood: 2 } });
+  assert.ok(a);
+  assert.equal(b, null);
+  assert.equal(state.units.jobs.length, 1);
+});
+
+test('zone jobs (sow/chop/mine/forage) dedupe by tile coordinates', () => {
+  const { sys } = makeSystem();
+  assert.ok(sys.addJob({ type: 'sow', x: 1, y: 2 }));
+  assert.equal(sys.addJob({ type: 'sow', x: 1, y: 2 }), null);
+  assert.ok(sys.addJob({ type: 'sow', x: 1, y: 3 }));
+  assert.ok(sys.addJob({ type: 'forage', x: 1, y: 2, targetI: 100 }));
+  assert.equal(sys.addJob({ type: 'forage', x: 1, y: 2, targetI: 100 }), null);
+});
+
+test('getJobIdentity returns null for unknown job types so they cannot silently collapse', () => {
+  const { sys } = makeSystem();
+  assert.equal(sys.getJobIdentity({ type: 'mystery', x: 0, y: 0 }), null);
+  assert.equal(sys.getJobIdentity(null), null);
+  assert.equal(sys.getJobIdentity({}), null);
+});


### PR DESCRIPTION
Previously jobKey() and hasSimilarJob() only compared type/x/y/bid, so
a wood haul and stone haul to the same building collapsed (audit #4),
hunt suppression evaded fleeing animals (audit #26), and cancelled
deliver-stage haul tombstones blocked fresh hauls of the same resource.

Replace jobKey with getJobIdentity, switching on job.type:
  haul       -> haul:b<bid>:r<resource>
  hunt       -> hunt:a<targetAid>
  build      -> build:b<bid>
  craft_bow  -> craft_bow:b<bid>
  sow|chop|mine|forage -> <type>:<x>,<y>
  unknown    -> null (no silent collapse)

Route hasSimilarJob, isJobSuppressed, and suppressJob through it, and
skip cancelled jobs in hasSimilarJob so a tombstoned deliver does not
block its replacement.

Add tests/jobs.identity.test.js covering the wood+stone case the audit
explicitly asks for, hunt suppression following animal id across
position changes, cancelled-tombstone replacement, and zone/build/craft
dedupe. New "test" script in package.json runs node --test.