### PR TITLE
Audit phase 7: UI/runtime robustness

### DIFF
--- a/AI_Village_Agent_Audit.md
+++ b/AI_Village_Agent_Audit.md
@@ -683,6 +683,12 @@ For stable checkpoint save, do not restore `activeBuildingId`; set it to `null`.
 
 ## 18. `newWorld()` does not reset pause/speed state
 
+**Resolved (Phase 7).** `newWorld` in `src/app.js` now resets
+`time.paused = false; time.speedIdx = 1;` alongside `tick`/`dayTime`,
+matching the `timeDefaults` in `src/state.js:20-25`. The reset pairs
+with the new `syncTimeButtons()` call at the end of `newWorld` (issue
+#19) so the UI never shows stale pause/speed state after a new world.
+
 **Files/lines**
 
 - `src/app.js:317-339`
@@ -708,6 +714,14 @@ or intentionally preserve these and sync UI labels.
 
 ## 19. Pause/speed UI can desync from actual time state
 
+**Resolved (Phase 7).** `createUISystem` in `src/app/ui.js` now exposes
+`syncTimeButtons()` and the click handlers route through it
+(`onPauseClick`/`onSpeedClick` mutate `time.*` then call the shared
+renderer). It is invoked at the end of `newWorld`, after the
+boot-time `bindUIListeners()` in `src/app.js`, and at the end of
+`loadGame` in `src/app/save.js`, so pause/speed buttons stay in sync
+across new-world, load, and click paths.
+
 **Files/lines**
 
 - `src/app/ui.js:111-118`
@@ -727,6 +741,13 @@ Add `syncTimeButtons()` and call after boot, load, new world, pause changes, and
 ---
 
 ## 20. `loadGame()` calls `newWorld()` and shows misleading new-world toasts
+
+**Resolved (Phase 7).** `newWorld` in `src/app.js` now accepts an
+`opts = {}` second argument; the two `Toast.show(...)` calls at
+`src/app.js:474-475` are gated on `!opts.silent`. More importantly,
+`loadGame` in `src/app/save.js` no longer calls `newWorld` at all
+(see #21), so the misleading new-world toasts cannot fire on load —
+the only remaining toast is `Loaded.` at `src/app/save.js:251`.
 
 **Files/lines**
 
@@ -753,6 +774,17 @@ Use silent mode during load.
 ---
 
 ## 21. World reload creates then discards villagers/animals
+
+**Resolved (Phase 7).** `newWorld` in `src/app.js` is now factored
+into `generateWorldBase(seed)` (pure terrain assembly: rng seed,
+`generateTerrain`, hillshade, `nextWorld` struct, `world =
+nextWorld`, `gameState.world = nextWorld`, lightmap/overlay/zone
+resets) and `resetVolatileState()` (jobs/buildings/items/animals
+arrays, `buildingsByKind`, `clearActiveZoneJobs`, `tickRunner.reset`,
+`markEmittersDirty`, `villagerNumberCounter`). Both are passed as
+deps to `createSaveSystem`. `loadGame` calls `resetVolatileState()`
+then `generateWorldBase(seed)` directly — no transient
+campfire/storage/villager/animal spawn happens during load.
 
 **Files/lines**
 
@@ -781,6 +813,13 @@ Load should generate terrain/base state without spawning new simulation entities
 
 ## 22. `main.js` tries to call a global fatal reporter that is not exposed
 
+**Resolved (Phase 7).** `src/app/storage.js` now sets
+`AIV_SCOPE.reportFatal = reportFatal` alongside the existing
+`AIV_SCOPE.AIV_STORAGE = Storage` assignment, so the feature-detect
+in `src/main.js:57-63` (`typeof GLOBAL_SCOPE.reportFatal ===
+'function'`) actually finds the function and the fatal overlay
+appears for early boot failures.
+
 **Files/lines**
 
 - `src/main.js:52-63`
@@ -805,6 +844,12 @@ Or move fatal overlay into a small module imported by `main.js`.
 ---
 
 ## 23. `canvas.js` reports a fatal error then crashes if canvas is missing
+
+**Resolved (Phase 7).** `src/app/canvas.js` now guards immediately
+after `document.getElementById('game')` — if the canvas is missing it
+calls `reportFatal(new Error('Missing #game canvas'))` and `throw`s,
+halting module evaluation before any deref of `canvas.style` /
+`canvas.addEventListener` / `canvas.getBoundingClientRect()`.
 
 **Files/lines**
 
@@ -832,6 +877,16 @@ if (!canvas) {
 
 ## 24. UI binding assumes every DOM node exists
 
+**Resolved (Phase 7).** `createUISystem` in `src/app/ui.js` now defines
+`safeOn(node, event, fn, opts)` and `safeOff(...)` helpers that
+no-op when the node is null or has no `addEventListener`.
+`bindUIListeners` and `unbindUIListeners` route every `uiRefs.*`
+binding through them. `onPauseClick`, `onSpeedClick`, and
+`onHelpCloseClick` short-circuit on null refs. `boot()` in
+`src/app.js` also null-checks `el('help')` before showing the help
+overlay. A renamed/missing button now disables that button without
+breaking boot.
+
 **Files/lines**
 
 - `src/app/ui.js:92-103`
@@ -856,6 +911,12 @@ function on(node, event, fn, opts) {
 ---
 
 ## 25. `onPriorClick()` assumes the priority sheet exists
+
+**Resolved (Phase 7).** `onPriorClick` in `src/app/ui.js` now returns
+early when `uiRefs.sheetPrior` is null, before the
+`getAttribute('data-open')` deref. Combined with #24, the click
+handler stays attached but harmlessly no-ops if the sheet is
+missing.
 
 **Files/lines**
 
@@ -1474,16 +1535,62 @@ Tasks (completed):
 
 ## Phase 7: UI/runtime robustness
 
-Goal: missing DOM elements and boot failures should produce clean errors.
+**Status: Done.** Resolves critical issues **#18**, **#19**, **#20**,
+**#21**, **#22**, **#23**, **#24**, **#25**.
 
-Tasks:
+`src/app/storage.js` now exposes `reportFatal` on `AIV_SCOPE`
+alongside `AIV_STORAGE`, so `src/main.js`'s catch block actually
+reaches the fatal overlay during early boot failures (#22).
+`src/app/canvas.js` throws after `reportFatal(new Error('Missing
+#game canvas'))` if the canvas element is absent, before any
+`canvas.style` deref (#23). `src/app/ui.js` adds `safeOn`/`safeOff`
+helpers and routes every `bindUIListeners`/`unbindUIListeners`
+attachment through them; `onPriorClick`/`onPauseClick`/`onSpeedClick`/
+`onHelpCloseClick` short-circuit on null refs (#24, #25). The new
+`syncTimeButtons()` is exposed from `createUISystem`, called at the
+end of `newWorld`, after the boot-time `bindUIListeners()`, and at
+the end of `loadGame`; click handlers route through it so the click
+path and external sync share one renderer (#19). `newWorld` resets
+`time.paused = false; time.speedIdx = 1;` to match
+`timeDefaults` (#18) and accepts an `opts.silent` flag that gates
+the new-world toasts (#20). `newWorld` is internally factored into
+`generateWorldBase(seed)` (pure terrain) and `resetVolatileState()`
+(jobs/buildings/items/animals/index/zone-jobs/tickRunner/villager
+counter); `createSaveSystem` receives both, and `loadGame` calls
+`resetVolatileState()` then `generateWorldBase(seed)` directly —
+no transient villagers or animals spawn during load (#21).
+`src/app.js`'s `boot()` also null-checks `el('help')` before showing
+the help overlay.
 
-1. Add `requireElement(id)` or safe event binding helpers.
-2. Fix `canvas.js` missing canvas fatal path.
-3. Expose or import `reportFatal` properly for `main.js`.
-4. Add `syncTimeButtons()` and call it after new/load/time changes.
-5. Add `newWorld(seed, { silent })` and use silent mode during load.
-6. Split `generateWorldBase()` from `initializeNewGame()`.
+Tests live in `tests/ui.runtime.phase7.test.js` and run via `npm
+test` (Node's built-in test runner; `ensureBrowserStubs()` at the
+top of the file fakes `document`, `window`, `localStorage`,
+`AIV_TERRAIN`, and `AIV_CONFIG` so `ui.js`'s transitive
+`canvas.js`/`storage.js` imports load under node, no new
+dependencies). Coverage: `syncTimeButtons` reflects state on both
+btnPause and btnSpeed and is null-safe; `bindUIListeners` /
+`unbindUIListeners` do not throw with null refs; `onPriorClick`
+remains attached and no-ops without `sheetPrior`; `onPauseClick`
+mutates `time.paused` and updates `btnPause.textContent` via
+`syncTimeButtons`; `loadGame` invokes `resetVolatileState` +
+`generateWorldBase` (not `newWorld`) once each, returns true, calls
+`syncTimeButtons`, and never emits the misleading "New pixel map
+created." toast.
+
+Tasks (completed):
+
+1. Add `requireElement(id)` or safe event binding helpers. **`safeOn`/`safeOff` added inline in `createUISystem`; null-guards added to `onPriorClick`, `onPauseClick`, `onSpeedClick`, `onHelpCloseClick`, and `boot()`'s `el('help')`.**
+2. Fix `canvas.js` missing canvas fatal path. **Throws after `reportFatal` if `#game` is missing.**
+3. Expose or import `reportFatal` properly for `main.js`. **`AIV_SCOPE.reportFatal = reportFatal` set in `src/app/storage.js`.**
+4. Add `syncTimeButtons()` and call it after new/load/time changes. **Exposed from `createUISystem`; called in `newWorld`, after `bindUIListeners()` at boot, at the end of `loadGame`, and from `onPauseClick`/`onSpeedClick`.**
+5. Add `newWorld(seed, { silent })` and use silent mode during load. **`opts.silent` gates the two new-world toasts; `loadGame` no longer calls `newWorld` at all, so the toasts cannot fire on load.**
+6. Split `generateWorldBase()` from `initializeNewGame()`. **`generateWorldBase(seed)` and `resetVolatileState()` are factored out of `newWorld`; both are deps of `createSaveSystem`. The public `newWorld` name is preserved (called from `boot`, `onNewClick`) — no renames required.**
+
+**Deferred:** `time.paused`/`time.speedIdx` are still not part of the
+save schema, so a saved game's pause/speed state does not survive a
+reload — they reset to defaults instead. This is tracked under
+issue **#3** ("Save/load resets global time but preserves
+tick-relative timers") and is out of Phase 7 scope.
 
 ## Phase 8: Performance and observability
 

--- a/src/app.js
+++ b/src/app.js
@@ -315,27 +315,12 @@ function applyShadingParams({ ambient, intensity, slopeScale } = {}) {
 registerShadingHandlers({ setMode: applyShadingMode, setParams: applyShadingParams });
 
 
-function newWorld(seed=Date.now()|0){
-  if(typeof unbindUIListeners === 'function') unbindUIListeners();
-  if(typeof unbindCanvasInputs === 'function') unbindCanvasInputs();
+// audit #21: pure terrain + world struct setup. Callable from loadGame
+// without spawning campfire/storage/villagers/animals.
+function generateWorldBase(seed){
   const normalizedSeed = seed >>> 0;
   rng.seed = normalizedSeed;
   rng.generator = mulberry32(normalizedSeed);
-  jobs.length=0; buildings.length=0; itemsOnGround.length=0; animals.length=0; markItemsDirty();
-  buildingsByKind.clear();
-  clearActiveZoneJobs();
-  if(typeof tickRunner !== 'undefined') tickRunner.reset();
-  markEmittersDirty();
-  villagerNumberCounter = 1;
-  // audit #38: starting stocks duplicated with state.js — defer consolidation.
-  for (const r of RESOURCE_TYPES) {
-    storageTotals[r] = 0;
-    storageReserved[r] = 0;
-  }
-  storageTotals.food = 24;
-  storageTotals.wood = 12;
-  time.tick = 0;
-  time.dayTime = 0;
   const terrain = generateTerrain(seed, WORLDGEN_DEFAULTS, { w: GRID_W, h: GRID_H });
   const aux = terrain.aux || {};
   const mode = normalizeShadingMode(SHADING_DEFAULTS.mode);
@@ -374,6 +359,37 @@ function newWorld(seed=Date.now()|0){
   world.growth.fill(0);
   refreshWaterRowMaskFromTiles();
   markZoneOverlayDirty();
+  return world;
+}
+
+// audit #21: extracted so loadGame can clear volatile state without
+// going through newWorld (which would spawn fresh villagers/animals).
+function resetVolatileState(){
+  jobs.length=0; buildings.length=0; itemsOnGround.length=0; animals.length=0; markItemsDirty();
+  buildingsByKind.clear();
+  clearActiveZoneJobs();
+  if(typeof tickRunner !== 'undefined') tickRunner.reset();
+  markEmittersDirty();
+  villagerNumberCounter = 1;
+}
+
+function newWorld(seed=Date.now()|0, opts={}){
+  if(typeof unbindUIListeners === 'function') unbindUIListeners();
+  if(typeof unbindCanvasInputs === 'function') unbindCanvasInputs();
+  resetVolatileState();
+  // audit #38: starting stocks duplicated with state.js — defer consolidation.
+  for (const r of RESOURCE_TYPES) {
+    storageTotals[r] = 0;
+    storageReserved[r] = 0;
+  }
+  storageTotals.food = 24;
+  storageTotals.wood = 12;
+  time.tick = 0;
+  time.dayTime = 0;
+  // audit #18: reset pause/speed so a new world starts at defaults.
+  time.paused = false;
+  time.speedIdx = 1;
+  generateWorldBase(seed);
   function idc(x,y){ return y*GRID_W+x; }
   const startFootprintClear=(kind, tx, ty)=>validateFootprintPlacement(kind, tx, ty)===null;
 
@@ -471,11 +487,15 @@ function newWorld(seed=Date.now()|0){
 
   ensureDebugKitConfigured();
 
-  Toast.show('New pixel map created.');
-  Toast.show('Villagers will choose buildings and resource zones automatically.');
+  // audit #20: silent mode skips new-world toasts (used by loadGame).
+  if (!opts.silent) {
+    Toast.show('New pixel map created.');
+    Toast.show('Villagers will choose buildings and resource zones automatically.');
+  }
   centerCamera(campfire.x,campfire.y); markStaticDirty();
   if(typeof bindCanvasInputs === 'function') bindCanvasInputs();
   if(typeof bindUIListeners === 'function') bindUIListeners();
+  if(typeof syncTimeButtons === 'function') syncTimeButtons();
 }
 function addBuilding(kind,x,y,opts={}){
   const def=BUILDINGS[kind]||{};
@@ -618,9 +638,11 @@ const bindUIListeners = _uiSystem.bindUIListeners;
 const unbindUIListeners = _uiSystem.unbindUIListeners;
 const bindCanvasInputs = _uiSystem.bindCanvasInputs;
 const unbindCanvasInputs = _uiSystem.unbindCanvasInputs;
+const syncTimeButtons = _uiSystem.syncTimeButtons;
 const toTile = _uiSystem.toTile;
 bindUIListeners();
 bindCanvasInputs();
+if (typeof syncTimeButtons === 'function') syncTimeButtons();
 
 /* ==================== Automation Helpers ==================== */
 
@@ -759,7 +781,9 @@ const _saveSystem = createSaveSystem({
   normalizeExperienceLedger,
   normalizeArraySource,
   applyArrayScaled,
-  newWorld,
+  generateWorldBase,
+  resetVolatileState,
+  syncTimeButtons,
   getFootprint,
   ensureBuildingData,
   reindexAllBuildings,
@@ -1068,7 +1092,8 @@ function boot(){
     if(!loaded) newWorld();         // always create a world
     openMode('inspect');            // UI init
     if(!Storage.get('aiv_help_px3')){
-      el('help').style.display='block';
+      const helpEl = el('help');
+      if (helpEl) helpEl.style.display='block';
     }
   } catch (e){
     reportFatal(e);

--- a/src/app/canvas.js
+++ b/src/app/canvas.js
@@ -2,6 +2,11 @@ import { CAMERA_MAX_Z, CAMERA_MIN_Z, GRID_H, GRID_W, TILE } from './constants.js
 import { reportFatal } from './storage.js';
 
 const canvas = document.getElementById('game');
+if (!canvas) {
+  const err = new Error('Missing #game canvas');
+  reportFatal(err);
+  throw err;
+}
 
 function context2d(canvas, opts){
   if (!canvas || typeof canvas.getContext !== 'function'){

--- a/src/app/save.js
+++ b/src/app/save.js
@@ -27,7 +27,9 @@ export function createSaveSystem(deps) {
     normalizeExperienceLedger,
     normalizeArraySource,
     applyArrayScaled,
-    newWorld,
+    generateWorldBase,
+    resetVolatileState,
+    syncTimeButtons,
     getFootprint,
     ensureBuildingData,
     reindexAllBuildings,
@@ -131,7 +133,12 @@ export function createSaveSystem(deps) {
           console.warn('AIV loadGame: ' + name + ' layer length ' + arr.length + ' does not match expected ' + expectedLen + ' (upscaleFactor=' + upscaleFactor + ')');
         }
       }
-      newWorld(Number.isFinite(d.seed) ? d.seed : undefined);
+      // audit #21: clear volatile state and rebuild base terrain only.
+      // Avoid newWorld() so we don't spawn transient villagers/animals
+      // that the load path immediately discards (and silences the
+      // misleading "New pixel map created." toasts — audit #20).
+      if (typeof resetVolatileState === 'function') resetVolatileState();
+      generateWorldBase(Number.isFinite(d.seed) ? d.seed : undefined);
       const world = getWorld();
       const buildings = getBuildings();
       const villagers = getVillagers();
@@ -247,6 +254,8 @@ export function createSaveSystem(deps) {
       });
       if (toast && typeof toast.show === 'function') toast.show('Loaded.');
       markStaticDirty();
+      // audit #19: refresh pause/speed UI so loaded state is visible.
+      if (typeof syncTimeButtons === 'function') syncTimeButtons();
       return true;
     } catch (e) {
       console.error(e);

--- a/src/app/storage.js
+++ b/src/app/storage.js
@@ -188,6 +188,7 @@ if (typeof window !== 'undefined') {
 
 if (AIV_SCOPE && typeof AIV_SCOPE === 'object') {
   AIV_SCOPE.AIV_STORAGE = Storage;
+  AIV_SCOPE.reportFatal = reportFatal;
 }
 
 export {

--- a/src/app/ui.js
+++ b/src/app/ui.js
@@ -14,6 +14,13 @@ export function createUISystem(deps) {
 
   const el = (id) => document.getElementById(id);
 
+  function safeOn(node, event, fn, opts) {
+    if (node && typeof node.addEventListener === 'function') node.addEventListener(event, fn, opts);
+  }
+  function safeOff(node, event, fn, opts) {
+    if (node && typeof node.removeEventListener === 'function') node.removeEventListener(event, fn, opts);
+  }
+
   const host = document.createElement('div');
   host.id = 'toastHost';
   host.style.cssText = `
@@ -108,15 +115,20 @@ export function createUISystem(deps) {
     btnSave.title = 'Saving unavailable in this context';
   }
 
+  function syncTimeButtons() {
+    if (uiRefs.btnPause) uiRefs.btnPause.textContent = time.paused ? '▶️' : '⏸';
+    if (uiRefs.btnSpeed) uiRefs.btnSpeed.textContent = SPEEDS[time.speedIdx] + '×';
+  }
   function onPauseClick() {
     time.paused = !time.paused;
-    uiRefs.btnPause.textContent = time.paused ? '▶️' : '⏸';
+    syncTimeButtons();
   }
   function onSpeedClick() {
     time.speedIdx = (time.speedIdx + 1) % SPEEDS.length;
-    uiRefs.btnSpeed.textContent = SPEEDS[time.speedIdx] + '×';
+    syncTimeButtons();
   }
   function onPriorClick() {
+    if (!uiRefs.sheetPrior) return;
     const open = uiRefs.sheetPrior.getAttribute('data-open') === 'true';
     toggleSheet('sheetPrior', !open);
   }
@@ -127,6 +139,7 @@ export function createUISystem(deps) {
   }
   function onNewClick() { newWorld(); }
   function onHelpCloseClick() {
+    if (!uiRefs.help) return;
     uiRefs.help.style.display = 'none';
     Storage.set('aiv_help_px3', '1');
   }
@@ -152,34 +165,34 @@ export function createUISystem(deps) {
   let uiListenersBound = false;
   function bindUIListeners() {
     if (uiListenersBound) return;
-    uiRefs.btnPause.addEventListener('click', onPauseClick);
-    uiRefs.btnSpeed.addEventListener('click', onSpeedClick);
-    uiRefs.btnPrior.addEventListener('click', onPriorClick);
-    uiRefs.btnSave.addEventListener('click', onSaveClick);
-    uiRefs.btnNew.addEventListener('click', onNewClick);
-    uiRefs.btnHelpClose.addEventListener('click', onHelpCloseClick);
-    uiRefs.sheetPrior.addEventListener('click', onSheetPriorClick);
+    safeOn(uiRefs.btnPause, 'click', onPauseClick);
+    safeOn(uiRefs.btnSpeed, 'click', onSpeedClick);
+    safeOn(uiRefs.btnPrior, 'click', onPriorClick);
+    safeOn(uiRefs.btnSave, 'click', onSaveClick);
+    safeOn(uiRefs.btnNew, 'click', onNewClick);
+    safeOn(uiRefs.btnHelpClose, 'click', onHelpCloseClick);
+    safeOn(uiRefs.sheetPrior, 'click', onSheetPriorClick);
     document.addEventListener('click', onDocumentClick);
     window.addEventListener('keydown', onKeyDown);
-    uiRefs.prioFood.addEventListener('input', onPrioFoodInput);
-    uiRefs.prioBuild.addEventListener('input', onPrioBuildInput);
-    uiRefs.prioExplore.addEventListener('input', onPrioExploreInput);
+    safeOn(uiRefs.prioFood, 'input', onPrioFoodInput);
+    safeOn(uiRefs.prioBuild, 'input', onPrioBuildInput);
+    safeOn(uiRefs.prioExplore, 'input', onPrioExploreInput);
     uiListenersBound = true;
   }
   function unbindUIListeners() {
     if (!uiListenersBound) return;
-    uiRefs.btnPause.removeEventListener('click', onPauseClick);
-    uiRefs.btnSpeed.removeEventListener('click', onSpeedClick);
-    uiRefs.btnPrior.removeEventListener('click', onPriorClick);
-    uiRefs.btnSave.removeEventListener('click', onSaveClick);
-    uiRefs.btnNew.removeEventListener('click', onNewClick);
-    uiRefs.btnHelpClose.removeEventListener('click', onHelpCloseClick);
-    uiRefs.sheetPrior.removeEventListener('click', onSheetPriorClick);
+    safeOff(uiRefs.btnPause, 'click', onPauseClick);
+    safeOff(uiRefs.btnSpeed, 'click', onSpeedClick);
+    safeOff(uiRefs.btnPrior, 'click', onPriorClick);
+    safeOff(uiRefs.btnSave, 'click', onSaveClick);
+    safeOff(uiRefs.btnNew, 'click', onNewClick);
+    safeOff(uiRefs.btnHelpClose, 'click', onHelpCloseClick);
+    safeOff(uiRefs.sheetPrior, 'click', onSheetPriorClick);
     document.removeEventListener('click', onDocumentClick);
     window.removeEventListener('keydown', onKeyDown);
-    uiRefs.prioFood.removeEventListener('input', onPrioFoodInput);
-    uiRefs.prioBuild.removeEventListener('input', onPrioBuildInput);
-    uiRefs.prioExplore.removeEventListener('input', onPrioExploreInput);
+    safeOff(uiRefs.prioFood, 'input', onPrioFoodInput);
+    safeOff(uiRefs.prioBuild, 'input', onPrioBuildInput);
+    safeOff(uiRefs.prioExplore, 'input', onPrioExploreInput);
     uiListenersBound = false;
   }
 
@@ -306,6 +319,7 @@ export function createUISystem(deps) {
     unbindUIListeners,
     bindCanvasInputs,
     unbindCanvasInputs,
+    syncTimeButtons,
     toTile,
     screenToWorld,
     pointerScale

--- a/tests/ui.runtime.phase7.test.js
+++ b/tests/ui.runtime.phase7.test.js
@@ -1,0 +1,251 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// Phase 7 covers UI/runtime robustness. ui.js → canvas.js touches
+// `document` and `window` at module load, and save.js's storage
+// import inspects `globalThis.localStorage`. Provide minimal stubs
+// before any dynamic import. Tests share these modules; per-test
+// state is isolated by mutating `_stubElements` and creating fresh
+// systems via `createUISystem` / `createSaveSystem`.
+
+const _stubElements = {};
+const _localStorageData = {};
+
+function makeFakeEl(extra = {}) {
+  const attrs = {};
+  const listeners = {};
+  return {
+    listeners,
+    textContent: '',
+    style: { cssText: '', display: '', cursor: '', touchAction: '' },
+    dataset: {},
+    classList: {
+      toggle() {},
+      add() {},
+      remove() {},
+    },
+    setAttribute(k, v) { attrs[k] = v; },
+    getAttribute(k) { return Object.prototype.hasOwnProperty.call(attrs, k) ? attrs[k] : null; },
+    addEventListener(ev, fn) { (listeners[ev] = listeners[ev] || []).push(fn); },
+    removeEventListener(ev, fn) {
+      if (!listeners[ev]) return;
+      const i = listeners[ev].indexOf(fn);
+      if (i >= 0) listeners[ev].splice(i, 1);
+    },
+    appendChild() {},
+    removeChild() {},
+    replaceChildren() {},
+    remove() {},
+    closest() { return null; },
+    setPointerCapture() {},
+    getContext: () => ({ imageSmoothingEnabled: true }),
+    getBoundingClientRect: () => ({ width: 800, height: 600, left: 0, top: 0 }),
+    width: 0,
+    height: 0,
+    disabled: false,
+    title: '',
+    id: '',
+    ...extra,
+  };
+}
+
+function ensureBrowserStubs() {
+  if (!globalThis.localStorage) {
+    globalThis.localStorage = {
+      getItem(k) { return Object.prototype.hasOwnProperty.call(_localStorageData, k) ? _localStorageData[k] : null; },
+      setItem(k, v) { _localStorageData[k] = String(v); },
+      removeItem(k) { delete _localStorageData[k]; },
+    };
+  }
+  if (!globalThis.document) {
+    globalThis.document = {
+      body: makeFakeEl(),
+      documentElement: makeFakeEl(),
+      readyState: 'complete',
+      addEventListener() {},
+      removeEventListener() {},
+      createElement: () => makeFakeEl(),
+      querySelectorAll: () => [],
+      getElementById(id) {
+        if (Object.prototype.hasOwnProperty.call(_stubElements, id)) return _stubElements[id];
+        // canvas.js requires #game to be non-null at module load.
+        return makeFakeEl({ id });
+      },
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = {
+      devicePixelRatio: 1,
+      addEventListener() {},
+      removeEventListener() {},
+      __AIV_BOOT__: false,
+    };
+  }
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const { createUISystem } = await import('../src/app/ui.js');
+const { createSaveSystem } = await import('../src/app/save.js');
+const { SPEEDS, SAVE_KEY, SAVE_VERSION } = await import('../src/app/constants.js');
+
+function makeUI({ overrides = {}, time = { paused: false, speedIdx: 1 } } = {}) {
+  // Reset element overrides per call so each createUISystem caches fresh refs.
+  for (const k of Object.keys(_stubElements)) delete _stubElements[k];
+  Object.assign(_stubElements, overrides);
+  const policy = { sliders: { food: 0.7, build: 0.5, explore: 0.3 } };
+  return {
+    sys: createUISystem({
+      policy,
+      time,
+      saveGame: () => {},
+      newWorld: () => {},
+    }),
+    time,
+    refs: overrides,
+  };
+}
+
+test('syncTimeButtons reflects current time state on btnPause and btnSpeed', () => {
+  const btnPause = makeFakeEl();
+  const btnSpeed = makeFakeEl();
+  const time = { paused: false, speedIdx: 1 };
+  const { sys } = makeUI({ overrides: { btnPause, btnSpeed }, time });
+
+  sys.syncTimeButtons();
+  assert.equal(btnPause.textContent, '⏸');
+  assert.equal(btnSpeed.textContent, SPEEDS[1] + '×');
+
+  time.paused = true;
+  time.speedIdx = 2;
+  sys.syncTimeButtons();
+  assert.equal(btnPause.textContent, '▶️');
+  assert.equal(btnSpeed.textContent, SPEEDS[2] + '×');
+});
+
+test('syncTimeButtons is null-safe when time buttons are missing', () => {
+  const { sys } = makeUI({ overrides: { btnPause: null, btnSpeed: null } });
+  assert.doesNotThrow(() => sys.syncTimeButtons());
+});
+
+test('bindUIListeners and unbindUIListeners do not throw when refs are null', () => {
+  const { sys } = makeUI({
+    overrides: {
+      btnPause: null, btnSpeed: null, btnPrior: null,
+      btnSave: null, btnNew: null, btnHelpClose: null,
+      sheetPrior: null, prioFood: null, prioBuild: null, prioExplore: null,
+    },
+  });
+  assert.doesNotThrow(() => sys.bindUIListeners());
+  assert.doesNotThrow(() => sys.unbindUIListeners());
+  // Idempotent: a second call should also not throw.
+  assert.doesNotThrow(() => sys.bindUIListeners());
+});
+
+test('onPriorClick (registered via bindUIListeners) is null-safe when sheetPrior is missing', () => {
+  const btnPrior = makeFakeEl();
+  // Provide btnPrior so bindUIListeners can attach the click handler,
+  // but leave sheetPrior unset (null) so the handler must guard.
+  const { sys } = makeUI({ overrides: { btnPrior, sheetPrior: null } });
+  sys.bindUIListeners();
+  const handlers = btnPrior.listeners.click || [];
+  assert.ok(handlers.length >= 1, 'onPriorClick should be registered on btnPrior');
+  assert.doesNotThrow(() => handlers[0]({ target: btnPrior }));
+});
+
+test('onPauseClick mutates time and updates btnPause via syncTimeButtons', () => {
+  const btnPause = makeFakeEl();
+  const btnSpeed = makeFakeEl();
+  const time = { paused: false, speedIdx: 1 };
+  const { sys } = makeUI({ overrides: { btnPause, btnSpeed }, time });
+  sys.bindUIListeners();
+  const handler = btnPause.listeners.click[0];
+  handler({});
+  assert.equal(time.paused, true);
+  assert.equal(btnPause.textContent, '▶️');
+  handler({});
+  assert.equal(time.paused, false);
+  assert.equal(btnPause.textContent, '⏸');
+});
+
+test('loadGame routes through generateWorldBase + resetVolatileState (not newWorld) and calls syncTimeButtons', () => {
+  // Pre-populate Storage with a minimal valid save under SAVE_KEY.
+  const minimalSave = {
+    saveVersion: SAVE_VERSION,
+    seed: 12345,
+    tiles: [], zone: [], trees: [], rocks: [], berries: [], growth: [],
+    season: 0, tSeason: 0,
+    buildings: [],
+    storageTotals: {},
+    storageReserved: {},
+    villagers: [],
+    animals: [],
+  };
+  globalThis.localStorage.setItem(SAVE_KEY, JSON.stringify(minimalSave));
+
+  const calls = { generateWorldBase: [], resetVolatileState: 0, syncTimeButtons: 0 };
+  // Fresh world object the save layers can apply onto.
+  const fakeWorld = {
+    tiles: new Uint8Array(0),
+    zone: new Uint8Array(0),
+    trees: new Uint8Array(0),
+    rocks: new Uint8Array(0),
+    berries: new Uint8Array(0),
+    growth: new Uint8Array(0),
+    season: 0, tSeason: 0,
+  };
+  const buildings = [];
+  const villagers = [];
+  const animals = [];
+  const storageTotals = {};
+  const storageReserved = {};
+  const toastShown = [];
+
+  const sys = createSaveSystem({
+    getWorld: () => fakeWorld,
+    getBuildings: () => buildings,
+    getVillagers: () => villagers,
+    getAnimals: () => animals,
+    getStorageTotals: () => storageTotals,
+    getStorageReserved: () => storageReserved,
+    getTick: () => 0,
+    starveThresh: { hungry: 0.4, starving: 0.6, sick: 0.8 },
+    childhoodTicks: 100,
+    ensureVillagerNumber: (v, n) => { v.displayNumber = n || 1; return v.displayNumber; },
+    normalizeExperienceLedger: () => null,
+    normalizeArraySource: (a) => Array.isArray(a) ? a : [],
+    applyArrayScaled: () => {},
+    generateWorldBase: (seed) => { calls.generateWorldBase.push(seed); },
+    resetVolatileState: () => { calls.resetVolatileState++; },
+    syncTimeButtons: () => { calls.syncTimeButtons++; },
+    getFootprint: () => ({ w: 1, h: 1 }),
+    ensureBuildingData: () => {},
+    reindexAllBuildings: () => {},
+    markEmittersDirty: () => {},
+    refreshWaterRowMaskFromTiles: () => {},
+    refreshZoneRowMask: () => {},
+    markZoneOverlayDirty: () => {},
+    markStaticDirty: () => {},
+    toast: { show: (msg) => toastShown.push(msg) },
+  });
+
+  const ok = sys.loadGame();
+  assert.equal(ok, true, 'loadGame should return true');
+  assert.deepEqual(calls.generateWorldBase, [12345], 'generateWorldBase called once with saved seed');
+  assert.equal(calls.resetVolatileState, 1, 'resetVolatileState called exactly once');
+  assert.equal(calls.syncTimeButtons, 1, 'syncTimeButtons called exactly once');
+  // The misleading new-world toasts must not fire on load.
+  assert.ok(!toastShown.includes('New pixel map created.'));
+  assert.ok(toastShown.includes('Loaded.'));
+});


### PR DESCRIPTION
Resolves audit issues #18, #19, #20, #21, #22, #23, #24, #25.

- src/app/storage.js exposes reportFatal on AIV_SCOPE so main.js's
  early-boot fallback can reach the fatal overlay (#22).
- src/app/canvas.js throws after reportFatal if #game is missing,
  before any canvas.style deref (#23).
- src/app/ui.js adds safeOn/safeOff helpers; bindUIListeners /
  unbindUIListeners route every uiRefs.* binding through them.
  onPriorClick, onPauseClick, onSpeedClick, onHelpCloseClick guard
  against null refs (#24, #25).
- syncTimeButtons() exposed from createUISystem; click handlers
  route through it; called after newWorld, after the boot-time
  bindUIListeners(), and at the end of loadGame so pause/speed
  buttons stay in sync across all paths (#19).
- newWorld resets time.paused / time.speedIdx to defaults (#18) and
  accepts opts.silent that gates the new-world toasts (#20).
- newWorld factored into generateWorldBase(seed) (pure terrain)
  and resetVolatileState(); both passed as deps to createSaveSystem.
  loadGame now calls resetVolatileState() then generateWorldBase()
  directly — no transient villagers/animals spawn during load (#21).
- src/app.js boot() null-checks el('help').

Tests: tests/ui.runtime.phase7.test.js. Six new cases covering
syncTimeButtons rendering and null-safety, bindUIListeners /
unbindUIListeners null-safety, onPriorClick null-safety,
onPauseClick → syncTimeButtons round-trip, and loadGame routing
through generateWorldBase + resetVolatileState (not newWorld) with
no misleading new-world toast.

Deferred: time.paused / time.speedIdx are still not part of the
save schema (issue #3, out of phase 7 scope).

https://claude.ai/code/session_01XnkjvHgGBb7xDDJz6yTPUS