### PR TITLE
Audit phase 5: idempotent harvest + planted-target sow gating

### DIFF
--- a/AI_Village_Agent_Audit.md
+++ b/AI_Village_Agent_Audit.md
@@ -571,6 +571,17 @@ Move `requestBuildHauls()` out of `pickJobFor()` into planner/build maintenance 
 
 ## 15. Ripe crops can become permanently stranded with no harvest job
 
+**Resolved (Phase 5).** `generateJobs()` in `src/app/planner.js` now
+emits a harvest job for every FARMLAND tile with `growth >= 150` on
+each pass, gated on `world.tiles[i] === TILES.FARMLAND` rather than
+`z === ZONES.FARM` (so a dezoned-but-sown tile is still harvested).
+`getJobIdentity` in `src/app/jobs.js` was missing a `harvest` case;
+adding it (key `harvest:${x},${y}`) makes the planner emission
+idempotent — a removed/cancelled/suppressed harvest job is recreated
+on the next planner pass. `seasonTick` keeps its threshold-crossing
+emission as the fast-path; the planner is the catch-up.
+
+
 **Files/lines**
 
 - `src/app.js:656-691`
@@ -599,6 +610,18 @@ if (world.tiles[i] === TILES.FARMLAND && world.growth[i] >= 150) {
 ---
 
 ## 16. Farm job logic over-enables sow/harvest work
+
+**Resolved (Phase 5).** `shouldGenerateJobType` in `src/app/planner.js`
+now treats sow and harvest separately. Harvest is always allowed (the
+FARMLAND scan is a no-op when nothing is ripe). Sow gates on a
+planted-tile target driven by `plantedTilesPerVillager` (default `1.5`,
+added to `DEFAULT_JOB_CREATION` in `src/policy/policy.js`); a new
+`countPlantedTiles()` helper counts FARMLAND tiles with `0 < growth <
+150`, so ripe-but-unharvested tiles do not throttle sowing. Forage was
+softened — the old `!hasRipeCrops()` clause is replaced with `(!hasRipeCrops()
+&& foodOnHand < villagerCount * 3)`, so forage stays a real
+food-pressure fallback rather than constant competition with farming.
+
 
 **Files/lines**
 
@@ -1344,9 +1367,33 @@ Tasks (completed):
 
 ## Phase 5: Repair farming lifecycle
 
-Goal: crops should not strand, and farming should not dominate forever.
+**Status: Done.** Resolves critical issues **#15** (ripe crops
+permanently stranded) and **#16** (sow/harvest over-enabled).
 
-Tasks:
+`getJobIdentity` in `src/app/jobs.js` now includes `harvest` (keyed as
+`harvest:${x},${y}`). `src/app/planner.js` adds `countPlantedTiles()`
+alongside `hasRipeCrops`/`hasAnyFarmTiles`; `shouldGenerateJobType`
+splits the sow and harvest cases — harvest is unconditional (the
+FARMLAND scan is the gate), sow gates on a planted-tile target driven
+by `cfg.plantedTilesPerVillager` (default `1.5`, added to
+`DEFAULT_JOB_CREATION` in `src/policy/policy.js`). `generateJobs()`
+emits harvest from the existing tile loop guarded by `world.tiles[i]
+=== TILES.FARMLAND && world.growth[i] >= 150` — keyed on FARMLAND, not
+zone, so a dezoned-but-sown tile is still harvested. `forageNeed` now
+keeps the `!hasRipeCrops()` branch but ANDs it with `foodOnHand <
+villagerCount * 3` so forage is a real food-pressure fallback rather
+than constant competition. `seasonTick` is unchanged: it stays as the
+fast-path emitter (emits exactly at the threshold crossing) while the
+planner catches up idempotently.
+
+Tests live in `tests/farming.lifecycle.test.js` and run via `npm test`
+(Node's built-in test runner, no new dependencies). Coverage:
+harvest dedupe at the same tile, re-emission after removal,
+re-emission after `cancelled = true`, harvest+sow at the same tile
+coexisting (different identity keys), and harvest suppression
+following coordinates with tick-based expiry.
+
+Tasks (completed):
 
 1. Generate harvest jobs idempotently whenever ripe crops exist.
 2. Generate sow jobs only when empty farm tiles should be planted.

--- a/src/app/jobs.js
+++ b/src/app/jobs.js
@@ -57,6 +57,7 @@ export function createJobsSystem(opts) {
       case 'craft_bow':
         return `craft_bow:b${job.bid}`;
       case 'sow':
+      case 'harvest':
       case 'chop':
       case 'mine':
       case 'forage':

--- a/src/app/planner.js
+++ b/src/app/planner.js
@@ -811,6 +811,17 @@ export function createPlanner(opts) {
     return false;
   }
 
+  function countPlantedTiles() {
+    const world = state.world;
+    if (!world || !world.growth || !world.tiles) return 0;
+    let count = 0;
+    for (let i = 0; i < world.tiles.length; i++) {
+      if (world.tiles[i] === TILES.FARMLAND
+        && world.growth[i] > 0 && world.growth[i] < 150) count++;
+    }
+    return count;
+  }
+
   function shouldGenerateJobType(type, bb, cfg) {
     if (!bb) return true;
     const villagersCount = Math.max(1, bb.villagers || 0);
@@ -818,10 +829,17 @@ export function createPlanner(opts) {
       if (bb.famine) return true;
       return evaluateResourceNeed('food', bb.availableFood || 0, villagersCount, cfg, 'minFoodPerVillager', 'food');
     }
-    if (type === 'sow' || type === 'harvest') {
+    if (type === 'harvest') {
+      // Harvest is always allowed; the FARMLAND scan emits nothing when no tile is ripe.
+      return true;
+    }
+    if (type === 'sow') {
       if (bb.famine) return true;
-      if (hasAnyFarmTiles()) return true;
-      return evaluateResourceNeed('food', bb.availableFood || 0, villagersCount, cfg, 'minFoodPerVillager', type);
+      const perVillager = Number.isFinite(cfg?.plantedTilesPerVillager)
+        ? cfg.plantedTilesPerVillager : 1.5;
+      const plantedTarget = Math.ceil(villagersCount * perVillager);
+      if (countPlantedTiles() < plantedTarget) return true;
+      return evaluateResourceNeed('food', bb.availableFood || 0, villagersCount, cfg, 'minFoodPerVillager', 'sow');
     }
     if (type === 'chop') {
       return evaluateResourceNeed('wood', bb.availableWood || 0, villagersCount, cfg, 'minWoodPerVillager');
@@ -845,13 +863,19 @@ export function createPlanner(opts) {
     const creationCfg = getJobCreationConfig();
     const bb = ensureBlackboardSnapshot();
     const allowSow = shouldGenerateJobType('sow', bb, creationCfg);
+    const allowHarvest = shouldGenerateJobType('harvest', bb, creationCfg);
     const allowChop = shouldGenerateJobType('chop', bb, creationCfg);
     const allowMine = shouldGenerateJobType('mine', bb, creationCfg);
     const allowCraftBow = shouldGenerateJobType('craft_bow', bb, creationCfg);
     const villagerCount = Math.max(1, bb?.villagers || villagers.length || 0);
     const famineSeverity = computeFamineSeverity(bb);
     const foodOnHand = bb?.availableFood ?? storageTotals.food ?? 0;
-    const forageNeed = bb?.famine || !hasRipeCrops() || foodOnHand < villagerCount * 2;
+    // Forage as a real food-pressure fallback: famine, food deficit, or
+    // moderate food + no ripe crops to bridge the growing gap. Without the
+    // last clause, forage would dominate whenever crops were still growing.
+    const forageNeed = bb?.famine
+      || foodOnHand < villagerCount * 2
+      || (!hasRipeCrops() && foodOnHand < villagerCount * 3);
     const allowForage = shouldGenerateJobType('forage', bb, creationCfg) && forageNeed;
     for (let y = 0; y < GRID_H; y++) {
       for (let x = 0; x < GRID_W; x++) {
@@ -870,6 +894,16 @@ export function createPlanner(opts) {
           if (allowMine && zoneHasWorkNow(z, i) && !violatesSpacing(x, y, 'mine', creationCfg)) {
             addJob({ type: 'mine', x, y, prio: 0.5 + (policy.sliders.build || 0) * 0.5 });
           }
+        }
+        // Harvest is keyed on FARMLAND, not on FARM zone, because a tile that
+        // was sown can survive a zone clear and still need its crop pulled.
+        // addJob() dedupes via getJobIdentity('harvest:x,y'), so this stays
+        // idempotent each planner pass.
+        if (allowHarvest
+          && world.tiles[i] === TILES.FARMLAND
+          && world.growth[i] >= 150
+          && !violatesSpacing(x, y, 'harvest', creationCfg)) {
+          addJob({ type: 'harvest', x, y, prio: 0.65 + (policy.sliders.food || 0) * 0.6 });
         }
       }
     }

--- a/src/policy/policy.js
+++ b/src/policy/policy.js
@@ -62,6 +62,7 @@ const DEFAULT_JOB_CREATION = Object.freeze({
   minFoodPerVillager: 0.6,
   minWoodPerVillager: 1.2,
   minStonePerVillager: 0.6,
+  plantedTilesPerVillager: 1.5,
   hysteresis: 0.2,
   minSpacing: {
     sow: 0,

--- a/tests/farming.lifecycle.test.js
+++ b/tests/farming.lifecycle.test.js
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { createJobsSystem } from '../src/app/jobs.js';
+
+function makeSystem() {
+  const state = {
+    units: { jobs: [], villagers: [] },
+    time: { tick: 0 },
+    stocks: { totals: {}, reserved: {} }
+  };
+  const policy = { style: {}, sliders: {} };
+  const sys = createJobsSystem({ state, policy });
+  return { state, sys };
+}
+
+test('harvest jobs dedupe by tile coordinates', () => {
+  const { state, sys } = makeSystem();
+  const first = sys.addJob({ type: 'harvest', x: 5, y: 5, prio: 0.65 });
+  const second = sys.addJob({ type: 'harvest', x: 5, y: 5, prio: 0.7 });
+  assert.ok(first, 'first harvest job should be added');
+  assert.equal(second, null, 'duplicate harvest at same tile should not be added');
+  assert.equal(state.units.jobs.length, 1);
+});
+
+test('harvest re-emits after the prior job is removed from the queue', () => {
+  const { state, sys } = makeSystem();
+  const first = sys.addJob({ type: 'harvest', x: 5, y: 5 });
+  assert.ok(first);
+  state.units.jobs.length = 0;
+  const replacement = sys.addJob({ type: 'harvest', x: 5, y: 5 });
+  assert.ok(replacement, 'fresh harvest should succeed once the prior is gone');
+  assert.equal(state.units.jobs.length, 1);
+});
+
+test('harvest re-emits after the prior job is cancelled', () => {
+  const { state, sys } = makeSystem();
+  const first = sys.addJob({ type: 'harvest', x: 5, y: 5 });
+  assert.ok(first);
+  first.cancelled = true;
+  const replacement = sys.addJob({ type: 'harvest', x: 5, y: 5 });
+  assert.ok(replacement, 'cancelled tombstone must not block a fresh harvest');
+  assert.equal(state.units.jobs.length, 2);
+});
+
+test('harvest and sow at the same tile coexist', () => {
+  const { state, sys } = makeSystem();
+  const sow = sys.addJob({ type: 'sow', x: 5, y: 5 });
+  const harvest = sys.addJob({ type: 'harvest', x: 5, y: 5 });
+  assert.ok(sow, 'sow at (5,5) should be added');
+  assert.ok(harvest, 'harvest at (5,5) should be added alongside sow');
+  assert.equal(state.units.jobs.length, 2);
+});
+
+test('harvest suppression follows tile coordinates and expires on tick', () => {
+  const { state, sys } = makeSystem();
+  sys.suppressJob({ type: 'harvest', x: 5, y: 5 }, 100);
+  const blocked = sys.addJob({ type: 'harvest', x: 5, y: 5 });
+  assert.equal(blocked, null, 'suppression should block re-emission until expiry');
+  state.time.tick = 101;
+  const allowed = sys.addJob({ type: 'harvest', x: 5, y: 5 });
+  assert.ok(allowed, 'expired suppression should not block a fresh harvest');
+});


### PR DESCRIPTION
Resolves critical issues #15 and #16. `getJobIdentity` now keys
harvest as `harvest:${x},${y}` so harvest emission can be
idempotent. `generateJobs()` emits harvest from a FARMLAND scan
(not a FARM-zone scan, so dezoned-but-sown tiles still harvest);
seasonTick remains as the fast-path. Sow gates on a planted-tile
target driven by `plantedTilesPerVillager` (default 1.5), counting
only growing tiles (`0 < growth < 150`) so a ripe backlog never
throttles sowing. Forage keeps the no-ripe-crops branch but ANDs
with a food deficit, so it stays a real fallback.

https://claude.ai/code/session_01MD6i1oUoM8YrRtcSBRj5UP