### PR TITLE
Phase 9 (B4/S7): seasonal growth and hunger multipliers

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -48,7 +48,8 @@ import {
 } from './app/world.js';
 import {
   createTimeOfDay,
-  normalizeExperienceLedger
+  normalizeExperienceLedger,
+  seasonalGrowthMultiplier
 } from './app/simulation.js';
 
 if (import.meta.env?.DEV) {
@@ -692,7 +693,9 @@ function seasonTick(){
     if(prev<=0 || prev>=240) continue;
     const y=(i/GRID_W)|0, x=i%GRID_W;
     // Crop balance knob: faster base growth to help farms stabilize food.
-    let delta=1.2;
+    // Phase 9 (B4/S7): season multiplier on base growth only; booster
+    // bonuses layer on top so wells/farmplots partially mitigate winter.
+    let delta = 1.2 * seasonalGrowthMultiplier(world.season, world.tSeason / SEASON_LEN);
     if(hasFarmBoosters){
       const { growthBonus } = agricultureBonusesAt(x,y);
       if(growthBonus>0){

--- a/src/app/simulation.js
+++ b/src/app/simulation.js
@@ -178,3 +178,27 @@ export function createTimeOfDay(deps) {
 
   return { ambientAt, isNightTime };
 }
+
+// Phase 9 (B4/S7): seasonal growth/hunger multipliers.
+// Seasons match world.season encoding: 0=Spring, 1=Summer, 2=Autumn, 3=Winter.
+export const SEASON_GROWTH_BASE = Object.freeze([1.0, 1.2, 0.8, 0.3]);
+export const SEASON_HUNGER_BASE = Object.freeze([1.0, 0.95, 1.0, 1.15]);
+// Only the last 15% of a season cross-fades into the next so the season's
+// base multiplier dominates the middle. A full-season linear blend would
+// average winter to ~0.65 and break the "~3x slower in winter" target.
+export const SEASON_BLEND_WIDTH = 0.15;
+
+export function seasonalGrowthMultiplier(season, seasonProgress = 0) {
+  const s = ((season | 0) % 4 + 4) % 4;
+  const p = clamp(Number.isFinite(seasonProgress) ? seasonProgress : 0, 0, 1);
+  const base = SEASON_GROWTH_BASE[s];
+  if (p <= 1 - SEASON_BLEND_WIDTH) return base;
+  const next = SEASON_GROWTH_BASE[(s + 1) % 4];
+  const t = (p - (1 - SEASON_BLEND_WIDTH)) / SEASON_BLEND_WIDTH;
+  return base + (next - base) * t;
+}
+
+export function seasonalHungerMultiplier(season) {
+  const s = ((season | 0) % 4 + 4) % 4;
+  return SEASON_HUNGER_BASE[s];
+}

--- a/src/app/villagerTick.js
+++ b/src/app/villagerTick.js
@@ -6,7 +6,8 @@ import {
   isDeepNight,
   isNightAmbient,
   moodMotivation,
-  moodThought
+  moodThought,
+  seasonalHungerMultiplier
 } from './simulation.js';
 import { DAY_LENGTH, HUNT_RANGE, HUNT_RETRY_COOLDOWN } from './constants.js';
 import { BUILDINGS } from './world.js';
@@ -145,7 +146,9 @@ export function createVillagerTick(opts) {
     if (v.hydrationBuffTicks > 0) v.hydrationBuffTicks--;
     const hydratedBuff = (v.hydrationBuffTicks || 0) > 0;
     const dehydrated = v.hydration < HYDRATION_LOW;
-    const hungerRate = (resting ? HUNGER_RATE * REST_HUNGER_MULT : HUNGER_RATE) * (hydratedBuff ? HYDRATION_HUNGER_MULT : (dehydrated ? HYDRATION_DEHYDRATED_PENALTY : 1));
+    // Phase 9 (B4/S7): winter raises drain ~15%, summer dips slightly.
+    const seasonalHungerMult = seasonalHungerMultiplier(state?.world?.season ?? 0);
+    const hungerRate = (resting ? HUNGER_RATE * REST_HUNGER_MULT : HUNGER_RATE) * (hydratedBuff ? HYDRATION_HUNGER_MULT : (dehydrated ? HYDRATION_DEHYDRATED_PENALTY : 1)) * seasonalHungerMult;
     v.hunger += hungerRate;
 
     const tileX = v.x | 0;

--- a/tests/season.growth.phase9.test.js
+++ b/tests/season.growth.phase9.test.js
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// simulation.js -> environment.js asserts on AIV_TERRAIN / AIV_CONFIG at
+// module-load time. Mirror the stubs other tests use.
+function ensureBrowserStubs() {
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const {
+  SEASON_GROWTH_BASE,
+  SEASON_BLEND_WIDTH,
+  seasonalGrowthMultiplier,
+} = await import('../src/app/simulation.js');
+
+const SPRING = 0;
+const SUMMER = 1;
+const AUTUMN = 2;
+const WINTER = 3;
+
+test('B4: growth multiplier returns each season base value at progress=0', () => {
+  assert.equal(seasonalGrowthMultiplier(SPRING, 0), 1.0);
+  assert.equal(seasonalGrowthMultiplier(SUMMER, 0), 1.2);
+  assert.equal(seasonalGrowthMultiplier(AUTUMN, 0), 0.8);
+  assert.equal(seasonalGrowthMultiplier(WINTER, 0), 0.3);
+});
+
+test('B4: growth multiplier holds base value through the middle of the season', () => {
+  assert.equal(seasonalGrowthMultiplier(WINTER, 0.5), 0.3);
+  assert.equal(seasonalGrowthMultiplier(WINTER, 1 - SEASON_BLEND_WIDTH), 0.3);
+  assert.equal(seasonalGrowthMultiplier(SUMMER, 0.5), 1.2);
+});
+
+test('B4: growth multiplier blends to next season base over the tail window', () => {
+  // End of winter blends toward spring (1.0).
+  const winterEnd = seasonalGrowthMultiplier(WINTER, 1);
+  assert.ok(Math.abs(winterEnd - SEASON_GROWTH_BASE[SPRING]) < 1e-9,
+    `expected end-of-winter to equal spring base, got ${winterEnd}`);
+  // A midpoint inside the blend window is strictly between base and next.
+  const winterBlendMid = seasonalGrowthMultiplier(WINTER, 1 - SEASON_BLEND_WIDTH / 2);
+  assert.ok(winterBlendMid > 0.3 && winterBlendMid < 1.0,
+    `expected blend midpoint between 0.3 and 1.0, got ${winterBlendMid}`);
+  // Monotonic ramp across the blend window.
+  const a = seasonalGrowthMultiplier(WINTER, 1 - SEASON_BLEND_WIDTH + 1e-6);
+  const b = seasonalGrowthMultiplier(WINTER, 1 - SEASON_BLEND_WIDTH / 2);
+  const c = seasonalGrowthMultiplier(WINTER, 1);
+  assert.ok(a < b && b < c, `expected monotonic blend, got ${a} ${b} ${c}`);
+});
+
+test('B4: end of summer blends toward autumn base', () => {
+  const summerEnd = seasonalGrowthMultiplier(SUMMER, 1);
+  assert.ok(Math.abs(summerEnd - SEASON_GROWTH_BASE[AUTUMN]) < 1e-9,
+    `expected end-of-summer to equal autumn base, got ${summerEnd}`);
+});
+
+test('B4: spring/winter average ratio encodes "~3x slower in winter"', () => {
+  const samples = 100;
+  let springSum = 0;
+  let winterSum = 0;
+  for (let i = 0; i < samples; i++) {
+    const p = i / samples;
+    springSum += seasonalGrowthMultiplier(SPRING, p);
+    winterSum += seasonalGrowthMultiplier(WINTER, p);
+  }
+  const ratio = (springSum / samples) / (winterSum / samples);
+  assert.ok(ratio >= 2.7 && ratio <= 3.5,
+    `expected spring/winter growth ratio in [2.7, 3.5], got ${ratio}`);
+});
+
+test('B4: out-of-range season values wrap into 0..3', () => {
+  assert.equal(seasonalGrowthMultiplier(-1, 0), SEASON_GROWTH_BASE[WINTER]);
+  assert.equal(seasonalGrowthMultiplier(4, 0), SEASON_GROWTH_BASE[SPRING]);
+  assert.equal(seasonalGrowthMultiplier(7, 0), SEASON_GROWTH_BASE[WINTER]);
+  assert.equal(seasonalGrowthMultiplier(6, 0), SEASON_GROWTH_BASE[AUTUMN]);
+});
+
+test('B4: non-finite progress is treated as 0', () => {
+  assert.equal(seasonalGrowthMultiplier(WINTER, NaN), 0.3);
+  assert.equal(seasonalGrowthMultiplier(WINTER, Infinity), 0.3);
+  assert.equal(seasonalGrowthMultiplier(WINTER, undefined), 0.3);
+});

--- a/tests/season.hunger.phase9.test.js
+++ b/tests/season.hunger.phase9.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// simulation.js -> environment.js asserts on AIV_TERRAIN / AIV_CONFIG at
+// module-load time. Mirror the stubs other tests use.
+function ensureBrowserStubs() {
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const {
+  SEASON_HUNGER_BASE,
+  seasonalHungerMultiplier,
+} = await import('../src/app/simulation.js');
+
+const SPRING = 0;
+const SUMMER = 1;
+const AUTUMN = 2;
+const WINTER = 3;
+
+test('S7: hunger multiplier matches per-season tuning', () => {
+  assert.equal(seasonalHungerMultiplier(SPRING), 1.0);
+  assert.equal(seasonalHungerMultiplier(SUMMER), 0.95);
+  assert.equal(seasonalHungerMultiplier(AUTUMN), 1.0);
+  assert.equal(seasonalHungerMultiplier(WINTER), 1.15);
+});
+
+test('S7: winter/spring hunger ratio is ~1.15 (drains ~15% faster in winter)', () => {
+  const ratio = seasonalHungerMultiplier(WINTER) / seasonalHungerMultiplier(SPRING);
+  assert.ok(ratio > 1.149 && ratio < 1.151,
+    `expected winter/spring hunger ratio ~1.15, got ${ratio}`);
+});
+
+test('S7: out-of-range season values wrap into 0..3', () => {
+  assert.equal(seasonalHungerMultiplier(-1), SEASON_HUNGER_BASE[WINTER]);
+  assert.equal(seasonalHungerMultiplier(4), SEASON_HUNGER_BASE[SPRING]);
+  assert.equal(seasonalHungerMultiplier(7), SEASON_HUNGER_BASE[WINTER]);
+  assert.equal(seasonalHungerMultiplier(6), SEASON_HUNGER_BASE[AUTUMN]);
+});


### PR DESCRIPTION
Winter slows crop growth ~3x and raises hunger drain 15%; spring/summer/
autumn tuned per spec. Growth multiplier applies to the base 1.2 delta
so farm boosters (wells/farmplots) partially mitigate winter. A 15%
end-of-season blend smooths transitions without diluting the seasonal
target. Adds pure-function tests for both helpers.