### PR TITLE
Phase 4: mood / scoring correctness

### DIFF
--- a/src/ai/scoring.js
+++ b/src/ai/scoring.js
@@ -88,7 +88,6 @@ export function score(job, villager, policy, blackboard) {
     : workerRoleBonus * 2;
   const energyFatigueThreshold = Number.isFinite(style.energyFatigueThreshold) ? style.energyFatigueThreshold : 0.32;
   const energyHeavyJobPenalty = Number.isFinite(style.energyHeavyJobPenalty) ? style.energyHeavyJobPenalty : 0;
-  const energyRestBonus = Number.isFinite(style.energyRestBonus) ? style.energyRestBonus : 0;
   const seasonWinterHarvestLead = Number.isFinite(style.seasonWinterHarvestLead) ? style.seasonWinterHarvestLead : 0.25;
   const seasonHarvestWinterBonus = Number.isFinite(style.seasonHarvestWinterBonus) ? style.seasonHarvestWinterBonus : 0;
   const seasonWinterSowPenalty = Number.isFinite(style.seasonWinterSowPenalty) ? style.seasonWinterSowPenalty : 0;
@@ -164,9 +163,6 @@ export function score(job, villager, policy, blackboard) {
     const penalty = clamp(deficit / Math.max(energyFatigueThreshold, 0.0001), 0, 1) * energyHeavyJobPenalty;
     if (HEAVY_JOB_TYPES.has(job.type)) {
       value -= penalty;
-    }
-    if (job.type === 'rest') {
-      value += penalty * energyRestBonus;
     }
   }
 

--- a/src/app/villagerTick.js
+++ b/src/app/villagerTick.js
@@ -157,7 +157,6 @@ export function createVillagerTick(opts) {
     if (wellFed && wellRested) {
       happyDelta += 0.0008 + Math.max(0, v.energy - 0.55) * 0.0006;
     }
-    energyDelta += moodEnergyBoost;
     if (hydratedBuff) {
       energyDelta *= HYDRATION_FATIGUE_BONUS;
       happyDelta += HYDRATION_MOOD_TICK * 0.5;
@@ -165,6 +164,7 @@ export function createVillagerTick(opts) {
       energyDelta *= HYDRATION_DEHYDRATED_PENALTY;
       happyDelta -= HYDRATION_MOOD_TICK;
     }
+    energyDelta += moodEnergyBoost;
     if (resting) {
       energyDelta += REST_ENERGY_RECOVERY;
       happyDelta += REST_MOOD_TICK;

--- a/src/app/world.js
+++ b/src/app/world.js
@@ -1,7 +1,7 @@
 import { GRID_W, GRID_H, TILES } from './constants.js';
 
 export const BUILDINGS = {
-  campfire: { label: 'Campfire', cost: 0, wood: 0, stone: 0, effects: { radius: 4, moodBonus: 0.0011 }, tooltip: 'Villagers gather here at night; warms and cheers everyone within 4 tiles.' },
+  campfire: { label: 'Campfire', cost: 0, wood: 0, stone: 0, effects: { radius: 4 }, tooltip: 'Villagers gather here at night; warms and cheers everyone within 4 tiles.' },
   storage:  { label: 'Storage',  cost: 8, wood: 8, stone: 0 },
   hut:      { label: 'Hut',      cost: 10, wood: 10, stone: 0, effects: { radius: 3, moodBonus: 0.0008 }, tooltip: 'Shelter that gently lifts moods nearby.' },
   hunterLodge: {
@@ -250,7 +250,6 @@ export function agricultureBonusesAt(buildings, x, y) {
       const influence = influenceFor(radius, dist);
       if (influence <= 0) continue;
       if (eff.hydrationGrowthBonus) { growthBonus += eff.hydrationGrowthBonus * influence; }
-      if (eff.harvestBonus) { harvestBonus += eff.harvestBonus * influence; }
       if (eff.moodBonus) { moodBonus += eff.moodBonus * influence; }
     } else if (eff.moodBonus) {
       const radius = (eff.radius | 0);

--- a/src/policy/policy.js
+++ b/src/policy/policy.js
@@ -42,7 +42,6 @@ const DEFAULT_JOB_STYLE = Object.freeze({
   restEnergyThreshold: 0.26,
   restFatigueBoost: 0.04,
   energyHeavyJobPenalty: 0.25,
-  energyRestBonus: 0.15,
   seasonWinterHarvestLead: 0.25,
   seasonHarvestWinterBonus: 0.08,
   seasonWinterSowPenalty: 0.1,

--- a/tests/mood.campfire.phase4.test.js
+++ b/tests/mood.campfire.phase4.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { BUILDINGS, agricultureBonusesAt } from '../src/app/world.js';
+
+function makeBuilding(kind, overrides = {}) {
+  return { id: 1, kind, x: 0, y: 0, built: 1, ...overrides };
+}
+
+test('B26: campfire effects no longer carry moodBonus (passive mood removed)', () => {
+  // The campfire's passive moodBonus was being triple-counted with the
+  // `nearbyWarmth` warm flag and NIGHT_CAMPFIRE_MOOD_TICK. The fix removes the
+  // moodBonus from the campfire's effects so agricultureBonusesAt no longer
+  // contributes a third source.
+  assert.equal(BUILDINGS.campfire.effects.moodBonus, undefined,
+    'campfire must not declare moodBonus in effects');
+  assert.equal(BUILDINGS.campfire.effects.radius, 4,
+    'campfire radius preserved for CAMPFIRE_EFFECT_RADIUS');
+});
+
+test('B26: agricultureBonusesAt returns zero moodBonus from a campfire', () => {
+  const buildings = [makeBuilding('campfire', { x: 5, y: 5 })];
+  // Tile right next to the campfire footprint — well inside its radius=4.
+  const bonuses = agricultureBonusesAt(buildings, 5, 5);
+  assert.equal(bonuses.moodBonus, 0, 'campfire must not contribute passive moodBonus');
+  assert.equal(bonuses.growthBonus, 0);
+  assert.equal(bonuses.harvestBonus, 0);
+});
+
+test('B26: huts still contribute passive moodBonus via agricultureBonusesAt', () => {
+  // Regression guard: only the campfire was supposed to lose its passive
+  // moodBonus. Huts and wells must remain mood sources.
+  const buildings = [makeBuilding('hut', { x: 5, y: 5 })];
+  const bonuses = agricultureBonusesAt(buildings, 5, 5);
+  assert.ok(bonuses.moodBonus > 0, 'hut must still contribute moodBonus');
+});

--- a/tests/mood.hydration.phase4.test.js
+++ b/tests/mood.hydration.phase4.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// Mirrors the energy-delta composition at src/app/villagerTick.js:146-167
+// after the B8 fix. The fix multiplies the hydration factor against the drain
+// only, then adds the mood-energy boost — so the mood term must contribute
+// identically regardless of hydration state.
+const ENERGY_DRAIN_BASE = 0.0011;
+const HYDRATION_FATIGUE_BONUS = 0.8;
+const HYDRATION_DEHYDRATED_PENALTY = 1.12;
+
+function computeEnergyDelta({ moodEnergyBoost, hydratedBuff, dehydrated }) {
+  let energyDelta = -ENERGY_DRAIN_BASE;
+  if (hydratedBuff) energyDelta *= HYDRATION_FATIGUE_BONUS;
+  else if (dehydrated) energyDelta *= HYDRATION_DEHYDRATED_PENALTY;
+  energyDelta += moodEnergyBoost;
+  return energyDelta;
+}
+
+test('B8: mood-energy boost adds linearly regardless of hydration state', () => {
+  const moodEnergyBoost = 0.00045; // happy=1.0, moodMotivation*0.00045
+  const cases = [
+    { hydratedBuff: false, dehydrated: false, label: 'neutral' },
+    { hydratedBuff: true, dehydrated: false, label: 'hydrated' },
+    { hydratedBuff: false, dehydrated: true, label: 'dehydrated' },
+  ];
+  for (const c of cases) {
+    const withBoost = computeEnergyDelta({ ...c, moodEnergyBoost });
+    const withoutBoost = computeEnergyDelta({ ...c, moodEnergyBoost: 0 });
+    assert.ok(Math.abs((withBoost - withoutBoost) - moodEnergyBoost) < 1e-12,
+      `${c.label}: mood boost contribution must equal moodEnergyBoost (got ${withBoost - withoutBoost})`);
+  }
+});
+
+test('B8: hydration multiplies the drain only, not the mood boost', () => {
+  const moodEnergyBoost = 0.00045;
+  const hydrated = computeEnergyDelta({ moodEnergyBoost, hydratedBuff: true, dehydrated: false });
+  const expected = -ENERGY_DRAIN_BASE * HYDRATION_FATIGUE_BONUS + moodEnergyBoost;
+  assert.ok(Math.abs(hydrated - expected) < 1e-12,
+    `hydrated delta must be drain*0.8 + mood boost, got ${hydrated}, expected ${expected}`);
+});
+
+test('B8: happy + hydrated villager strictly drains less than unhappy + hydrated', () => {
+  // The pre-fix bug had the hydration multiplier scale the mood boost too,
+  // shrinking happy villagers' net gain. Post-fix, mood boost is unaffected,
+  // so a happy villager always nets a more positive (less negative) delta
+  // than an unhappy one at the same hydration.
+  const happyHydrated = computeEnergyDelta({ moodEnergyBoost: 0.00045, hydratedBuff: true, dehydrated: false });
+  const unhappyHydrated = computeEnergyDelta({ moodEnergyBoost: -0.00045, hydratedBuff: true, dehydrated: false });
+  assert.ok(happyHydrated > unhappyHydrated,
+    `happy+hydrated (${happyHydrated}) must drain less than unhappy+hydrated (${unhappyHydrated})`);
+  // And the difference equals 2*moodEnergyBoost (linear contribution).
+  assert.ok(Math.abs((happyHydrated - unhappyHydrated) - 0.0009) < 1e-12,
+    'mood boost difference must contribute linearly');
+});

--- a/tests/scoring.noRestBranch.phase4.test.js
+++ b/tests/scoring.noRestBranch.phase4.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// scoring.js → simulation.js → environment.js asserts on AIV_TERRAIN /
+// AIV_CONFIG at module-load time. Mirror the stubs other tests use.
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = {
+      getElementById: () => ({
+        getContext: () => ({ imageSmoothingEnabled: true }),
+        getBoundingClientRect: () => ({ width: 800, height: 600 }),
+        style: {},
+        width: 0,
+        height: 0,
+      }),
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  }
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const { policy } = await import('../src/policy/policy.js');
+const { score } = await import('../src/ai/scoring.js');
+
+test('B10: energyRestBonus removed from policy.style.jobScoring', () => {
+  assert.ok(!('energyRestBonus' in policy.style.jobScoring),
+    'energyRestBonus knob must be deleted from DEFAULT_JOB_STYLE');
+});
+
+test('B10: scoring a "rest"-type job for a fatigued villager does not throw', () => {
+  // Rest is not a real job type — the audit removed the dead branch.
+  // This test guards against accidentally re-adding rest-specific scoring,
+  // and verifies the function still produces a finite score for a job whose
+  // type doesn't match any branch.
+  const job = { type: 'rest', prio: 0.5, distance: 0 };
+  const villager = { x: 0, y: 0, energy: 0.1, happy: 0.5, hunger: 0.3 };
+  const value = score(job, villager, policy, null);
+  assert.ok(Number.isFinite(value), `score must be finite, got ${value}`);
+});
+
+test('B10: a fatigued villager scoring a heavy job still incurs the heavy penalty', () => {
+  // Regression guard for the surrounding fatigue branch — only the rest-type
+  // sub-branch was removed; the heavy-job penalty path must still fire.
+  const lowEnergyVillager = { x: 0, y: 0, energy: 0.1, happy: 0.5, hunger: 0.3 };
+  const restedVillager = { x: 0, y: 0, energy: 0.9, happy: 0.5, hunger: 0.3 };
+  const heavyJob = { type: 'chop', prio: 0.5, distance: 0 };
+  const lowScore = score(heavyJob, lowEnergyVillager, policy, null);
+  const highScore = score(heavyJob, restedVillager, policy, null);
+  assert.ok(highScore > lowScore,
+    `rested villager must score heavy job higher than fatigued (low=${lowScore}, high=${highScore})`);
+});

--- a/tests/world.wellBonuses.phase4.test.js
+++ b/tests/world.wellBonuses.phase4.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { BUILDINGS, agricultureBonusesAt } from '../src/app/world.js';
+
+function makeBuilding(kind, overrides = {}) {
+  return { id: 1, kind, x: 0, y: 0, built: 1, ...overrides };
+}
+
+test('B12: well effects do not declare harvestBonus', () => {
+  // The dead branch in agricultureBonusesAt's well case checked for a field
+  // that no well effect actually defines. This test fails if someone adds
+  // harvestBonus to wells without also reinstating the read.
+  assert.equal(BUILDINGS.well.effects.harvestBonus, undefined,
+    'well must not declare harvestBonus');
+});
+
+test('B12: agricultureBonusesAt over a well returns harvestBonus = 0', () => {
+  const buildings = [makeBuilding('well', { x: 5, y: 5 })];
+  const bonuses = agricultureBonusesAt(buildings, 5, 5);
+  assert.equal(bonuses.harvestBonus, 0, 'well must not contribute harvestBonus');
+  assert.ok(bonuses.growthBonus > 0, 'well must contribute hydrationGrowthBonus');
+  assert.ok(bonuses.moodBonus > 0, 'well must contribute moodBonus');
+});
+
+test('B12: well outside hydration radius returns no bonuses', () => {
+  const buildings = [makeBuilding('well', { x: 5, y: 5 })];
+  const bonuses = agricultureBonusesAt(buildings, 50, 50);
+  assert.equal(bonuses.harvestBonus, 0);
+  assert.equal(bonuses.growthBonus, 0);
+  assert.equal(bonuses.moodBonus, 0);
+});


### PR DESCRIPTION
Per AI_VILLAGE_FIX_PLAN.md Phase 4, fix four input-counting bugs so mood
and job-scoring compose against the Phase 3 baselines correctly.

- B26: Stop triple-counting campfire mood. The `warm` flag, the
  agriculture-pass `moodBonus`, and the night-only campfire tick all
  fired for the same fire. Remove `moodBonus` from the campfire's effects
  so `agricultureBonusesAt` no longer contributes; the warm flag and
  NIGHT_CAMPFIRE_MOOD_TICK remain the two authoritative sources.
- B8: Hydration multiplier now scales the energy drain only, not the
  mood-energy bonus. Reorder villagerTick so the hydration factor is
  applied before moodEnergyBoost is added.
- B10: Remove the dead `job.type === 'rest'` branch in scoring.js and
  delete the corresponding `energyRestBonus` knob from policy. Rest is
  not a real job type.
- B12: Drop the dead `eff.harvestBonus` check in the well case of
  `agricultureBonusesAt`. Wells declare hydrationGrowthBonus and
  moodBonus only.

New tests cover each fix:
- tests/mood.campfire.phase4.test.js
- tests/mood.hydration.phase4.test.js
- tests/world.wellBonuses.phase4.test.js
- tests/scoring.noRestBranch.phase4.test.js

`npm run lint` clean (pre-existing planner.js warning unchanged) and
`npm test` 63/63 pass.

https://claude.ai/code/session_0135VaKGA8d1JpFKWWGJU9JC