### PR TITLE
Add seasonal artwork system

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -682,7 +682,12 @@ function seasonTick(){
   const SEASON_LEN=60*10;
   if(world.tSeason>=SEASON_LEN){
     world.tSeason=0;
+    const prevSeason = world.season;
     world.season=(world.season+1)%4;
+
+    if (world.season !== prevSeason && typeof markStaticDirty === 'function') {
+      markStaticDirty();
+    }
   }
   const hasFarmBoosters=buildings.some(b=>b.built>=1 && (b.kind==='farmplot'||b.kind==='well'));
   const creationCfg = getJobCreationConfig();

--- a/src/app/render.js
+++ b/src/app/render.js
@@ -18,7 +18,7 @@ import {
 import { LIGHTING, clamp01 } from './lighting.js';
 import { clamp } from './rng.js';
 import { context2d } from './canvas.js';
-import { SHADOW_TEXTURE, Tileset, makeCanvas } from './tileset.js';
+import { SHADOW_TEXTURE, Tileset, makeCanvas, normalizeSeason, seasonName } from './tileset.js';
 import {
   BUILDINGS,
   buildingCenter,
@@ -76,6 +76,7 @@ export function createRenderSystem(deps) {
     canvas: null,
     ctx: null,
     frameIndex: -1,
+    season: null,
     camX: null,
     camY: null,
     camZ: null,
@@ -487,34 +488,50 @@ export function createRenderSystem(deps) {
   function drawStaticAlbedo() {
     const world = getWorld();
     if (!world) return;
+
     if (!staticAlbedoCanvas) {
       staticAlbedoCanvas = makeCanvas(GRID_W * TILE, GRID_H * TILE);
       staticAlbedoCtx = context2d(staticAlbedoCanvas);
     }
+
     const g = staticAlbedoCtx;
     if (!g) return;
+
+    const season = normalizeSeason(world.season);
+    const baseSet = Tileset.baseBySeason?.[season] || Tileset.base || {};
+    const fallback = Tileset.base?.grass || baseSet.grass;
+
     ensureRowMasksSize();
+
     for (let y = 0; y < GRID_H; y++) {
       let rowHasWater = 0;
       const rowStart = y * GRID_W;
+
       for (let x = 0; x < GRID_W; x++) {
         const i = rowStart + x;
         const t = world.tiles[i];
-        let img = Tileset.base.grass;
-        if (t === TILES.GRASS) img = Tileset.base.grass;
-        else if (t === TILES.FERTILE) img = Tileset.base.fertile;
-        else if (t === TILES.MEADOW) img = Tileset.base.meadow;
-        else if (t === TILES.MARSH) img = Tileset.base.marsh;
-        else if (t === TILES.SAND) img = Tileset.base.sand;
-        else if (t === TILES.SNOW) img = Tileset.base.snow;
-        else if (t === TILES.ROCK) img = Tileset.base.rock;
-        else if (t === TILES.WATER) img = Tileset.base.water;
-        else if (t === TILES.FARMLAND) img = Tileset.base.farmland;
-        g.drawImage(img, x * TILE, y * TILE);
+
+        let img = baseSet.grass || fallback;
+
+        if (t === TILES.GRASS) img = baseSet.grass || fallback;
+        else if (t === TILES.FOREST) img = baseSet.forest || baseSet.grass || fallback;
+        else if (t === TILES.FERTILE) img = baseSet.fertile || fallback;
+        else if (t === TILES.MEADOW) img = baseSet.meadow || fallback;
+        else if (t === TILES.MARSH) img = baseSet.marsh || fallback;
+        else if (t === TILES.SAND) img = baseSet.sand || fallback;
+        else if (t === TILES.SNOW) img = baseSet.snow || fallback;
+        else if (t === TILES.ROCK) img = baseSet.rock || fallback;
+        else if (t === TILES.WATER) img = baseSet.water || fallback;
+        else if (t === TILES.FARMLAND) img = baseSet.farmland || fallback;
+
+        if (img) g.drawImage(img, x * TILE, y * TILE);
+
         if (t === TILES.WATER) rowHasWater = 1;
       }
+
       waterRowMask[y] = rowHasWater;
     }
+
     world.staticAlbedoCanvas = staticAlbedoCanvas;
     world.staticAlbedoCtx = staticAlbedoCtx;
     staticDirty = false;
@@ -633,7 +650,9 @@ export function createRenderSystem(deps) {
     const cam = getCam();
     const W = getViewportW();
     const H = getViewportH();
+    const overlaySeason = normalizeSeason(world.season);
     const needsRedraw = waterOverlayCache.frameIndex !== frameIndex
+      || waterOverlayCache.season !== overlaySeason
       || waterOverlayCache.camX !== cam.x
       || waterOverlayCache.camY !== cam.y
       || waterOverlayCache.camZ !== cam.z
@@ -655,11 +674,69 @@ export function createRenderSystem(deps) {
         }
       }
       waterOverlayCache.frameIndex = frameIndex;
+      waterOverlayCache.season = overlaySeason;
       waterOverlayCache.camX = cam.x;
       waterOverlayCache.camY = cam.y;
       waterOverlayCache.camZ = cam.z;
     }
     ctx.drawImage(waterOverlayCache.canvas, 0, 0);
+  }
+
+  function drawSeasonAtmosphere(season, tick, vis) {
+    const ctx = getCtx();
+    const cam = getCam();
+    if (!ctx || !cam || !vis) return;
+
+    const name = seasonName(season);
+
+    ctx.save();
+
+    if (name === 'winter') {
+      ctx.globalAlpha = 0.08;
+      ctx.fillStyle = '#dcecff';
+      ctx.fillRect(0, 0, getViewportW(), getViewportH());
+
+      ctx.globalAlpha = 0.45;
+      ctx.fillStyle = '#f8fdff';
+
+      for (let y = vis.y0; y <= vis.y1; y += 3) {
+        for (let x = vis.x0; x <= vis.x1; x += 4) {
+          const n = (x * 928371 + y * 364479 + Math.floor(tick / 24) * 53) % 19;
+          if (n !== 0) continue;
+          const px = tileToPxX(x + 0.3, cam);
+          const py = tileToPxY(y + 0.2, cam);
+          ctx.fillRect(px, py, Math.max(1, cam.z), Math.max(1, cam.z));
+        }
+      }
+    } else if (name === 'autumn') {
+      ctx.globalAlpha = 0.05;
+      ctx.fillStyle = '#d38b3a';
+      ctx.fillRect(0, 0, getViewportW(), getViewportH());
+
+      ctx.globalAlpha = 0.4;
+      const colors = ['#d9852d', '#b84f2a', '#e1a33a'];
+
+      for (let y = vis.y0; y <= vis.y1; y += 4) {
+        for (let x = vis.x0; x <= vis.x1; x += 5) {
+          const n = (x * 7127 + y * 9151 + Math.floor(tick / 40) * 17) % 23;
+          if (n !== 0) continue;
+          const px = tileToPxX(x + 0.5, cam);
+          const py = tileToPxY(y + 0.4, cam);
+          ctx.fillStyle = colors[(x + y) % colors.length];
+          ctx.fillRect(px, py, Math.max(1, cam.z * 1.5), Math.max(1, cam.z));
+        }
+      }
+    } else if (name === 'spring') {
+      ctx.globalAlpha = 0.035;
+      ctx.fillStyle = '#b9ffd0';
+      ctx.fillRect(0, 0, getViewportW(), getViewportH());
+    } else if (name === 'summer') {
+      ctx.globalAlpha = 0.025;
+      ctx.fillStyle = '#ffe2a0';
+      ctx.fillRect(0, 0, getViewportW(), getViewportH());
+    }
+
+    ctx.restore();
   }
 
   function drawShadow(tileX, tileY, footprintW = 1, footprintH = 1, screenRect = null) {
@@ -743,7 +820,6 @@ export function createRenderSystem(deps) {
     if (!ctx || !world) return;
     const cam = getCam();
     const tick = getTick();
-    const storageTotals = getStorageTotals ? getStorageTotals() : null;
     const g = ctx;
     const s = cam.z;
     const fp = getFootprint(b.kind);
@@ -763,76 +839,132 @@ export function createRenderSystem(deps) {
     const useMultiply = LIGHTING.useMultiplyComposite && LIGHTING.mode !== 'off';
     const sampledLight = useMultiply ? 1 : sampleLightAt(world, center.x, center.y);
     const shade = b.kind === 'farmplot' ? 1 : sampledLight;
-    const campfireShade = b.kind === 'campfire' ? Math.max(shade, 0.95) : shade;
     drawShadow(b.x, b.y, fp.w, fp.h);
     const offsetX = Math.floor((ENTITY_TILE_PX - fp.w * TILE) * s * 0.5);
     const offsetY = Math.floor((ENTITY_TILE_PX - fp.h * TILE) * s * 0.5);
     gx -= offsetX;
     gy -= offsetY;
     g.save();
-    if (b.kind === 'campfire') {
-      g.fillStyle = shadeFillColorLit('#7b8591', campfireShade);
-      g.fillRect(gx + 10 * s, gy + 18 * s, 12 * s, 6 * s);
-      const f = (tick % 6);
-      const flameColor = ['#ffde7a', '#ffc05a', '#ff9b4a'][f % 3];
-      const flameH = 6 * s * (1 + activityPulse * 0.8);
-      g.fillStyle = shadeFillColorLit(flameColor, campfireShade);
-      g.fillRect(gx + 14 * s, gy + 12 * s, 4 * s, flameH);
-      g.globalAlpha = 0.35 + activityPulse * 0.25;
-      g.fillStyle = shadeFillColorLit('rgba(142,142,142,0.75)', campfireShade);
+
+    const line = (x1, y1, x2, y2, color, width = 1) => {
+      g.strokeStyle = shadeFillColorLit(color, shade);
+      g.lineWidth = Math.max(1, Math.round(width * s));
       g.beginPath();
-      g.arc(gx + 16 * s, gy + (10 - f) * s, 3 * s + activityPulse * 3 * s, 0, Math.PI * 2);
-      g.fill();
+      g.moveTo(gx + x1 * s, gy + y1 * s);
+      g.lineTo(gx + x2 * s, gy + y2 * s);
+      g.stroke();
+    };
+
+    const box = (x, y, w, h, color) => {
+      g.fillStyle = shadeFillColorLit(color, shade);
+      g.fillRect(gx + x * s, gy + y * s, w * s, h * s);
+    };
+
+    const litBox = (x, y, w, h, color, alpha = 1) => {
+      const oldAlpha = g.globalAlpha;
+      g.globalAlpha *= alpha;
+      box(x, y, w, h, color);
+      g.globalAlpha = oldAlpha;
+    };
+
+    if (b.kind === 'campfire') {
+      box(10, 21, 12, 3, '#5a5a5a');
+      box(8, 22, 4, 3, '#777777');
+      box(20, 22, 4, 3, '#777777');
+      box(12, 20, 8, 2, '#3a2a1d');
+
+      line(11, 22, 21, 18, '#6a3d1f', 2);
+      line(21, 22, 11, 18, '#6a3d1f', 2);
+
+      const flame = 1 + activityPulse * 0.4;
+      litBox(14, 14 - flame, 4, 8 + flame, '#f7b733', 0.95);
+      litBox(15, 11 - flame, 2, 8 + flame, '#ff6b2d', 0.9);
+      litBox(16, 16, 2, 5, '#fff1a8', 0.85);
+
+      g.globalAlpha *= 0.28 + activityPulse * 0.25;
+      box(9, 9, 14, 14, '#ffb347');
+      g.globalAlpha = 1;
+
+      g.globalAlpha = 0.25;
+      box(13, 7 - Math.sin(tick * 0.05) * 2, 2, 2, '#d8d0c0');
+      box(18, 5 - Math.sin(tick * 0.04) * 2, 3, 2, '#d8d0c0');
       g.globalAlpha = 1;
     } else if (b.kind === 'storage') {
-      g.fillStyle = shadeFillColorLit('#6a5338', shade);
-      g.fillRect(gx + 6 * s, gy + 10 * s, 20 * s, 14 * s);
-      g.fillStyle = shadeFillColorLit('#8b6b44', shade);
-      g.fillRect(gx + 6 * s, gy + 20 * s, 20 * s, 2 * s);
-      g.fillStyle = shadeFillColorLit('#3b2b1a', shade);
-      g.fillRect(gx + 6 * s, gy + 10 * s, 20 * s, 1 * s);
-      const totals = storageTotals || { food: 0, wood: 0, stone: 0 };
-      // audit Phase 2: pelt intentionally excluded from this fill heuristic
-      // (visualizes building-material/food fullness, not craft-resource stocks).
-      const storedLevel = Math.min(1, (totals.food * 0.5 + totals.wood * 0.35 + totals.stone * 0.35) / 40);
-      if (storedLevel > 0.02) {
-        const fillH = Math.max(2 * s, Math.floor(12 * storedLevel) * s);
-        g.fillStyle = shadeFillColorLit('rgba(152,118,76,0.9)', shade);
-        g.fillRect(gx + 8 * s, gy + 10 * s + (12 * s - fillH), 16 * s, fillH);
+      box(7, 12, 18, 13, '#7a5530');
+      box(6, 10, 20, 4, '#5d3b20');
+      box(9, 15, 14, 2, '#9b7044');
+      box(9, 20, 14, 2, '#9b7044');
+      line(11, 13, 11, 25, '#4a2d18', 1);
+      line(20, 13, 20, 25, '#4a2d18', 1);
+
+      box(10, 22, 4, 3, '#c6a35f');
+      box(15, 21, 4, 4, '#8d8f72');
+      box(20, 22, 3, 3, '#b88a4f');
+
+      const stored = Math.min(1, (b.store || 0) / Math.max(1, BUILDINGS[b.kind]?.cost || 1));
+      if (stored > 0.15) {
+        litBox(8, 8, 16 * stored, 2, '#d0b56c', 0.75);
       }
     } else if (b.kind === 'hut') {
-      g.fillStyle = shadeFillColorLit('#7d5a3a', shade);
-      g.fillRect(gx + 8 * s, gy + 16 * s, 16 * s, 12 * s);
-      g.fillStyle = shadeFillColorLit('#caa56a', shade);
-      g.fillRect(gx + 6 * s, gy + 12 * s, 20 * s, 6 * s);
-      g.fillStyle = shadeFillColorLit('#31251a', shade);
-      g.fillRect(gx + 14 * s, gy + 20 * s, 4 * s, 8 * s);
-      if (activityPulse > 0.05) {
-        const glowAlpha = Math.min(0.55, 0.25 + activityPulse * 0.5);
-        g.fillStyle = shadeFillColorLit(`rgba(255,215,128,${glowAlpha})`, shade);
-        g.fillRect(gx + 10 * s, gy + 18 * s, 4 * s, 4 * s);
-        g.fillRect(gx + 16 * s, gy + 18 * s, 4 * s, 4 * s);
-      }
+      box(8, 14, 17, 12, '#8a5d35');
+      box(10, 16, 13, 10, '#a06d3f');
+      box(7, 12, 19, 3, '#5b3a22');
+      box(9, 9, 15, 4, '#6e4728');
+      box(11, 7, 11, 3, '#7a4e2c');
+
+      box(14, 19, 5, 7, '#3b2415');
+      litBox(21, 17, 2, 3, '#ffd27a', 0.45);
+      box(13, 26, 7, 2, '#4a2d19');
+    } else if (b.kind === 'hunterLodge') {
+      box(7, 14, 18, 12, '#765033');
+      box(8, 11, 16, 4, '#4b2f1c');
+      box(10, 8, 12, 4, '#5e3b22');
+      box(5, 18, 4, 8, '#6a4329');
+      box(23, 18, 4, 8, '#6a4329');
+
+      line(9, 9, 5, 6, '#d7c7a2', 1);
+      line(23, 9, 27, 6, '#d7c7a2', 1);
+      line(10, 9, 7, 5, '#d7c7a2', 1);
+      line(22, 9, 25, 5, '#d7c7a2', 1);
+
+      box(13, 19, 6, 7, '#2f2016');
+      box(20, 18, 3, 4, '#b78b5a');
     } else if (b.kind === 'farmplot') {
-      g.fillStyle = shadeFillColorLit('#4a3624', shade);
-      g.fillRect(gx + 4 * s, gy + 8 * s, 24 * s, 16 * s);
-      g.fillStyle = shadeFillColorLit('#3b2a1d', shade);
-      g.fillRect(gx + 4 * s, gy + 12 * s, 24 * s, 2 * s);
-      g.fillRect(gx + 4 * s, gy + 16 * s, 24 * s, 2 * s);
-      g.fillRect(gx + 4 * s, gy + 20 * s, 24 * s, 2 * s);
+      box(4, 8, 24, 17, '#4d3420');
+      box(5, 9, 22, 2, '#704d2f');
+      box(5, 14, 22, 2, '#332217');
+      box(5, 19, 22, 2, '#332217');
+      box(5, 24, 22, 1, '#704d2f');
+
+      for (let x = 8; x <= 23; x += 5) {
+        box(x, 12, 1, 10, '#7dbb58');
+        box(x - 1, 14, 3, 1, '#9fd46b');
+        box(x, 18, 3, 1, '#9fd46b');
+      }
+
+      box(3, 7, 2, 20, '#6b4a2d');
+      box(27, 7, 2, 20, '#6b4a2d');
     } else if (b.kind === 'well') {
-      g.fillStyle = shadeFillColorLit('#6f8696', shade);
-      g.fillRect(gx + 10 * s, gy + 14 * s, 12 * s, 10 * s);
-      g.fillStyle = shadeFillColorLit('#2b3744', shade);
-      g.fillRect(gx + 12 * s, gy + 18 * s, 8 * s, 6 * s);
-      g.fillStyle = shadeFillColorLit('#927a54', shade);
-      g.fillRect(gx + 8 * s, gy + 12 * s, 16 * s, 2 * s);
+      box(9, 16, 14, 9, '#728896');
+      box(10, 15, 12, 3, '#9baab4');
+      box(12, 19, 8, 5, '#263746');
+
+      box(8, 9, 2, 13, '#7b5b38');
+      box(22, 9, 2, 13, '#7b5b38');
+      box(7, 8, 18, 3, '#8a6842');
+      box(10, 5, 12, 4, '#5d3b22');
+
+      line(16, 11, 16, 18, '#2f2520', 1);
+      box(15, 18, 3, 3, '#6f4d2e');
+
+      litBox(13, 20, 6, 2, '#7ec8ff', 0.8);
+
       if (hydratePulse > 0.05) {
         g.strokeStyle = shadeFillColorLit('rgba(134,201,255,0.9)', shade);
         g.lineWidth = Math.max(1, Math.round(s));
         const ripple = 3 * s + (Math.sin(tick * 0.2) + 1) * s * 0.8;
         g.beginPath();
-        g.arc(gx + 16 * s, gy + 17 * s, ripple * (1 + hydratePulse * 0.6), 0, Math.PI * 2);
+        g.arc(gx + 16 * s, gy + 20 * s, ripple * (1 + hydratePulse * 0.6), 0, Math.PI * 2);
         g.stroke();
       }
     }
@@ -1098,12 +1230,17 @@ export function createRenderSystem(deps) {
     const vis = visibleTileBounds();
     const x0 = vis.x0, y0 = vis.y0, x1 = vis.x1, y1 = vis.y1;
 
-    const frames = Tileset.waterOverlay || [];
+    const season = normalizeSeason(world.season);
+    const frames = Tileset.waterOverlayBySeason?.[season]?.length
+      ? Tileset.waterOverlayBySeason[season]
+      : Tileset.waterOverlay || [];
+
     if (frames.length) {
       const frame = Math.floor((tick / 10) % frames.length);
       drawWaterOverlay(frames, frame, vis);
     }
 
+    drawSeasonAtmosphere(season, tick, vis);
     drawZoneOverlay(activeZoneJobs, cam, baseDx, baseDy);
 
     __ck('albedo:end', true, null);
@@ -1151,27 +1288,37 @@ export function createRenderSystem(deps) {
             const rect = entityDrawRect(x, y, cam);
             const raisedY = rect.y - Math.round(cam.z * TREE_VERTICAL_RAISE);
             const light = useMultiply ? 1 : sampleLightAt(world, x, y);
-            ctx.save();
-            ctx.drawImage(Tileset.sprite.tree, 0, 0, ENTITY_TILE_PX, ENTITY_TILE_PX, rect.x, raisedY, rect.size, rect.size);
-            applySpriteShadeLit(ctx, rect.x, raisedY, rect.size, rect.size, light);
-            ctx.restore();
+            const treeSprite = Tileset.sprite.treeBySeason?.[season] || Tileset.sprite.tree;
+            if (treeSprite) {
+              ctx.save();
+              ctx.drawImage(treeSprite, 0, 0, ENTITY_TILE_PX, ENTITY_TILE_PX, rect.x, raisedY, rect.size, rect.size);
+              applySpriteShadeLit(ctx, rect.x, raisedY, rect.size, rect.size, light);
+              ctx.restore();
+            }
           }
           if (world.berries[i] > 0) {
             drawShadow(x, y, 1, 1);
             const rect = entityDrawRect(x, y, cam);
             const light = useMultiply ? 1 : sampleLightAt(world, x, y);
-            ctx.save();
-            ctx.drawImage(Tileset.sprite.berry, 0, 0, ENTITY_TILE_PX, ENTITY_TILE_PX, rect.x, rect.y, rect.size, rect.size);
-            applySpriteShadeLit(ctx, rect.x, rect.y, rect.size, rect.size, light);
-            ctx.restore();
+            const berrySprite = Tileset.sprite.berryBySeason?.[season] || Tileset.sprite.berry;
+            if (berrySprite) {
+              ctx.save();
+              ctx.drawImage(berrySprite, 0, 0, ENTITY_TILE_PX, ENTITY_TILE_PX, rect.x, rect.y, rect.size, rect.size);
+              applySpriteShadeLit(ctx, rect.x, rect.y, rect.size, rect.size, light);
+              ctx.restore();
+            }
           }
           if (world.tiles[i] === TILES.FARMLAND && world.growth[i] > 0) {
             drawShadow(x, y, 1, 1);
             const stageIndex = Math.min(2, Math.floor(world.growth[i] / 80));
             const rect = entityDrawRect(x, y, cam);
-            ctx.save();
-            ctx.drawImage(Tileset.sprite.sprout[stageIndex], 0, 0, ENTITY_TILE_PX, ENTITY_TILE_PX, rect.x, rect.y, rect.size, rect.size);
-            ctx.restore();
+            const sproutSet = Tileset.sprite.sproutBySeason?.[season] || Tileset.sprite.sprout;
+            const sproutSprite = sproutSet?.[stageIndex] || Tileset.sprite.sprout?.[stageIndex];
+            if (sproutSprite) {
+              ctx.save();
+              ctx.drawImage(sproutSprite, 0, 0, ENTITY_TILE_PX, ENTITY_TILE_PX, rect.x, rect.y, rect.size, rect.size);
+              ctx.restore();
+            }
           }
         }
       }

--- a/src/app/tileset.js
+++ b/src/app/tileset.js
@@ -2,13 +2,56 @@ import { ENTITY_TILE_PX, TILE } from './constants.js';
 import { context2d } from './canvas.js';
 import { irnd } from './rng.js';
 
-const Tileset = { base:{}, waterOverlay:[], zoneGlyphs:{}, villagerSprites:{}, sprite:{ tree:null, berry:null, sprout:[], animals:{} } };
+const SEASON_NAMES = ['spring', 'summer', 'autumn', 'winter'];
 
-function makeCanvas(w,h){ const c=document.createElement('canvas'); c.width=w; c.height=h; return c; }
-function px(g,x,y,c){ if(!g) return; g.fillStyle=c; g.fillRect(x,y,1,1); }
-function rect(g,x,y,w,h,c){ if(!g) return; g.fillStyle=c; g.fillRect(x,y,w,h); }
-function makeSprite(w,h,drawFn){
-  const c = makeCanvas(w,h);
+function normalizeSeason(season) {
+  const n = Number.isFinite(season) ? Math.floor(season) : 0;
+  return ((n % 4) + 4) % 4;
+}
+
+function seasonName(season) {
+  return SEASON_NAMES[normalizeSeason(season)] || 'spring';
+}
+
+const Tileset = {
+  base: {},
+  baseBySeason: [{}, {}, {}, {}],
+  waterOverlay: [],
+  waterOverlayBySeason: [[], [], [], []],
+  zoneGlyphs: {},
+  villagerSprites: {},
+  sprite: {
+    tree: null,
+    treeBySeason: [],
+    berry: null,
+    berryBySeason: [],
+    sprout: [],
+    sproutBySeason: [[], [], [], []],
+    animals: {}
+  }
+};
+
+function makeCanvas(w, h) {
+  const c = document.createElement('canvas');
+  c.width = w;
+  c.height = h;
+  return c;
+}
+
+function px(g, x, y, c) {
+  if (!g) return;
+  g.fillStyle = c;
+  g.fillRect(x, y, 1, 1);
+}
+
+function rect(g, x, y, w, h, c) {
+  if (!g) return;
+  g.fillStyle = c;
+  g.fillRect(x, y, w, h);
+}
+
+function makeSprite(w, h, drawFn) {
+  const c = makeCanvas(w, h);
   const g = context2d(c);
   if (!g) return c;
   if (typeof drawFn === 'function') drawFn(g);
@@ -31,120 +74,875 @@ const SHADOW_TEXTURE = (() => {
   return canvas;
 })();
 
-function makeGrassVariant({ base, blades, shadow, overlay, extras }){
-  const c=makeCanvas(TILE,TILE), g=context2d(c);
-  if (!g) return c;
-  rect(g,0,0,TILE,TILE,base);
-  for(let i=0;i<40;i++){
-    const color=blades[i % blades.length];
-    px(g,irnd(0,TILE-1),irnd(0,TILE-1),color);
+const SEASON_PALETTES = [
+  {
+    name: 'spring',
+    grass: {
+      base: '#2d703b',
+      blades: ['#3f9a50', '#4fb660', '#77d26f', '#2f8444'],
+      shadow: '#1f4f2b',
+      flowers: ['#f8e7a1', '#ffc5df', '#d7f3ff']
+    },
+    forest: {
+      base: '#285f35',
+      blades: ['#347a43', '#429a55', '#5ebd67'],
+      shadow: '#1c4426'
+    },
+    fertile: {
+      base: '#347c43',
+      blades: ['#51b968', '#419e55', '#82dc7a'],
+      shadow: '#245f31'
+    },
+    meadow: {
+      base: '#3c8548',
+      blades: ['#61bb6d', '#4aa75a', '#93e084'],
+      shadow: '#2b6235',
+      flowers: ['#fff3ac', '#ffb8d5', '#c9f0ff', '#e9c9ff']
+    },
+    marsh: {
+      base: '#255940',
+      blades: ['#357953', '#2d6849', '#4d8c65'],
+      shadow: '#183b2a',
+      puddle: '#34615e'
+    },
+    sand: {
+      base: '#c4a761',
+      specks: ['#d8c17c', '#a98c4a', '#edd691']
+    },
+    rock: {
+      base: '#626c75',
+      specks: ['#8d98a2', '#4e5861', '#74808b']
+    },
+    water: {
+      base: '#155a7c',
+      deep: '#0e3f5b',
+      ripple: '#79c7ef'
+    },
+    farmland: {
+      soil: '#563d26',
+      furrow: '#3d2a1a',
+      highlight: '#745133'
+    },
+    snow: {
+      base: '#d9e8f7',
+      specks: ['#c8d8e8', '#eef8ff']
+    },
+    tree: {
+      trunk: '#68401f',
+      barkDark: '#4d2d17',
+      leafDark: '#255d31',
+      leafMid: '#348143',
+      leafLight: '#62bd62',
+      accent: '#b6e89a',
+      snow: null
+    },
+    berry: {
+      leafDark: '#2f6938',
+      leafMid: '#3d8848',
+      leafLight: '#5cad5c',
+      fruit: '#b74c6b',
+      fruitLight: '#e27791',
+      snow: null
+    },
+    crop: {
+      stem: '#64ad55',
+      leaf: '#86cc6b',
+      head: '#d9c35c',
+      frost: null
+    }
+  },
+  {
+    name: 'summer',
+    grass: {
+      base: '#2f6d35',
+      blades: ['#3c8f43', '#4fa94f', '#6fc55f', '#2b7a3a'],
+      shadow: '#204c26',
+      flowers: ['#f4db7b', '#f6a6c8']
+    },
+    forest: {
+      base: '#245b2d',
+      blades: ['#31733a', '#3e8e47', '#56aa55'],
+      shadow: '#193f20'
+    },
+    fertile: {
+      base: '#326f37',
+      blades: ['#4fa854', '#3f9349', '#7cc76d'],
+      shadow: '#214e28'
+    },
+    meadow: {
+      base: '#3b7c3f',
+      blades: ['#5dab5c', '#4b9950', '#80cf6b'],
+      shadow: '#2a5830',
+      flowers: ['#f8df70', '#f2a6c0', '#fff2a0']
+    },
+    marsh: {
+      base: '#254f38',
+      blades: ['#34704d', '#2d6044', '#4a805d'],
+      shadow: '#173625',
+      puddle: '#2f5657'
+    },
+    sand: {
+      base: '#c9aa61',
+      specks: ['#e0c87e', '#ac8f4a', '#f1d98d']
+    },
+    rock: {
+      base: '#5f6870',
+      specks: ['#89949d', '#4d555d', '#717b84']
+    },
+    water: {
+      base: '#145273',
+      deep: '#0b3a54',
+      ripple: '#68b9e5'
+    },
+    farmland: {
+      soil: '#523720',
+      furrow: '#392616',
+      highlight: '#6d492b'
+    },
+    snow: {
+      base: '#d3e1ef',
+      specks: ['#c0cfdd', '#eaf3fb']
+    },
+    tree: {
+      trunk: '#5f381c',
+      barkDark: '#432614',
+      leafDark: '#214f27',
+      leafMid: '#2f7636',
+      leafLight: '#54a94f',
+      accent: '#83d06a',
+      snow: null
+    },
+    berry: {
+      leafDark: '#2c5f32',
+      leafMid: '#39793e',
+      leafLight: '#58a654',
+      fruit: '#9f384f',
+      fruitLight: '#d45b73',
+      snow: null
+    },
+    crop: {
+      stem: '#5f9f48',
+      leaf: '#7dbd55',
+      head: '#e2c75c',
+      frost: null
+    }
+  },
+  {
+    name: 'autumn',
+    grass: {
+      base: '#6d6938',
+      blades: ['#817b3f', '#9c8740', '#b9873a', '#5f5e33'],
+      shadow: '#4b4828',
+      leaves: ['#d27b31', '#bf4d2d', '#e2a03c']
+    },
+    forest: {
+      base: '#5f5b32',
+      blades: ['#806a34', '#a46f32', '#ba8436'],
+      shadow: '#3f3b22'
+    },
+    fertile: {
+      base: '#6a6338',
+      blades: ['#8a7c42', '#a0853f', '#c08f3b'],
+      shadow: '#4a4428'
+    },
+    meadow: {
+      base: '#74683a',
+      blades: ['#9b7f3d', '#b8893a', '#d09a45'],
+      shadow: '#51472a',
+      flowers: ['#e6b85c', '#d77a45']
+    },
+    marsh: {
+      base: '#455139',
+      blades: ['#667148', '#76693f', '#8a6b3d'],
+      shadow: '#303827',
+      puddle: '#435a56'
+    },
+    sand: {
+      base: '#b99858',
+      specks: ['#c8aa68', '#9f8045', '#dfc47a']
+    },
+    rock: {
+      base: '#626468',
+      specks: ['#888b90', '#4d5054', '#777a7f']
+    },
+    water: {
+      base: '#174d66',
+      deep: '#0d384a',
+      ripple: '#6aa8c8'
+    },
+    farmland: {
+      soil: '#4e321e',
+      furrow: '#362114',
+      highlight: '#69442a'
+    },
+    snow: {
+      base: '#d3dfec',
+      specks: ['#c3cfdb', '#eef5fb']
+    },
+    tree: {
+      trunk: '#5d3519',
+      barkDark: '#3f2210',
+      leafDark: '#8a3f24',
+      leafMid: '#b75f2d',
+      leafLight: '#e09a3a',
+      accent: '#f0c35b',
+      snow: null
+    },
+    berry: {
+      leafDark: '#5c4f2c',
+      leafMid: '#806b33',
+      leafLight: '#b9863c',
+      fruit: '#8e2f3e',
+      fruitLight: '#c85662',
+      snow: null
+    },
+    crop: {
+      stem: '#96783f',
+      leaf: '#b39145',
+      head: '#e0b854',
+      frost: null
+    }
+  },
+  {
+    name: 'winter',
+    grass: {
+      base: '#b9cddd',
+      blades: ['#d7e6f1', '#a8bdcc', '#eef7fb', '#91a7b7'],
+      shadow: '#93aabc',
+      snowFlecks: ['#f8fdff', '#dcecf7']
+    },
+    forest: {
+      base: '#aebfcd',
+      blades: ['#cbdbe7', '#91a5b5', '#eaf5fb'],
+      shadow: '#879cac'
+    },
+    fertile: {
+      base: '#b5c6d3',
+      blades: ['#d5e2ec', '#9cafbd', '#edf6fb'],
+      shadow: '#8ba0b0'
+    },
+    meadow: {
+      base: '#bdcfdb',
+      blades: ['#d9e8f2', '#a5b9c7', '#eff8fc'],
+      shadow: '#95aaba',
+      flowers: []
+    },
+    marsh: {
+      base: '#91a9b5',
+      blades: ['#b5c9d4', '#839ca9', '#d5e5ec'],
+      shadow: '#6f8793',
+      puddle: '#73919f'
+    },
+    sand: {
+      base: '#c4c7bd',
+      specks: ['#e5e9e5', '#aaaea7', '#d6dad2']
+    },
+    rock: {
+      base: '#68727c',
+      specks: ['#a1adb6', '#515b65', '#d9e5ee']
+    },
+    water: {
+      base: '#8fb6c8',
+      deep: '#5d879c',
+      ripple: '#d8f4ff'
+    },
+    farmland: {
+      soil: '#81756a',
+      furrow: '#6b625a',
+      highlight: '#b9c9d4'
+    },
+    snow: {
+      base: '#dcebf8',
+      specks: ['#c8d9e8', '#f6fdff']
+    },
+    tree: {
+      trunk: '#4f321c',
+      barkDark: '#332011',
+      leafDark: '#6f8290',
+      leafMid: '#91a7b5',
+      leafLight: '#dcecf7',
+      accent: '#f8fdff',
+      snow: '#eef8ff'
+    },
+    berry: {
+      leafDark: '#71818b',
+      leafMid: '#9aacb8',
+      leafLight: '#dcebf4',
+      fruit: '#8e3345',
+      fruitLight: '#c55b6c',
+      snow: '#f4fbff'
+    },
+    crop: {
+      stem: '#8da18a',
+      leaf: '#b6c6ad',
+      head: '#d6d4a5',
+      frost: '#eef8ff'
+    }
   }
-  if(shadow){ g.globalAlpha=0.25; rect(g,0,TILE-5,TILE,5,shadow); g.globalAlpha=1; }
-  if(overlay){ const oa=(typeof overlay.alpha==='number')?overlay.alpha:1; g.globalAlpha=oa; rect(g,0,0,TILE,TILE,overlay.color); g.globalAlpha=1; }
-  if(typeof extras==='function') extras(g);
+];
+
+function noisePixels(g, colors, count, alpha = 1) {
+  if (!g || !colors || !colors.length) return;
+  const oldAlpha = g.globalAlpha;
+  g.globalAlpha = alpha;
+  for (let i = 0; i < count; i++) {
+    px(g, irnd(0, TILE - 1), irnd(0, TILE - 1), colors[i % colors.length]);
+  }
+  g.globalAlpha = oldAlpha;
+}
+
+function grassClumps(g, colors, count) {
+  if (!g || !colors || !colors.length) return;
+  for (let i = 0; i < count; i++) {
+    const x = irnd(0, TILE - 2);
+    const y = irnd(2, TILE - 3);
+    const c = colors[i % colors.length];
+    px(g, x, y, c);
+    if (i % 3 === 0) px(g, x + 1, y, c);
+    if (i % 5 === 0 && y > 0) px(g, x, y - 1, c);
+  }
+}
+
+function cornerShade(g, color) {
+  if (!g) return;
+  const oldAlpha = g.globalAlpha;
+  g.globalAlpha = 0.22;
+  rect(g, 0, TILE - 5, TILE, 5, color);
+  rect(g, TILE - 4, 0, 4, TILE, color);
+  g.globalAlpha = oldAlpha;
+}
+
+function snowDust(g, colors, count = 22) {
+  if (!g || !colors || !colors.length) return;
+  const oldAlpha = g.globalAlpha;
+  g.globalAlpha = 0.55;
+  for (let i = 0; i < count; i++) {
+    const x = irnd(0, TILE - 2);
+    const y = irnd(0, TILE - 2);
+    const c = colors[i % colors.length];
+    px(g, x, y, c);
+    if (i % 4 === 0) px(g, x + 1, y, c);
+  }
+  g.globalAlpha = oldAlpha;
+}
+
+function leafScatter(g, colors, count = 8) {
+  if (!g || !colors || !colors.length) return;
+  for (let i = 0; i < count; i++) {
+    const x = irnd(1, TILE - 3);
+    const y = irnd(2, TILE - 3);
+    const c = colors[i % colors.length];
+    px(g, x, y, c);
+    if (i % 2 === 0) px(g, x + 1, y, c);
+  }
+}
+
+function flowerScatter(g, colors, count = 5) {
+  if (!g || !colors || !colors.length) return;
+  const oldAlpha = g.globalAlpha;
+  g.globalAlpha = 0.9;
+  for (let i = 0; i < count; i++) {
+    const x = irnd(1, TILE - 2);
+    const y = irnd(2, TILE - 3);
+    const c = colors[i % colors.length];
+    px(g, x, y, c);
+    if (i % 3 === 0) px(g, x + 1, y, c);
+  }
+  g.globalAlpha = oldAlpha;
+}
+
+function makeGroundTile(palette, kind) {
+  const c = makeCanvas(TILE, TILE);
+  const g = context2d(c);
+  if (!g) return c;
+
+  const p = palette[kind] || palette.grass;
+  rect(g, 0, 0, TILE, TILE, p.base);
+
+  grassClumps(g, p.blades || [], kind === 'forest' ? 32 : 42);
+
+  if (kind === 'marsh' && p.puddle) {
+    const oldAlpha = g.globalAlpha;
+    g.globalAlpha = 0.28;
+    rect(g, 4, 8, 7, 2, p.puddle);
+    rect(g, 17, 18, 8, 2, p.puddle);
+    rect(g, 12, 25, 5, 1, p.puddle);
+    g.globalAlpha = oldAlpha;
+  }
+
+  if (palette.name === 'spring' && kind === 'meadow') {
+    flowerScatter(g, p.flowers, 8);
+  } else if (palette.name === 'summer' && kind === 'meadow') {
+    flowerScatter(g, p.flowers, 5);
+  }
+
+  if (palette.name === 'autumn') {
+    leafScatter(g, p.leaves || palette.grass.leaves, kind === 'forest' ? 12 : 7);
+  }
+
+  if (palette.name === 'winter') {
+    snowDust(g, p.snowFlecks || palette.grass.snowFlecks, kind === 'forest' ? 26 : 34);
+  }
+
+  cornerShade(g, p.shadow || palette.grass.shadow);
   return c;
 }
 
-function makeGrass(){
-  return makeGrassVariant({
-    base:'#245a2f',
-    blades:['#2f7d3d','#2a6b37','#2a5f34'],
-    shadow:'#1a3e22'
-  });
+function makeSandTile(palette) {
+  const c = makeCanvas(TILE, TILE);
+  const g = context2d(c);
+  if (!g) return c;
+  const p = palette.sand;
+  rect(g, 0, 0, TILE, TILE, p.base);
+  noisePixels(g, p.specks, 32, 0.8);
+  if (palette.name === 'winter') snowDust(g, palette.snow.specks, 12);
+  cornerShade(g, '#927a45');
+  return c;
 }
-function makeFertile(){
-  return makeGrassVariant({
-    base:'#276b33',
-    blades:['#358845','#2f7d3d','#2c7036'],
-    shadow:'#1a3e22',
-    overlay:{ color:'rgba(140,220,145,0.18)', alpha:1 }
-  });
+
+function makeSnowTile(palette) {
+  const c = makeCanvas(TILE, TILE);
+  const g = context2d(c);
+  if (!g) return c;
+  const p = palette.snow;
+  rect(g, 0, 0, TILE, TILE, p.base);
+  snowDust(g, p.specks, 36);
+  cornerShade(g, '#b9cadc');
+  return c;
 }
-function makeMeadow(){
-  return makeGrassVariant({
-    base:'#276f39',
-    blades:['#348846','#2f7d3d','#2d7137'],
-    shadow:'#1a3e22',
-    overlay:{ color:'rgba(200,255,200,0.1)', alpha:1 },
-    extras:(g)=>{
-      const flowers=['#f4f0c0','#f7b4d4','#d5f5ff'];
-      g.globalAlpha=0.85;
-      for(let i=0;i<6;i++){
-        px(g,irnd(0,TILE-1),irnd(0,TILE-1),flowers[i%flowers.length]);
-      }
-      g.globalAlpha=1;
+
+function makeRockTile(palette) {
+  const c = makeCanvas(TILE, TILE);
+  const g = context2d(c);
+  if (!g) return c;
+  const p = palette.rock;
+  rect(g, 0, 0, TILE, TILE, p.base);
+  noisePixels(g, p.specks, 36, 0.85);
+
+  g.globalAlpha = 0.18;
+  rect(g, 3, 4, 12, 3, '#ffffff');
+  rect(g, 14, 18, 10, 2, '#ffffff');
+  g.globalAlpha = 1;
+
+  if (palette.name === 'winter') snowDust(g, palette.snow.specks, 16);
+  cornerShade(g, '#454d55');
+  return c;
+}
+
+function makeWaterBase(palette) {
+  const c = makeCanvas(TILE, TILE);
+  const g = context2d(c);
+  if (!g) return c;
+  const p = palette.water;
+  rect(g, 0, 0, TILE, TILE, p.base);
+
+  g.globalAlpha = 0.28;
+  rect(g, 0, TILE - 9, TILE, 9, p.deep);
+  rect(g, 0, 0, TILE, 4, '#ffffff');
+  g.globalAlpha = 1;
+
+  noisePixels(g, [p.deep, p.ripple], 18, palette.name === 'winter' ? 0.35 : 0.2);
+
+  if (palette.name === 'winter') {
+    g.globalAlpha = 0.32;
+    rect(g, 2, 5, 12, 2, '#e8fbff');
+    rect(g, 18, 20, 10, 2, '#e8fbff');
+    g.globalAlpha = 1;
+  }
+
+  return c;
+}
+
+function makeWaterOverlayFrames(palette) {
+  const frames = [];
+  const p = palette.water;
+
+  for (let f = 0; f < 4; f++) {
+    const c = makeCanvas(TILE, TILE);
+    const g = context2d(c);
+    if (!g) {
+      frames.push(c);
+      continue;
     }
-  });
-}
-function makeMarsh(){
-  return makeGrassVariant({
-    base:'#1f4e32',
-    blades:['#2d6a45','#245b3a','#27543a'],
-    shadow:'#163724',
-    overlay:{ color:'rgba(20,40,35,0.22)', alpha:1 },
-    extras:(g)=>{
-      const puddles=['#3a6b63','#2f5550'];
-      g.globalAlpha=0.35;
-      for(let i=0;i<5;i++){
-        px(g,irnd(0,TILE-1),irnd(0,TILE-1),puddles[i%puddles.length]);
-      }
-      g.globalAlpha=1;
+
+    g.globalAlpha = palette.name === 'winter' ? 0.18 : 0.26;
+    g.strokeStyle = p.ripple;
+    g.lineWidth = 1;
+
+    for (let i = 0; i < 3; i++) {
+      const y = 6 + i * 9 + f;
+      g.beginPath();
+      g.moveTo(-2, y);
+      g.quadraticCurveTo(TILE * 0.35, y + 3, TILE * 0.7, y);
+      g.quadraticCurveTo(TILE * 0.88, y - 2, TILE + 2, y + 1);
+      g.stroke();
     }
-  });
+
+    g.globalAlpha = 1;
+    frames.push(c);
+  }
+
+  return frames;
 }
-function makeSand(){ const c=makeCanvas(TILE,TILE), g=context2d(c); if(!g) return c; rect(g,0,0,TILE,TILE,'#b99a52'); for(let i=0;i<28;i++){ px(g,irnd(0,TILE-1),irnd(0,TILE-1), i%2?'#c7ad69':'#a78848'); } return c; }
-function makeSnow(){ const c=makeCanvas(TILE,TILE), g=context2d(c); if(!g) return c; rect(g,0,0,TILE,TILE,'#d7e6f8'); for(let i=0;i<24;i++){ px(g,irnd(0,TILE-1),irnd(0,TILE-1), '#c9d7ea'); } rect(g,0,TILE-4,TILE,4,'#c0d0e8'); return c; }
-function makeRock(){ const c=makeCanvas(TILE,TILE), g=context2d(c); if(!g) return c; rect(g,0,0,TILE,TILE,'#59616c'); for(let i=0;i<30;i++){ px(g,irnd(0,TILE-1),irnd(0,TILE-1), i%2?'#8f99a5':'#6c757f'); } rect(g,0,TILE-5,TILE,5,'#4a525b'); return c; }
-function makeWaterBase(){ const c=makeCanvas(TILE,TILE), g=context2d(c); if(!g) return c; rect(g,0,0,TILE,TILE,'#134a6a'); for (let i = 0; i < 14; i++) { px(g,irnd(0,TILE-1),irnd(0,TILE-1), i%2?'#0f3e59':'#0c3248'); } return c; }
-function makeWaterOverlayFrames(){ const frames=[]; for(let f=0; f<3; f++){ const c=makeCanvas(TILE,TILE), g=context2d(c); if(!g){ frames.push(c); continue; } g.globalAlpha=0.22; g.strokeStyle='#4fa3d6'; g.lineWidth=1; g.beginPath(); for(let i=0;i<3;i++){ const y=6+i*10+f*2; g.moveTo(0,y); g.quadraticCurveTo(TILE*0.5,y+2,TILE,y); } g.stroke(); g.globalAlpha=1; frames.push(c); } return frames; }
-function makeFarmland(){ const c=makeCanvas(TILE,TILE), g=context2d(c); if(!g) return c; rect(g,0,0,TILE,TILE,'#4a3624'); g.globalAlpha=0.25; for(let y=3;y<TILE;y+=6){ rect(g,0,y,TILE,2,'#3b2a1d'); } g.globalAlpha=1; return c; }
-function drawSproutOn(g,stage){
-  if(!g) return;
-  const s=Math.min(3,Math.floor(stage));
-  if(s<=0) return;
-  const centerX=Math.floor(ENTITY_TILE_PX/2);
-  const centerY=Math.floor(ENTITY_TILE_PX/2);
-  const gx=centerX-1;
-  const gy=centerY-1;
-  g.fillStyle='#86c06c';
-  g.fillRect(gx,gy,2,2);
-  if(s>=2){ g.fillRect(gx-2,gy+2,6,2); }
-  if(s>=3){ g.fillRect(gx-1,gy-2,4,2); }
+
+function makeFarmlandTile(palette) {
+  const c = makeCanvas(TILE, TILE);
+  const g = context2d(c);
+  if (!g) return c;
+
+  const p = palette.farmland;
+  rect(g, 0, 0, TILE, TILE, p.soil);
+
+  for (let y = 4; y < TILE; y += 6) {
+    rect(g, 0, y, TILE, 2, p.furrow);
+    rect(g, 0, y - 1, TILE, 1, p.highlight);
+  }
+
+  noisePixels(g, [p.furrow, p.highlight], 24, 0.35);
+
+  if (palette.name === 'autumn') {
+    leafScatter(g, palette.grass.leaves, 7);
+  }
+
+  if (palette.name === 'winter') {
+    snowDust(g, palette.snow.specks, 20);
+  }
+
+  cornerShade(g, p.furrow);
+  return c;
+}
+function drawCanopyBlob(g, x, y, w, h, color) {
+  rect(g, x + 2, y, w - 4, h, color);
+  rect(g, x, y + 2, w, h - 4, color);
+  rect(g, x + 1, y + 1, w - 2, h - 2, color);
+}
+
+function drawTree(g, season = 0) {
+  if (!g) return;
+  const palette = SEASON_PALETTES[normalizeSeason(season)];
+  const p = palette.tree;
+  const winter = palette.name === 'winter';
+
+  g.globalAlpha = 0.25;
+  rect(g, 8, 25, 17, 3, '#000000');
+  g.globalAlpha = 1;
+
+  rect(g, 14, 17, 5, 10, p.trunk);
+  rect(g, 13, 22, 3, 4, p.barkDark);
+  rect(g, 18, 21, 3, 5, p.barkDark);
+  rect(g, 12, 26, 4, 2, p.barkDark);
+  rect(g, 18, 26, 4, 2, p.barkDark);
+
+  if (winter) {
+    rect(g, 15, 8, 2, 10, p.barkDark);
+    rect(g, 10, 12, 7, 2, p.barkDark);
+    rect(g, 17, 13, 7, 2, p.barkDark);
+    rect(g, 8, 9, 4, 2, p.snow);
+    rect(g, 19, 10, 7, 2, p.snow);
+    rect(g, 12, 5, 8, 3, p.leafLight);
+    rect(g, 9, 8, 14, 4, p.leafMid);
+    rect(g, 7, 13, 18, 4, p.leafDark);
+    rect(g, 10, 7, 8, 1, p.accent);
+    rect(g, 7, 12, 12, 1, p.accent);
+    return;
+  }
+
+  drawCanopyBlob(g, 8, 8, 17, 13, p.leafDark);
+  drawCanopyBlob(g, 6, 13, 21, 10, p.leafMid);
+  drawCanopyBlob(g, 11, 5, 12, 10, p.leafMid);
+  rect(g, 12, 7, 7, 2, p.leafLight);
+  rect(g, 9, 15, 6, 2, p.leafLight);
+  rect(g, 18, 13, 5, 2, p.accent);
+  px(g, 22, 18, p.leafDark);
+  px(g, 7, 17, p.leafDark);
+}
+
+function drawBerry(g, season = 0) {
+  if (!g) return;
+  const palette = SEASON_PALETTES[normalizeSeason(season)];
+  const p = palette.berry;
+  const winter = palette.name === 'winter';
+
+  g.globalAlpha = 0.22;
+  rect(g, 8, 25, 17, 3, '#000000');
+  g.globalAlpha = 1;
+
+  drawCanopyBlob(g, 8, 15, 16, 10, p.leafDark);
+  drawCanopyBlob(g, 6, 18, 20, 8, p.leafMid);
+  rect(g, 10, 16, 7, 2, p.leafLight);
+  rect(g, 17, 20, 6, 2, p.leafLight);
+
+  if (!winter) {
+    rect(g, 11, 18, 2, 2, p.fruit);
+    rect(g, 18, 19, 2, 2, p.fruit);
+    rect(g, 15, 22, 2, 2, p.fruitLight);
+    if (palette.name !== 'spring') rect(g, 22, 22, 2, 2, p.fruit);
+  } else {
+    rect(g, 8, 15, 10, 2, p.snow);
+    rect(g, 15, 19, 10, 2, p.snow);
+    rect(g, 13, 23, 2, 2, p.fruit);
+  }
+}
+
+function drawSproutOn(g, stage, season = 0) {
+  if (!g) return;
+  const s = Math.min(3, Math.max(1, Math.floor(stage)));
+  const palette = SEASON_PALETTES[normalizeSeason(season)];
+  const p = palette.crop;
+
+  g.globalAlpha = 0.18;
+  rect(g, 8, 25, 17, 2, '#000000');
+  g.globalAlpha = 1;
+
+  if (s === 1) {
+    rect(g, 15, 19, 2, 6, p.stem);
+    rect(g, 12, 20, 4, 2, p.leaf);
+    rect(g, 17, 18, 4, 2, p.leaf);
+  } else if (s === 2) {
+    for (let x = 9; x <= 21; x += 4) {
+      rect(g, x, 16, 2, 9, p.stem);
+      rect(g, x - 2, 18, 4, 2, p.leaf);
+      rect(g, x + 1, 20, 4, 2, p.leaf);
+    }
+  } else {
+    for (let x = 8; x <= 22; x += 4) {
+      rect(g, x, 13, 2, 12, p.stem);
+      rect(g, x - 2, 16, 4, 2, p.leaf);
+      rect(g, x + 1, 19, 4, 2, p.leaf);
+      rect(g, x - 1, 11, 4, 3, p.head);
+    }
+  }
+
+  if (p.frost) {
+    g.globalAlpha = 0.55;
+    rect(g, 10, 13, 13, 1, p.frost);
+    rect(g, 12, 18, 10, 1, p.frost);
+    g.globalAlpha = 1;
+  }
 }
 function makeZoneGlyphs(){ const farm=makeCanvas(8,8), f=context2d(farm); rect(f,0,0,8,8,'rgba(0,0,0,0)'); px(f,3,6,'#9dd47a'); px(f,4,6,'#9dd47a'); px(f,3,5,'#73b85d'); px(f,4,5,'#73b85d'); px(f,3,4,'#5aa34b'); const cut=makeCanvas(8,8), c=context2d(cut); rect(c,0,0,8,8,'rgba(0,0,0,0)'); rect(c,2,2,4,1,'#caa56a'); rect(c,3,1,2,1,'#8f6934'); const mine=makeCanvas(8,8), m=context2d(mine); rect(m,0,0,8,8,'rgba(0,0,0,0)'); rect(m,2,2,4,1,'#9aa3ad'); rect(m,3,3,2,1,'#6d7782'); Tileset.zoneGlyphs={farm,cut,mine}; }
-function makeVillagerFrames(){ function role(shirt,hat){ const frames=[]; for(let f=0; f<3; f++){ const c=makeCanvas(16,16), g=context2d(c); rect(g,7,4,2,2,'#f1d4b6'); if(hat){ rect(g,6,3,4,1,hat); rect(g,6,2,4,1,hat); } rect(g,6,6,4,4,shirt); if(f===0){ rect(g,5,6,1,3,shirt); rect(g,10,6,1,2,shirt); } if(f===1){ rect(g,5,6,1,2,shirt); rect(g,10,6,1,3,shirt); } if(f===2){ rect(g,5,6,1,2,shirt); rect(g,10,6,1,2,shirt); } rect(g,6,10,1,4,'#3f3f4f'); rect(g,9,10,1,4,'#3f3f4f'); frames.push(c);} return frames; } Tileset.villagerSprites.farmer=role('#3aa357','#d6cf74'); Tileset.villagerSprites.worker=role('#a36b3a','#8f7440'); Tileset.villagerSprites.explorer=role('#3a6aa3',null); Tileset.villagerSprites.sleepy=role('#777','#444'); }
+function makeVillagerFrames() {
+  function role(options) {
+    const {
+      shirt,
+      shirtDark,
+      pants,
+      hair,
+      hat,
+      skin = '#f1d4b6'
+    } = options;
 
-function drawTree(g){ g.fillStyle='#6b3f1f'; g.fillRect(14,20,4,6); g.fillStyle='#2c6b34'; g.fillRect(10,12,12,10); g.fillStyle='#2f7f3d'; g.fillRect(12,10,8,4); }
-function drawBerry(g){ g.fillStyle='#2f6d36'; g.fillRect(8,16,16,10); g.fillStyle='#a04a5a'; g.fillRect(12,18,2,2); g.fillRect(18,20,2,2); g.fillRect(16,22,2,2); }
-function drawDeer(g){ g.fillStyle='#8b5e3c'; g.fillRect(10,14,10,10); g.fillRect(8,16,2,8); g.fillRect(20,16,2,8); g.fillRect(10,12,6,4); g.fillRect(14,10,2,4); g.fillRect(10,10,2,2); }
-function drawBoar(g){ g.fillStyle='#5a3a2a'; g.fillRect(10,16,12,10); g.fillRect(8,18,2,8); g.fillRect(22,18,2,8); g.fillRect(12,12,6,4); g.fillRect(10,14,2,2); }
+    const frames = [];
 
-function buildTileset(){
-  try { Tileset.base.grass = makeGrass(); } catch(e){ console.warn('grass', e); }
-  try { Tileset.base.fertile = makeFertile(); } catch(e){ console.warn('fertile', e); }
-  try { Tileset.base.meadow = makeMeadow(); } catch(e){ console.warn('meadow', e); }
-  try { Tileset.base.marsh = makeMarsh(); } catch(e){ console.warn('marsh', e); }
-  try { Tileset.base.sand = makeSand(); } catch(e){ console.warn('sand', e); }
-  try { Tileset.base.snow = makeSnow(); } catch(e){ console.warn('snow', e); }
-  try { Tileset.base.rock = makeRock(); } catch(e){ console.warn('rock', e); }
-  try { Tileset.base.water = makeWaterBase(); } catch(e){ console.warn('water', e); }
-  try { Tileset.base.farmland = makeFarmland(); } catch(e){ console.warn('farmland', e); }
-  try { Tileset.waterOverlay = makeWaterOverlayFrames(); } catch(e){ console.warn('waterOverlay', e); Tileset.waterOverlay = []; }
-  try { makeZoneGlyphs(); } catch(e){ console.warn('zones', e); }
-  try { makeVillagerFrames(); } catch(e){ console.warn('villagers', e); }
+    for (let f = 0; f < 3; f++) {
+      const c = makeCanvas(16, 16);
+      const g = context2d(c);
+      if (!g) {
+        frames.push(c);
+        continue;
+      }
+
+      const armSwing = f === 1 ? 1 : f === 2 ? -1 : 0;
+      const legA = f === 1 ? 1 : 0;
+      const legB = f === 2 ? 1 : 0;
+
+      g.globalAlpha = 0.2;
+      rect(g, 4, 14, 8, 1, '#000000');
+      g.globalAlpha = 1;
+
+      rect(g, 6, 4, 4, 4, skin);
+      rect(g, 6, 3, 4, 2, hair);
+
+      if (hat) {
+        rect(g, 5, 2, 6, 1, hat);
+        rect(g, 6, 1, 4, 2, hat);
+      }
+
+      px(g, 7, 5, '#35251d');
+      px(g, 9, 5, '#35251d');
+
+      rect(g, 5, 8, 6, 4, shirt);
+      rect(g, 5, 11, 6, 1, shirtDark || shirt);
+
+      rect(g, 4, 8 + armSwing, 1, 4, shirtDark || shirt);
+      rect(g, 11, 8 - armSwing, 1, 4, shirtDark || shirt);
+
+      rect(g, 5, 12, 2, 3 + legA, pants);
+      rect(g, 9, 12, 2, 3 + legB, pants);
+
+      rect(g, 5, 15, 2, 1, '#2b2524');
+      rect(g, 9, 15, 2, 1, '#2b2524');
+
+      frames.push(c);
+    }
+
+    return frames;
+  }
+
+  Tileset.villagerSprites.farmer = role({
+    shirt: '#3aa357',
+    shirtDark: '#2b7c42',
+    pants: '#4b4631',
+    hair: '#7a4d27',
+    hat: '#d6cf74'
+  });
+
+  Tileset.villagerSprites.worker = role({
+    shirt: '#a36b3a',
+    shirtDark: '#704825',
+    pants: '#3f3a32',
+    hair: '#5a3820',
+    hat: '#8f7440'
+  });
+
+  Tileset.villagerSprites.explorer = role({
+    shirt: '#3a6aa3',
+    shirtDark: '#284d7a',
+    pants: '#38394a',
+    hair: '#3b2a1d',
+    hat: '#5a78a8'
+  });
+
+  Tileset.villagerSprites.sleepy = role({
+    shirt: '#777777',
+    shirtDark: '#555555',
+    pants: '#3f3f4f',
+    hair: '#444444',
+    hat: null
+  });
+}
+
+function drawDeer(g) {
+  if (!g) return;
+
+  g.globalAlpha = 0.22;
+  rect(g, 8, 25, 17, 3, '#000000');
+  g.globalAlpha = 1;
+
+  const body = '#8b5a35';
+  const dark = '#5b351f';
+  const light = '#c08a5a';
+
+  rect(g, 10, 15, 12, 8, body);
+  rect(g, 13, 13, 6, 4, body);
+  rect(g, 15, 11, 4, 3, body);
+  rect(g, 11, 23, 2, 5, dark);
+  rect(g, 19, 23, 2, 5, dark);
+  rect(g, 10, 18, 10, 2, light);
+  rect(g, 18, 10, 2, 2, light);
+  px(g, 17, 12, '#111111');
+
+  rect(g, 13, 9, 1, 3, dark);
+  rect(g, 20, 9, 1, 3, dark);
+  rect(g, 12, 8, 3, 1, dark);
+  rect(g, 20, 8, 3, 1, dark);
+  rect(g, 7, 17, 3, 2, body);
+  px(g, 6, 17, light);
+}
+
+function drawBoar(g) {
+  if (!g) return;
+
+  g.globalAlpha = 0.25;
+  rect(g, 8, 25, 18, 3, '#000000');
+  g.globalAlpha = 1;
+
+  const body = '#5b3b2b';
+  const dark = '#352015';
+  const light = '#8a634f';
+
+  rect(g, 9, 16, 15, 8, body);
+  rect(g, 12, 13, 8, 4, body);
+  rect(g, 7, 18, 4, 4, body);
+  rect(g, 6, 20, 3, 2, light);
+  rect(g, 10, 24, 2, 4, dark);
+  rect(g, 21, 24, 2, 4, dark);
+
+  rect(g, 12, 12, 2, 2, dark);
+  rect(g, 15, 11, 2, 2, dark);
+  rect(g, 18, 12, 2, 2, dark);
+  px(g, 8, 18, '#111111');
+  px(g, 6, 22, '#e8d8c8');
+}
+
+function buildTileset() {
   try {
-    Tileset.sprite.tree = makeSprite(ENTITY_TILE_PX, ENTITY_TILE_PX, drawTree);
-    Tileset.sprite.berry = makeSprite(ENTITY_TILE_PX, ENTITY_TILE_PX, drawBerry);
-    Tileset.sprite.sprout = [
-      makeSprite(ENTITY_TILE_PX, ENTITY_TILE_PX, g=>drawSproutOn(g,1)),
-      makeSprite(ENTITY_TILE_PX, ENTITY_TILE_PX, g=>drawSproutOn(g,2)),
-      makeSprite(ENTITY_TILE_PX, ENTITY_TILE_PX, g=>drawSproutOn(g,3))
-    ];
+    for (let s = 0; s < 4; s++) {
+      const palette = SEASON_PALETTES[s];
+      const base = {};
+
+      base.grass = makeGroundTile(palette, 'grass');
+      base.forest = makeGroundTile(palette, 'forest');
+      base.fertile = makeGroundTile(palette, 'fertile');
+      base.meadow = makeGroundTile(palette, 'meadow');
+      base.marsh = makeGroundTile(palette, 'marsh');
+      base.sand = makeSandTile(palette);
+      base.snow = makeSnowTile(palette);
+      base.rock = makeRockTile(palette);
+      base.water = makeWaterBase(palette);
+      base.farmland = makeFarmlandTile(palette);
+
+      Tileset.baseBySeason[s] = base;
+      Tileset.waterOverlayBySeason[s] = makeWaterOverlayFrames(palette);
+
+      Tileset.sprite.treeBySeason[s] = makeSprite(
+        ENTITY_TILE_PX,
+        ENTITY_TILE_PX,
+        g => drawTree(g, s)
+      );
+
+      Tileset.sprite.berryBySeason[s] = makeSprite(
+        ENTITY_TILE_PX,
+        ENTITY_TILE_PX,
+        g => drawBerry(g, s)
+      );
+
+      Tileset.sprite.sproutBySeason[s] = [
+        makeSprite(ENTITY_TILE_PX, ENTITY_TILE_PX, g => drawSproutOn(g, 1, s)),
+        makeSprite(ENTITY_TILE_PX, ENTITY_TILE_PX, g => drawSproutOn(g, 2, s)),
+        makeSprite(ENTITY_TILE_PX, ENTITY_TILE_PX, g => drawSproutOn(g, 3, s))
+      ];
+    }
+
+    Tileset.base = Tileset.baseBySeason[0];
+    Tileset.waterOverlay = Tileset.waterOverlayBySeason[0];
+
+    Tileset.sprite.tree = Tileset.sprite.treeBySeason[0];
+    Tileset.sprite.berry = Tileset.sprite.berryBySeason[0];
+    Tileset.sprite.sprout = Tileset.sprite.sproutBySeason[0];
+  } catch (e) {
+    console.warn('seasonal tileset generation failed', e);
+  }
+
+  try {
+    makeZoneGlyphs();
+  } catch (e) {
+    console.warn('zones', e);
+  }
+
+  try {
+    makeVillagerFrames();
+  } catch (e) {
+    console.warn('villagers', e);
+  }
+
+  try {
     Tileset.sprite.animals = {
       deer: makeSprite(ENTITY_TILE_PX, ENTITY_TILE_PX, drawDeer),
       boar: makeSprite(ENTITY_TILE_PX, ENTITY_TILE_PX, drawBoar)
     };
-  } catch(e){ console.warn('sprites', e); }
+  } catch (e) {
+    console.warn('animal sprites', e);
+  }
 }
 
-export { Tileset, SHADOW_TEXTURE, buildTileset, makeCanvas, px, rect };
+export {
+  Tileset,
+  SHADOW_TEXTURE,
+  buildTileset,
+  makeCanvas,
+  px,
+  rect,
+  normalizeSeason,
+  seasonName
+};


### PR DESCRIPTION
Generate four seasonal tile and sprite variants (spring/summer/autumn/winter)
in tileset.js, drive selection from world.season in render.js, and invalidate
the static albedo cache when the season rolls over so terrain repaints.

Adds dedicated artwork for the hunter lodge and replaces the building shape
branches with palette-aware helpers.

https://claude.ai/code/session_01NSX788QY9p5bk18FNaypzw