### PR TITLE
Phase 6: pregnancy / population gating

### DIFF
--- a/src/app/population.js
+++ b/src/app/population.js
@@ -6,6 +6,10 @@ export const PREGNANCY_TICKS = DAY_LENGTH * 2;
 export const CHILDHOOD_TICKS = DAY_LENGTH * 5;
 export const PREGNANCY_ATTEMPT_COOLDOWN_TICKS = Math.floor(DAY_LENGTH * 1.1);
 export const PREGNANCY_ATTEMPT_CHANCE = 0.12;
+// Short recheck cooldown for villagers that fail body-state eligibility
+// (tired, sad, sick, hungry). Keeps tryStartPregnancy off the hot path:
+// at TICKS_PER_SECOND=6 this is ~10 s of game time per re-evaluation.
+export const PREGNANCY_RECHECK_TICKS = 60;
 export const POPULATION_SOFT_BUFFER = 2;
 export const POPULATION_HARD_CAP = 80;
 export const FOOD_HEADROOM_PER_VILLAGER = 1.25;
@@ -21,6 +25,8 @@ export function createPopulation(opts) {
 
   const villagers = state.units.villagers;
   const storageTotals = state.stocks.totals;
+  // Drained every tick by flushPendingBirths (see src/app/tick.js); lifetime
+  // of any entry is < 1 tick, so we deliberately don't persist it in saves.
   const pendingBirths = [];
 
   function getWorld() { return state.world; }
@@ -122,17 +128,24 @@ export function createPopulation(opts) {
     return underCap && wellFed;
   }
 
+  function isPregnancyEligible(v) {
+    if (v.lifeStage !== 'adult') return false;
+    if (v.pregnancyTimer > 0) return false;
+    if ((v.starveStage || 0) >= 1) return false;
+    if (v.condition === 'sick') return false;
+    if ((v.energy || 0) < 0.4) return false;
+    if ((v.happy || 0) < 0.35) return false;
+    return true;
+  }
+
   function findBirthMate(v) {
     const tick = getTick();
     let best = null;
     let bestDist = Infinity;
     for (const other of villagers) {
       if (other === v) continue;
-      if (other.lifeStage !== 'adult') continue;
-      if (other.pregnancyTimer > 0) continue;
       if ((other.nextPregnancyTick || 0) > tick) continue;
-      if ((other.starveStage || 0) >= 2) continue;
-      if (other.condition !== 'normal' && other.condition !== 'hungry') continue;
+      if (!isPregnancyEligible(other)) continue;
       const dist = Math.abs((other.x | 0) - (v.x | 0)) + Math.abs((other.y | 0) - (v.y | 0));
       if (dist < bestDist) { best = other; bestDist = dist; }
     }
@@ -141,12 +154,11 @@ export function createPopulation(opts) {
 
   function tryStartPregnancy(v) {
     const tick = getTick();
-    if (v.lifeStage !== 'adult') return;
-    if (v.pregnancyTimer > 0) return;
-    if ((v.starveStage || 0) >= 1) return;
-    if (v.condition === 'sick') return;
-    if (v.energy < 0.4 || v.happy < 0.35) return;
     if (tick < (v.nextPregnancyTick || 0)) return;
+    if (!isPregnancyEligible(v)) {
+      v.nextPregnancyTick = tick + PREGNANCY_RECHECK_TICKS;
+      return;
+    }
     if (!canSupportBirth()) {
       v.nextPregnancyTick = Math.max(v.nextPregnancyTick || 0, tick + Math.floor(PREGNANCY_ATTEMPT_COOLDOWN_TICKS * 0.5));
       return;
@@ -229,6 +241,7 @@ export function createPopulation(opts) {
     housingCapacity,
     populationLimit,
     canSupportBirth,
+    isPregnancyEligible,
     findBirthMate,
     tryStartPregnancy,
     spawnChildNearParents,

--- a/src/app/villagerAI.js
+++ b/src/app/villagerAI.js
@@ -206,6 +206,9 @@ export function createVillagerAI(opts) {
         && (j.assigned || 0) < 1
       );
       if (existing) {
+        // Release any prior claim so its assigned counter doesn't leak when
+        // the urgent-food path interrupts a non-forage job.
+        if (v.targetJob && v.targetJob !== existing) finishJob(v);
         v.targetJob = existing;
         existing.assigned = (existing.assigned || 0) + 1;
         noteJobAssignmentChanged(existing);

--- a/tests/forage.emergencyJobLifecycle.phase6.test.js
+++ b/tests/forage.emergencyJobLifecycle.phase6.test.js
@@ -1,0 +1,139 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = {
+      getElementById: () => ({
+        getContext: () => ({ imageSmoothingEnabled: true }),
+        getBoundingClientRect: () => ({ width: 800, height: 600 }),
+        style: {},
+        width: 0,
+        height: 0,
+      }),
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  }
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const { createVillagerAI } = await import('../src/app/villagerAI.js');
+const { GRID_W, GRID_H } = await import('../src/app/constants.js');
+
+const fakeIdx = (x, y) => y * GRID_W + x;
+
+function makeBerryWorld(berryX, berryY) {
+  const tiles = new Uint8Array(GRID_W * GRID_H);
+  const berries = new Uint8Array(GRID_W * GRID_H);
+  berries[fakeIdx(berryX, berryY)] = 1;
+  return { tiles, berries, growth: new Uint8Array(0), trees: new Uint8Array(0), rocks: new Uint8Array(0) };
+}
+
+function makeAI({ jobs = [], world }) {
+  const noteCalls = { count: 0, lastJob: null };
+  const state = {
+    units: { buildings: [], jobs, villagers: [], itemsOnGround: [] },
+    stocks: { totals: { food: 0, wood: 0, stone: 0 }, reserved: {} },
+    time: { tick: 100, dayTime: 1000 },
+    world,
+    bb: null,
+  };
+  const noop = () => {};
+  const finishJob = (v, remove = false) => {
+    const job = v.targetJob;
+    if (job) {
+      job.assigned = Math.max(0, (job.assigned || 0) - 1);
+      if (remove) {
+        const ji = jobs.indexOf(job);
+        if (ji !== -1) jobs.splice(ji, 1);
+      }
+    }
+    v.targetJob = null;
+  };
+  const ai = createVillagerAI({
+    state,
+    policy: { style: { jobScoring: {} }, sliders: {} },
+    pathfind: (sx, sy, x, y) => [{ x, y }],
+    passable: () => true,
+    Toast: { show: noop },
+    addJob: noop,
+    finishJob,
+    noteJobAssignmentChanged: (j) => { noteCalls.count++; noteCalls.lastJob = j; },
+    availableToReserve: () => 0,
+    reserveMaterials: () => true,
+    releaseReservedMaterials: noop,
+    findAnimalById: () => null,
+    findEntryTileNear: () => ({ x: 0, y: 0 }),
+    getBuildingById: () => null,
+    buildingsByKind: new Map(),
+    idx: fakeIdx,
+    ambientAt: () => 'day',
+    isNightTime: () => false,
+  });
+  return { ai, state, jobs, noteCalls, finishJob };
+}
+
+function makeVillager(overrides = {}) {
+  return {
+    x: 5, y: 5,
+    hunger: 1.1,
+    energy: 0.5,
+    happy: 0.5,
+    condition: 'starving',
+    starveStage: 2,
+    state: 'idle',
+    path: null,
+    targetJob: null,
+    targetI: null,
+    _nextPathTick: 0,
+    thought: '',
+    ...overrides,
+  };
+}
+
+test('Phase 6 carry-over: emergency forage releases a prior non-forage claim', () => {
+  // The urgent-food path can fire while the villager is mid-job. Without
+  // releasing the prior claim, its assigned counter leaks to 1 forever and
+  // the job becomes unpickable.
+  const world = makeBerryWorld(7, 5);
+  const targetI = fakeIdx(7, 5);
+  const chopJob = { id: 42, type: 'chop', x: 9, y: 9, prio: 0.5, assigned: 1 };
+  const forageJob = { id: 1, type: 'forage', x: 7, y: 5, targetI, prio: 0.85, assigned: 0 };
+  const { ai } = makeAI({ jobs: [chopJob, forageJob], world });
+  const v = makeVillager({ targetJob: chopJob, state: 'chop' });
+
+  const ok = ai.seekEmergencyFood(v);
+  assert.equal(ok, true);
+  assert.equal(chopJob.assigned, 0, 'prior chop job must be released back to assigned=0');
+  assert.equal(forageJob.assigned, 1, 'forage job must be claimed');
+  assert.equal(v.targetJob, forageJob, 'targetJob must point at the forage job');
+});
+
+test('Phase 6 carry-over: emergency forage with no prior claim is unchanged', () => {
+  // Regression guard: the new release branch must not run when v.targetJob
+  // is null (the original Phase 5 case).
+  const world = makeBerryWorld(7, 5);
+  const targetI = fakeIdx(7, 5);
+  const forageJob = { id: 1, type: 'forage', x: 7, y: 5, targetI, prio: 0.85, assigned: 0 };
+  const { ai } = makeAI({ jobs: [forageJob], world });
+  const v = makeVillager();
+
+  const ok = ai.seekEmergencyFood(v);
+  assert.equal(ok, true);
+  assert.equal(v.targetJob, forageJob);
+  assert.equal(forageJob.assigned, 1);
+});

--- a/tests/pregnancy.eligibility.phase6.test.js
+++ b/tests/pregnancy.eligibility.phase6.test.js
@@ -1,0 +1,163 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = {
+      getElementById: () => ({
+        getContext: () => ({ imageSmoothingEnabled: true }),
+        getBoundingClientRect: () => ({ width: 800, height: 600 }),
+        style: {},
+        width: 0,
+        height: 0,
+      }),
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  }
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const {
+  createPopulation,
+  PREGNANCY_RECHECK_TICKS,
+  PREGNANCY_ATTEMPT_COOLDOWN_TICKS,
+  PREGNANCY_TICKS,
+} = await import('../src/app/population.js');
+const { setRandomSource } = await import('../src/app/rng.js');
+
+function makeAdult(overrides = {}) {
+  return {
+    id: overrides.id ?? Math.floor(Math.random() * 1e9),
+    x: 0, y: 0,
+    lifeStage: 'adult',
+    pregnancyTimer: 0,
+    pregnancyMateId: null,
+    starveStage: 0,
+    condition: 'normal',
+    energy: 0.7,
+    happy: 0.6,
+    nextPregnancyTick: 0,
+    thought: '',
+    ...overrides,
+  };
+}
+
+function makePopulation({ villagers = [], food = 100, huts = 10, tick = 1000 } = {}) {
+  const state = {
+    units: { villagers },
+    stocks: { totals: { food } },
+    time: { tick },
+    world: { tiles: new Uint8Array(0) },
+  };
+  const pop = createPopulation({
+    state,
+    countBuildingsByKind: (kind) => kind === 'hut' ? { built: huts, planned: 0 } : { built: 0, planned: 0 },
+    tileOccupiedByBuilding: () => false,
+    idx: (x, y) => y * 64 + x,
+    ensureVillagerNumber: (v) => v,
+  });
+  return { state, pop };
+}
+
+const RECHECK_BAIL_CASES = [
+  ['lifeStage child', { lifeStage: 'child' }],
+  ['already pregnant', { pregnancyTimer: 100 }],
+  ['starveStage 1 (hungry)', { starveStage: 1 }],
+  ['condition sick', { condition: 'sick' }],
+  ['low energy', { energy: 0.3 }],
+  ['low happy', { happy: 0.3 }],
+];
+
+for (const [label, override] of RECHECK_BAIL_CASES) {
+  test(`B5: tryStartPregnancy sets short cooldown when ineligible (${label})`, () => {
+    const tick = 1000;
+    const v = makeAdult(override);
+    const { pop } = makePopulation({ villagers: [v], tick });
+    pop.tryStartPregnancy(v);
+    assert.equal(
+      v.nextPregnancyTick,
+      tick + PREGNANCY_RECHECK_TICKS,
+      'every ineligibility bail must set nextPregnancyTick = tick + PREGNANCY_RECHECK_TICKS',
+    );
+    assert.equal(v.pregnancyTimer, override.pregnancyTimer ?? 0);
+  });
+}
+
+test('B5: tryStartPregnancy is a no-op while the cooldown is active', () => {
+  const tick = 1000;
+  const v = makeAdult({ energy: 0.3, nextPregnancyTick: tick + 30 });
+  const { pop } = makePopulation({ villagers: [v], tick });
+  pop.tryStartPregnancy(v);
+  assert.equal(v.nextPregnancyTick, tick + 30, 'active cooldown must not be re-extended');
+});
+
+test('B6: tired mate is rejected by findBirthMate', () => {
+  const parent = makeAdult({ id: 1, energy: 0.7, happy: 0.6 });
+  const tiredMate = makeAdult({ id: 2, energy: 0.2, happy: 0.6, x: 1 });
+  const { pop } = makePopulation({ villagers: [parent, tiredMate] });
+  assert.equal(pop.findBirthMate(parent), null, 'mate with energy<0.4 must not be drafted');
+});
+
+test('B6: sad mate is rejected by findBirthMate', () => {
+  const parent = makeAdult({ id: 1, energy: 0.7, happy: 0.6 });
+  const sadMate = makeAdult({ id: 2, energy: 0.7, happy: 0.3, x: 1 });
+  const { pop } = makePopulation({ villagers: [parent, sadMate] });
+  assert.equal(pop.findBirthMate(parent), null, 'mate with happy<0.35 must not be drafted');
+});
+
+test('B6: tryStartPregnancy with a tired-only mate sets the no-mate cooldown', () => {
+  const tick = 1000;
+  const parent = makeAdult({ id: 1, energy: 0.7, happy: 0.6 });
+  const tiredMate = makeAdult({ id: 2, energy: 0.2, happy: 0.6, x: 1 });
+  const { pop } = makePopulation({ villagers: [parent, tiredMate], tick });
+  setRandomSource(() => 0.01);
+  try {
+    pop.tryStartPregnancy(parent);
+  } finally {
+    setRandomSource(Math.random);
+  }
+  assert.equal(parent.pregnancyTimer, 0, 'no pregnancy should start without an eligible mate');
+  assert.equal(parent.nextPregnancyTick, tick + PREGNANCY_ATTEMPT_COOLDOWN_TICKS);
+});
+
+test('eligible parent + eligible mate conceive when RNG passes', () => {
+  const tick = 1000;
+  const parent = makeAdult({ id: 1, energy: 0.7, happy: 0.6 });
+  const mate = makeAdult({ id: 2, energy: 0.7, happy: 0.6, x: 1 });
+  const { pop } = makePopulation({ villagers: [parent, mate], tick });
+  setRandomSource(() => 0.01);
+  try {
+    pop.tryStartPregnancy(parent);
+  } finally {
+    setRandomSource(Math.random);
+  }
+  assert.equal(parent.pregnancyTimer, PREGNANCY_TICKS);
+  assert.equal(parent.pregnancyMateId, mate.id);
+  assert.equal(parent.nextPregnancyTick, tick + PREGNANCY_ATTEMPT_COOLDOWN_TICKS);
+  assert.ok(
+    mate.nextPregnancyTick >= tick + PREGNANCY_ATTEMPT_COOLDOWN_TICKS,
+    'mate cooldown must also be set on conception',
+  );
+});
+
+test('isPregnancyEligible matches all bail conditions exactly', () => {
+  const { pop } = makePopulation();
+  assert.equal(pop.isPregnancyEligible(makeAdult()), true);
+  for (const [, override] of RECHECK_BAIL_CASES) {
+    assert.equal(pop.isPregnancyEligible(makeAdult(override)), false);
+  }
+});


### PR DESCRIPTION
- B5: tryStartPregnancy now sets a short PREGNANCY_RECHECK_TICKS
  cooldown (60 ticks ~= 10 s) on every body-state ineligibility bail
  (lifeStage, already pregnant, starveStage>=1, sick, low energy, low
  happy). Previously these paths returned without setting
  nextPregnancyTick, so the function ran 6x/sec on tired villagers.
- B6: extracted isPregnancyEligible(v) and shared it between
  tryStartPregnancy and findBirthMate, so a tired or sad mate is no
  longer drafted as a partner.
- pendingBirths: documented as intentionally not persisted (drained
  every tick by flushPendingBirths).
- Carry-over from Phase 5: seekEmergencyFood's berry branch now
  releases any prior v.targetJob via finishJob(v) before claiming the
  matching forage job, preventing a permanent assigned-counter leak
  when the urgent-food path interrupts a non-forage job.

Tests: tests/pregnancy.eligibility.phase6.test.js,
tests/forage.emergencyJobLifecycle.phase6.test.js.

https://claude.ai/code/session_01BcBqpZ67j8VNQvCr6EN1mJ