### PR TITLE
Phase 5: job-system correctness

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ import {
   GRID_SIZE,
   GRID_W,
   RESOURCE_TYPES,
+  RIPE_THRESHOLD,
   TILE,
   TILES,
   ZONES,
@@ -704,7 +705,7 @@ function seasonTick(){
     const next=Math.min(240, prev+delta);
     world.growth[i]=next;
     // Slightly earlier harvest window so ripe food gets picked before withering.
-    if(prev<150 && next>=150){
+    if(prev<RIPE_THRESHOLD && next>=RIPE_THRESHOLD){
       if(!violatesSpacing(x,y,'harvest',creationCfg)){
         addJob({type:'harvest',x,y, prio:0.65+(policy.sliders.food||0)*0.6});
       }

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -107,6 +107,11 @@ const ANIMAL_TYPES = {
 };
 const HUNT_RANGE = 3.5;
 const HUNT_RETRY_COOLDOWN = 140;
+// Crops are harvest-ready at this growth value. Used by both the planner's
+// harvest-job emit scan and `hasRipeCrops()` so the two stay in sync — a
+// mismatch caused B2/S8/S9 (forage jobs scheduled on top of harvest in the
+// 150–160 window).
+const RIPE_THRESHOLD = 150;
 const ANIMAL_BEHAVIORS = {
   deer: {
     roamRadius: 4,
@@ -188,6 +193,7 @@ export {
   LIGHT_VECTOR_LENGTH,
   LAYER_ORDER,
   RESOURCE_TYPES,
+  RIPE_THRESHOLD,
   SAVE_KEY,
   SAVE_MIGRATIONS,
   SAVE_VERSION,

--- a/src/app/planner.js
+++ b/src/app/planner.js
@@ -3,6 +3,7 @@ import {
   GRID_H,
   GRID_W,
   ITEM,
+  RIPE_THRESHOLD,
   TILES,
   ZONES
 } from './constants.js';
@@ -802,7 +803,7 @@ export function createPlanner(opts) {
     return best;
   }
 
-  function hasRipeCrops(threshold = 160) {
+  function hasRipeCrops(threshold = RIPE_THRESHOLD) {
     const world = state.world;
     if (!world || !world.growth || !world.tiles) return false;
     for (let i = 0; i < world.growth.length; i++) {
@@ -817,7 +818,7 @@ export function createPlanner(opts) {
     let count = 0;
     for (let i = 0; i < world.tiles.length; i++) {
       if (world.tiles[i] === TILES.FARMLAND
-        && world.growth[i] > 0 && world.growth[i] < 150) count++;
+        && world.growth[i] > 0 && world.growth[i] < RIPE_THRESHOLD) count++;
     }
     return count;
   }
@@ -901,7 +902,7 @@ export function createPlanner(opts) {
         // idempotent each planner pass.
         if (allowHarvest
           && world.tiles[i] === TILES.FARMLAND
-          && world.growth[i] >= 150
+          && world.growth[i] >= RIPE_THRESHOLD
           && !violatesSpacing(x, y, 'harvest', creationCfg)) {
           addJob({ type: 'harvest', x, y, prio: 0.65 + (policy.sliders.food || 0) * 0.6 });
         }
@@ -1030,5 +1031,5 @@ export function createPlanner(opts) {
     }
   }
 
-  return { planZones, planBuildings, generateJobs };
+  return { planZones, planBuildings, generateJobs, hasRipeCrops };
 }

--- a/src/app/villagerAI.js
+++ b/src/app/villagerAI.js
@@ -38,7 +38,7 @@ export function createVillagerAI(opts) {
     Toast,
     addJob: _addJob, // unused but kept for symmetry; pickJobFor doesn't add jobs directly
     finishJob,
-    noteJobAssignmentChanged: _noteJobAssignmentChanged,
+    noteJobAssignmentChanged,
     availableToReserve: _availableToReserve,
     reserveMaterials,
     releaseReservedMaterials,
@@ -52,7 +52,6 @@ export function createVillagerAI(opts) {
   } = opts;
 
   void _addJob;
-  void _noteJobAssignmentChanged;
   void _availableToReserve;
   void _getBuildingById;
 
@@ -198,6 +197,19 @@ export function createVillagerAI(opts) {
     const cooldown = Math.max(8, Math.min(22, target.path.length + 6));
     v._nextPathTick = tick + cooldown;
     if (target.kind === 'berry') {
+      // Attach an existing planner-emitted forage job at this tile so the
+      // arrival path's finishJob(remove=true) cleans it up. Without this,
+      // the queue accumulates orphaned forage jobs at picked-empty tiles.
+      const existing = jobs.find(j =>
+        j && j.type === 'forage'
+        && j.targetI === target.targetI
+        && (j.assigned || 0) < 1
+      );
+      if (existing) {
+        v.targetJob = existing;
+        existing.assigned = (existing.assigned || 0) + 1;
+        noteJobAssignmentChanged(existing);
+      }
       v.state = 'forage';
       v.targetI = target.targetI;
       v.thought = moodThought(v, 'Foraging');
@@ -542,6 +554,15 @@ export function createVillagerAI(opts) {
     let distance;
     if (j.type === 'build') {
       distance = buildTarget ? distanceToFootprint(v.x | 0, v.y | 0, buildTarget) : Math.abs((v.x | 0) - j.x) + Math.abs((v.y | 0) - j.y);
+    } else if (j.type === 'hunt') {
+      // Must mirror pickJobFor's live-animal lookup — j.x/j.y is the hunt's
+      // spawn point, not where the animal is now. Without this,
+      // maybeInterruptJob compares stale-distance current vs fresh-distance
+      // candidate and drops live pursuits.
+      const targetAnimal = findAnimalById(j.targetAid);
+      const targetX = targetAnimal?.x ?? j.x;
+      const targetY = targetAnimal?.y ?? j.y;
+      distance = Math.abs((v.x | 0) - Math.round(targetX)) + Math.abs((v.y | 0) - Math.round(targetY));
     } else {
       distance = Math.abs((v.x | 0) - j.x) + Math.abs((v.y | 0) - j.y);
     }

--- a/tests/forage.emergencyJobLifecycle.phase5.test.js
+++ b/tests/forage.emergencyJobLifecycle.phase5.test.js
@@ -1,0 +1,174 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = {
+      getElementById: () => ({
+        getContext: () => ({ imageSmoothingEnabled: true }),
+        getBoundingClientRect: () => ({ width: 800, height: 600 }),
+        style: {},
+        width: 0,
+        height: 0,
+      }),
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  }
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const { createVillagerAI } = await import('../src/app/villagerAI.js');
+const { GRID_W, GRID_H } = await import('../src/app/constants.js');
+
+// Small encoder mirroring the real `idx` closure dep. We don't need full
+// GRID_W*GRID_H allocation because the AI only reads world.berries[i] and
+// uses our stubbed idx to compute i.
+const fakeIdx = (x, y) => y * GRID_W + x;
+
+function makeBerryWorld(berryX, berryY) {
+  const tiles = new Uint8Array(GRID_W * GRID_H);
+  const berries = new Uint8Array(GRID_W * GRID_H);
+  berries[fakeIdx(berryX, berryY)] = 1;
+  return { tiles, berries, growth: new Uint8Array(0), trees: new Uint8Array(0), rocks: new Uint8Array(0) };
+}
+
+function makeAI({ jobs = [], world }) {
+  const noteCalls = { count: 0, lastJob: null };
+  const state = {
+    units: { buildings: [], jobs, villagers: [], itemsOnGround: [] },
+    stocks: { totals: { food: 0, wood: 0, stone: 0 }, reserved: {} },
+    time: { tick: 100, dayTime: 1000 },
+    world,
+    bb: null,
+  };
+  const noop = () => {};
+  // finishJob mirrors jobs.js: decrement assigned, optionally remove.
+  const finishJob = (v, remove = false) => {
+    const job = v.targetJob;
+    if (job) {
+      job.assigned = Math.max(0, (job.assigned || 0) - 1);
+      if (remove) {
+        const ji = jobs.indexOf(job);
+        if (ji !== -1) jobs.splice(ji, 1);
+      }
+    }
+    v.targetJob = null;
+  };
+  const ai = createVillagerAI({
+    state,
+    policy: { style: { jobScoring: {} }, sliders: {} },
+    pathfind: (sx, sy, x, y) => [{ x, y }], // any non-null path
+    passable: () => true,
+    Toast: { show: noop },
+    addJob: noop,
+    finishJob,
+    noteJobAssignmentChanged: (j) => { noteCalls.count++; noteCalls.lastJob = j; },
+    availableToReserve: () => 0,
+    reserveMaterials: () => true,
+    releaseReservedMaterials: noop,
+    findAnimalById: () => null,
+    findEntryTileNear: () => ({ x: 0, y: 0 }),
+    getBuildingById: () => null,
+    buildingsByKind: new Map(),
+    idx: fakeIdx,
+    ambientAt: () => 'day',
+    isNightTime: () => false,
+  });
+  return { ai, state, jobs, noteCalls, finishJob };
+}
+
+function makeVillager(overrides = {}) {
+  return {
+    x: 5, y: 5,
+    hunger: 1.1,
+    energy: 0.5,
+    happy: 0.5,
+    condition: 'starving',
+    starveStage: 2,
+    state: 'idle',
+    path: null,
+    targetJob: null,
+    targetI: null,
+    _nextPathTick: 0,
+    thought: '',
+    ...overrides,
+  };
+}
+
+test('B17: seekEmergencyFood attaches a matching unassigned forage job', () => {
+  const world = makeBerryWorld(7, 5);
+  const targetI = fakeIdx(7, 5);
+  const forageJob = { id: 1, type: 'forage', x: 7, y: 5, targetI, prio: 0.85, assigned: 0 };
+  const { ai, noteCalls } = makeAI({ jobs: [forageJob], world });
+  const v = makeVillager();
+
+  const ok = ai.seekEmergencyFood(v);
+  assert.equal(ok, true, 'emergency forage should succeed when a berry is in range');
+  assert.equal(v.state, 'forage');
+  assert.equal(v.targetI, targetI);
+  assert.equal(v.targetJob, forageJob, 'targetJob must be attached to the matching forage job');
+  assert.equal(forageJob.assigned, 1, 'matching job must increment assigned to 1');
+  assert.equal(noteCalls.count, 1, 'noteJobAssignmentChanged must fire exactly once');
+  assert.equal(noteCalls.lastJob, forageJob);
+});
+
+test('B17: arriving at the berry tile removes the attached job from the queue', () => {
+  const world = makeBerryWorld(7, 5);
+  const targetI = fakeIdx(7, 5);
+  const forageJob = { id: 1, type: 'forage', x: 7, y: 5, targetI, prio: 0.85, assigned: 0 };
+  const { ai, jobs, finishJob } = makeAI({ jobs: [forageJob], world });
+  const v = makeVillager();
+
+  ai.seekEmergencyFood(v);
+  assert.equal(jobs.length, 1, 'precondition: job is in queue while villager is walking');
+
+  // Simulate the onArrive forage path: finishJob(v, true) is the cleanup call.
+  finishJob(v, true);
+  assert.equal(jobs.length, 0, 'matching job must be removed from the queue on arrival');
+  assert.equal(v.targetJob, null);
+});
+
+test('B17: with no matching job, emergency forage proceeds without orphaning anything', () => {
+  // Berry outside the planner's forage radius — no forage job was ever
+  // emitted for it. Behavior must not regress: pickup proceeds, targetJob
+  // stays null, no orphan accumulates.
+  const world = makeBerryWorld(7, 5);
+  const { ai, jobs } = makeAI({ jobs: [], world });
+  const v = makeVillager();
+
+  const ok = ai.seekEmergencyFood(v);
+  assert.equal(ok, true);
+  assert.equal(v.state, 'forage');
+  assert.equal(v.targetJob, null, 'no matching job → targetJob stays null');
+  assert.equal(jobs.length, 0, 'no orphan job created or left behind');
+});
+
+test('B17: an already-claimed forage job is not double-assigned', () => {
+  // Another villager is already routed to this berry (assigned=1). The
+  // emergency forager must not steal the count — the other villager owns
+  // the cleanup.
+  const world = makeBerryWorld(7, 5);
+  const targetI = fakeIdx(7, 5);
+  const claimedJob = { id: 1, type: 'forage', x: 7, y: 5, targetI, prio: 0.85, assigned: 1 };
+  const { ai, noteCalls } = makeAI({ jobs: [claimedJob], world });
+  const v = makeVillager();
+
+  ai.seekEmergencyFood(v);
+  assert.equal(claimedJob.assigned, 1, 'claimed job must not be double-incremented');
+  assert.equal(v.targetJob, null, 'targetJob must stay null when no unassigned match exists');
+  assert.equal(noteCalls.count, 0, 'noteJobAssignmentChanged must not fire on a claimed job');
+});

--- a/tests/jobs.huntDistance.phase5.test.js
+++ b/tests/jobs.huntDistance.phase5.test.js
@@ -1,0 +1,143 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// villagerAI → simulation → environment asserts on AIV_TERRAIN / AIV_CONFIG at
+// module-load time; world.js → canvas.js touches `document` / `window`.
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = {
+      getElementById: () => ({
+        getContext: () => ({ imageSmoothingEnabled: true }),
+        getBoundingClientRect: () => ({ width: 800, height: 600 }),
+        style: {},
+        width: 0,
+        height: 0,
+      }),
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  }
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const { createVillagerAI } = await import('../src/app/villagerAI.js');
+
+function makeAI({ animal, jobs = [] }) {
+  const state = {
+    units: { buildings: [], jobs, villagers: [], itemsOnGround: [] },
+    stocks: { totals: { food: 0, wood: 0, stone: 0 }, reserved: {} },
+    time: { tick: 100, dayTime: 1000 },
+    world: {},
+    bb: null,
+  };
+  const noop = () => {};
+  // Empty-default scoring except a non-zero distanceFalloff so the distance
+  // term actually matters in the score. Without it, B9 would be unobservable.
+  const policy = { style: { jobScoring: { distanceFalloff: 0.01 } }, sliders: {} };
+  const ai = createVillagerAI({
+    state,
+    policy,
+    pathfind: () => null,
+    passable: () => true,
+    Toast: { show: noop },
+    addJob: noop,
+    finishJob: (v) => { v.targetJob = null; },
+    noteJobAssignmentChanged: noop,
+    availableToReserve: () => 0,
+    reserveMaterials: () => true,
+    releaseReservedMaterials: noop,
+    findAnimalById: (id) => (animal && animal.id === id ? animal : null),
+    findEntryTileNear: () => ({ x: 0, y: 0 }),
+    getBuildingById: () => null,
+    buildingsByKind: new Map(),
+    idx: () => 0,
+    ambientAt: () => 'day',
+    isNightTime: () => false,
+  });
+  return { ai, state };
+}
+
+function makeVillager(overrides = {}) {
+  return {
+    x: 0, y: 0,
+    hunger: 0,
+    energy: 1,
+    happy: 0.5, // mood = 0; isolates distance as the only score signal
+    condition: 'normal',
+    starveStage: 0,
+    state: 'idle',
+    path: null,
+    targetJob: null,
+    equippedBow: true, // pickJobFor filters out hunt jobs without a bow
+    ...overrides,
+  };
+}
+
+test('B9: scoreExistingJobForVillager uses live animal position, not stale j.x/j.y', () => {
+  const animal = { id: 42, x: 10, y: 10 };
+  const huntJob = { id: 1, type: 'hunt', x: 0, y: 0, prio: 0.5, targetAid: 42, assigned: 0 };
+  const { ai } = makeAI({ animal, jobs: [huntJob] });
+  const v = makeVillager();
+
+  const scoreClose = ai.scoreExistingJobForVillager(huntJob, v, null);
+  // Manhattan distance from (0,0) to live (10,10) = 20.
+  // score = prio - distance*falloff = 0.5 - 20*0.01 = 0.3.
+  assert.ok(Math.abs(scoreClose - 0.3) < 1e-9,
+    `expected ~0.3 from live distance, got ${scoreClose}`);
+
+  animal.x = 20; animal.y = 20;
+  const scoreFar = ai.scoreExistingJobForVillager(huntJob, v, null);
+  // Manhattan = 40 → score = 0.5 - 0.4 = 0.1.
+  assert.ok(Math.abs(scoreFar - 0.1) < 1e-9,
+    `expected ~0.1 after animal moved away, got ${scoreFar}`);
+
+  assert.ok(scoreFar < scoreClose,
+    'further animal must score strictly lower; otherwise the function is reading stale j.x/j.y');
+});
+
+test('B9: scoreExistingJobForVillager matches pickJobFor for the same hunt', () => {
+  // pickJobFor's hunt branch (lines 629-633 villagerAI.js) already uses live
+  // animal position. After the B9 fix, scoreExistingJobForVillager must agree
+  // — otherwise maybeInterruptJob compares apples to oranges.
+  const animal = { id: 7, x: 12, y: 8 };
+  const huntJob = { id: 2, type: 'hunt', x: 0, y: 0, prio: 0.5, targetAid: 7, assigned: 0 };
+  const { ai } = makeAI({ animal, jobs: [huntJob] });
+  const v = makeVillager();
+
+  const picked = ai.pickJobFor(v);
+  assert.equal(picked, huntJob, 'pickJobFor should select the only hunt job');
+
+  // Both functions must compute the same score for the same villager+job pair.
+  // We rebuild pickJobFor's expected score: distance = |0-12|+|0-8| = 20,
+  // score = 0.5 - 20*0.01 = 0.3.
+  const scoreFromExisting = ai.scoreExistingJobForVillager(huntJob, v, null);
+  assert.ok(Math.abs(scoreFromExisting - 0.3) < 1e-9,
+    `scoreExistingJobForVillager must use live animal position; got ${scoreFromExisting}`);
+});
+
+test('B9: missing animal falls back to job spawn coordinates', () => {
+  // findAnimalById returns null → use j.x/j.y as the fallback (matches
+  // pickJobFor's `?? j.x` pattern). Important for the case where the animal
+  // was killed but the job tombstone is still being scored.
+  const huntJob = { id: 3, type: 'hunt', x: 5, y: 5, prio: 0.5, targetAid: 999, assigned: 0 };
+  const { ai } = makeAI({ animal: null, jobs: [huntJob] });
+  const v = makeVillager({ x: 0, y: 0 });
+
+  const score = ai.scoreExistingJobForVillager(huntJob, v, null);
+  // distance = 10, score = 0.5 - 0.1 = 0.4.
+  assert.ok(Math.abs(score - 0.4) < 1e-9,
+    `expected fallback to j.x/j.y when animal not found; got ${score}`);
+});

--- a/tests/planner.ripeThreshold.phase5.test.js
+++ b/tests/planner.ripeThreshold.phase5.test.js
@@ -1,0 +1,119 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = {
+      getElementById: () => ({
+        getContext: () => ({ imageSmoothingEnabled: true }),
+        getBoundingClientRect: () => ({ width: 800, height: 600 }),
+        style: {},
+        width: 0,
+        height: 0,
+      }),
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  }
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const { createPlanner } = await import('../src/app/planner.js');
+const { GRID_W, GRID_H, TILES, RIPE_THRESHOLD } = await import('../src/app/constants.js');
+
+function makePlanner() {
+  const tiles = new Uint8Array(GRID_W * GRID_H);
+  const growth = new Uint8Array(GRID_W * GRID_H);
+  const zone = new Uint8Array(GRID_W * GRID_H);
+  const berries = new Uint8Array(GRID_W * GRID_H);
+  const trees = new Uint8Array(GRID_W * GRID_H);
+  const rocks = new Uint8Array(GRID_W * GRID_H);
+  const state = {
+    units: { villagers: [], animals: [], buildings: [], jobs: [] },
+    stocks: { totals: { food: 0, wood: 0, stone: 0, bow: 0, pelt: 0 }, reserved: {} },
+    time: { tick: 0, dayTime: 0 },
+    world: { tiles, growth, zone, berries, trees, rocks },
+  };
+  const noop = () => {};
+  const planner = createPlanner({
+    state,
+    policy: { sliders: {}, style: { jobScoring: {}, jobCreation: {} } },
+    pathfind: () => null,
+    addJob: () => null,
+    hasSimilarJob: () => false,
+    noteJobRemoved: noop,
+    requestBuildHauls: noop,
+    countBuildingsByKind: () => 0,
+    ensureBlackboardSnapshot: () => null,
+    getJobCreationConfig: () => ({}),
+    violatesSpacing: () => false,
+    zoneCanEverWork: () => true,
+    zoneHasWorkNow: () => true,
+    updateZoneRow: noop,
+    markZoneOverlayDirty: noop,
+    markStaticDirty: noop,
+    availableToReserve: () => 0,
+    reserveMaterials: () => true,
+    releaseReservedMaterials: noop,
+    addBuilding: noop,
+    Toast: { show: noop },
+    toTile: (n) => n | 0,
+  });
+  return { planner, state, tiles, growth };
+}
+
+test('B2: RIPE_THRESHOLD constant is 150 (matches harvest job emit threshold)', () => {
+  // Regression guard against accidental drift. The whole point of unifying
+  // 150 and 160 was to fix the `hasRipeCrops()` / harvest-emit mismatch.
+  assert.equal(RIPE_THRESHOLD, 150);
+});
+
+test('B2: hasRipeCrops returns true once any FARMLAND tile reaches RIPE_THRESHOLD', () => {
+  const { planner, tiles, growth } = makePlanner();
+  // Pre-condition: empty world has no ripe crops.
+  assert.equal(planner.hasRipeCrops(), false, 'empty world should have no ripe crops');
+
+  const i = 5 * GRID_W + 7;
+  tiles[i] = TILES.FARMLAND;
+  growth[i] = 149;
+  assert.equal(planner.hasRipeCrops(), false, 'growth=149 must not count as ripe');
+
+  growth[i] = RIPE_THRESHOLD;
+  assert.equal(planner.hasRipeCrops(), true, 'growth=RIPE_THRESHOLD must count as ripe');
+});
+
+test('B2/S8/S9: at growth 152 hasRipeCrops is true (the old 160 threshold reported false)', () => {
+  // The bug: harvest jobs emit at growth >= 150 but hasRipeCrops() defaulted
+  // to threshold 160. During growth ∈ [150, 160), the planner believed "no
+  // ripe crops" and the `forageNeed` clause spuriously added forage on top
+  // of harvest. The fix unifies on RIPE_THRESHOLD = 150.
+  const { planner, tiles, growth } = makePlanner();
+  const i = 12 * GRID_W + 30;
+  tiles[i] = TILES.FARMLAND;
+  growth[i] = 152;
+  assert.equal(planner.hasRipeCrops(), true,
+    'growth=152 must report ripe; pre-fix this returned false because of the 160 default');
+});
+
+test('B2: non-FARMLAND tiles with high growth are ignored', () => {
+  // Defensive: a stray growth value on a non-FARMLAND tile (e.g., a tile
+  // that was zone-cleared mid-grow) should not inflate hasRipeCrops.
+  const { planner, tiles, growth } = makePlanner();
+  const i = 4 * GRID_W + 4;
+  tiles[i] = TILES.GRASS;
+  growth[i] = 200;
+  assert.equal(planner.hasRipeCrops(), false);
+});


### PR DESCRIPTION
Fixes three bugs where the job system was lying to itself about its own
state, per AI_VILLAGE_FIX_PLAN.md Phase 5:

- B9: scoreExistingJobForVillager now uses the live animal position
  (via findAnimalById) for hunt distance, mirroring pickJobFor. Without
  this, maybeInterruptJob compared stale-distance current jobs against
  fresh-distance candidates and dropped live pursuits.

- B17: seekEmergencyFood now attaches a matching unassigned forage job
  to v.targetJob and increments assigned, so onArrive's existing
  finishJob(v, true) cleans the queue entry on pickup. Berries outside
  the planner's forage radius still pick up jobless (no orphan to
  begin with). Already-claimed jobs are left alone so the original
  owner cleans them up.

- B2/S8/S9: introduces RIPE_THRESHOLD=150 in constants.js and uses it
  in hasRipeCrops, countPlantedTiles, the planner harvest scan, and
  seasonTick. This unifies the threshold so growth in [150,160) no
  longer triggers spurious forage on top of harvest.

Three new test files cover all three issues. No save format change.