### PR TITLE
Visual polish PR-A: palette refinement, tile + tree variants

### DIFF
--- a/src/app/lighting.js
+++ b/src/app/lighting.js
@@ -19,6 +19,44 @@ const clamp01 = (value) => {
   return value <= 0 ? 0 : value >= 1 ? 1 : value;
 };
 
+// Lightmap color grading. The lightmap composites with 'multiply', so these
+// tints are channel scalars in [0, 1] applied to the greyscale brightness.
+// A value below 1 attenuates that channel (cools when r/g drop, warms when
+// b drops). Picked to read as cozy-sim atmosphere rather than a colored
+// filter — every tint stays close to neutral.
+const NIGHT_TINT = Object.freeze({ r: 0.66, g: 0.78, b: 1.00 });
+const DAWN_DUSK_TINT = Object.freeze({ r: 1.00, g: 0.92, b: 0.78 });
+const NEUTRAL_TINT = Object.freeze({ r: 1.00, g: 1.00, b: 1.00 });
+
+function lerp(a, b, t) { return a + (b - a) * t; }
+
+function lerpTint(a, b, t) {
+  return {
+    r: lerp(a.r, b.r, t),
+    g: lerp(a.g, b.g, t),
+    b: lerp(a.b, b.b, t)
+  };
+}
+
+// gradeLightmap maps the scalar ambient into a per-channel multiplier:
+//   ambient < 0.40  : night → neutral
+//   0.40 ≤ a < 0.55 : neutral → dawn/dusk warm
+//   0.55 ≤ a < 0.85 : warm → neutral
+//   ambient ≥ 0.85  : neutral daylight
+function gradeLightmap(ambient) {
+  const a = clamp01(ambient);
+  if (a < 0.40) {
+    return lerpTint(NIGHT_TINT, NEUTRAL_TINT, a / 0.40);
+  }
+  if (a < 0.55) {
+    return lerpTint(NEUTRAL_TINT, DAWN_DUSK_TINT, (a - 0.40) / 0.15);
+  }
+  if (a < 0.85) {
+    return lerpTint(DAWN_DUSK_TINT, NEUTRAL_TINT, (a - 0.55) / 0.30);
+  }
+  return { ...NEUTRAL_TINT };
+}
+
 let setShadingModeImpl = () => {};
 let setShadingParamsImpl = () => {};
 
@@ -69,8 +107,12 @@ function makeAltitudeShade(height, w, h, cfg = SHADING_DEFAULTS) {
 
 export {
   clamp01,
+  DAWN_DUSK_TINT,
+  gradeLightmap,
   LIGHTING,
   makeAltitudeShade,
+  NEUTRAL_TINT,
+  NIGHT_TINT,
   registerShadingHandlers,
   setShadingMode,
   setShadingParams

--- a/src/app/render.js
+++ b/src/app/render.js
@@ -16,7 +16,7 @@ import {
   tileToPxY
 } from './constants.js';
 import { LIGHTING, clamp01 } from './lighting.js';
-import { clamp } from './rng.js';
+import { clamp, hash2 } from './rng.js';
 import { context2d } from './canvas.js';
 import { SHADOW_TEXTURE, Tileset, makeCanvas, normalizeSeason, seasonName } from './tileset.js';
 import {
@@ -499,7 +499,23 @@ export function createRenderSystem(deps) {
 
     const season = normalizeSeason(world.season);
     const baseSet = Tileset.baseBySeason?.[season] || Tileset.base || {};
-    const fallback = Tileset.base?.grass || baseSet.grass;
+    const fallbackSet = baseSet.grass || Tileset.base?.grass;
+
+    // baseSet[kind] is an array of canvases (length 1 for sand/snow/rock,
+    // multiple for grass/forest/meadow/etc). Picking by hash2(x, y) gives a
+    // deterministic, repetition-breaking variant per tile that survives
+    // reloads and only re-evaluates on staticDirty.
+    const pickVariant = (set, x, y) => {
+      if (!set) return null;
+      if (Array.isArray(set)) {
+        if (set.length === 0) return null;
+        if (set.length === 1) return set[0];
+        return set[hash2(x, y) % set.length];
+      }
+      return set;
+    };
+
+    const fallback = pickVariant(fallbackSet, 0, 0);
 
     ensureRowMasksSize();
 
@@ -511,18 +527,18 @@ export function createRenderSystem(deps) {
         const i = rowStart + x;
         const t = world.tiles[i];
 
-        let img = baseSet.grass || fallback;
+        let img = pickVariant(baseSet.grass, x, y) || fallback;
 
-        if (t === TILES.GRASS) img = baseSet.grass || fallback;
-        else if (t === TILES.FOREST) img = baseSet.forest || baseSet.grass || fallback;
-        else if (t === TILES.FERTILE) img = baseSet.fertile || fallback;
-        else if (t === TILES.MEADOW) img = baseSet.meadow || fallback;
-        else if (t === TILES.MARSH) img = baseSet.marsh || fallback;
-        else if (t === TILES.SAND) img = baseSet.sand || fallback;
-        else if (t === TILES.SNOW) img = baseSet.snow || fallback;
-        else if (t === TILES.ROCK) img = baseSet.rock || fallback;
-        else if (t === TILES.WATER) img = baseSet.water || fallback;
-        else if (t === TILES.FARMLAND) img = baseSet.farmland || fallback;
+        if (t === TILES.GRASS) img = pickVariant(baseSet.grass, x, y) || fallback;
+        else if (t === TILES.FOREST) img = pickVariant(baseSet.forest, x, y) || pickVariant(baseSet.grass, x, y) || fallback;
+        else if (t === TILES.FERTILE) img = pickVariant(baseSet.fertile, x, y) || fallback;
+        else if (t === TILES.MEADOW) img = pickVariant(baseSet.meadow, x, y) || fallback;
+        else if (t === TILES.MARSH) img = pickVariant(baseSet.marsh, x, y) || fallback;
+        else if (t === TILES.SAND) img = pickVariant(baseSet.sand, x, y) || fallback;
+        else if (t === TILES.SNOW) img = pickVariant(baseSet.snow, x, y) || fallback;
+        else if (t === TILES.ROCK) img = pickVariant(baseSet.rock, x, y) || fallback;
+        else if (t === TILES.WATER) img = pickVariant(baseSet.water, x, y) || fallback;
+        else if (t === TILES.FARMLAND) img = pickVariant(baseSet.farmland, x, y) || fallback;
 
         if (img) g.drawImage(img, x * TILE, y * TILE);
 
@@ -1288,7 +1304,15 @@ export function createRenderSystem(deps) {
             const rect = entityDrawRect(x, y, cam);
             const raisedY = rect.y - Math.round(cam.z * TREE_VERTICAL_RAISE);
             const light = useMultiply ? 1 : sampleLightAt(world, x, y);
-            const treeSprite = Tileset.sprite.treeBySeason?.[season] || Tileset.sprite.tree;
+            const treeSet = Tileset.sprite.treeBySeason?.[season];
+            let treeSprite = null;
+            if (Array.isArray(treeSet) && treeSet.length > 0) {
+              treeSprite = treeSet[hash2(x, y, 17) % treeSet.length];
+            } else if (treeSet) {
+              treeSprite = treeSet;
+            } else {
+              treeSprite = Tileset.sprite.tree;
+            }
             if (treeSprite) {
               ctx.save();
               ctx.drawImage(treeSprite, 0, 0, ENTITY_TILE_PX, ENTITY_TILE_PX, rect.x, raisedY, rect.size, rect.size);

--- a/src/app/render.js
+++ b/src/app/render.js
@@ -15,7 +15,7 @@ import {
   tileToPxX,
   tileToPxY
 } from './constants.js';
-import { LIGHTING, clamp01 } from './lighting.js';
+import { LIGHTING, clamp01, gradeLightmap } from './lighting.js';
 import { clamp, hash2 } from './rng.js';
 import { context2d } from './canvas.js';
 import { SHADOW_TEXTURE, Tileset, makeCanvas, normalizeSeason, seasonName } from './tileset.js';
@@ -415,11 +415,17 @@ export function createRenderSystem(deps) {
       img = ctx.createImageData(qw, qh);
       targetWorld.lightmapImageData = img;
     }
+    // Per-channel tint shifts the lightmap's neutral grey toward warm at
+    // dawn/dusk and cool blue at night. The multiply composite carries the
+    // tint across the whole scene, so this is the cheapest place to grade.
+    const tint = gradeLightmap(ambient);
     const data = img.data;
     for (let i = 0, p = 0; i < length; i++, p += 4) {
       const v = Math.max(0, Math.min(1, Lq[i]));
-      const b = Math.round(v * 255);
-      data[p] = data[p + 1] = data[p + 2] = b;
+      const b = v * 255;
+      data[p] = Math.round(b * tint.r);
+      data[p + 1] = Math.round(b * tint.g);
+      data[p + 2] = Math.round(b * tint.b);
       data[p + 3] = 255;
     }
     ctx.putImageData(img, 0, 0);
@@ -519,13 +525,19 @@ export function createRenderSystem(deps) {
 
     ensureRowMasksSize();
 
+    const tiles = world.tiles;
+    const isWater = (xi, yi) => {
+      if (xi < 0 || xi >= GRID_W || yi < 0 || yi >= GRID_H) return false;
+      return tiles[yi * GRID_W + xi] === TILES.WATER;
+    };
+
     for (let y = 0; y < GRID_H; y++) {
       let rowHasWater = 0;
       const rowStart = y * GRID_W;
 
       for (let x = 0; x < GRID_W; x++) {
         const i = rowStart + x;
-        const t = world.tiles[i];
+        const t = tiles[i];
 
         let img = pickVariant(baseSet.grass, x, y) || fallback;
 
@@ -541,6 +553,19 @@ export function createRenderSystem(deps) {
         else if (t === TILES.FARMLAND) img = pickVariant(baseSet.farmland, x, y) || fallback;
 
         if (img) g.drawImage(img, x * TILE, y * TILE);
+
+        // Foam edges: paint a 1-pixel pale rim on the side of any non-water
+        // tile that touches water. Drawn at bake time so per-frame cost is
+        // zero, and the contrast reads nicely at every zoom level.
+        if (t !== TILES.WATER) {
+          const px = x * TILE;
+          const py = y * TILE;
+          g.fillStyle = 'rgba(232, 245, 255, 0.55)';
+          if (isWater(x, y - 1)) g.fillRect(px, py, TILE, 1);
+          if (isWater(x, y + 1)) g.fillRect(px, py + TILE - 1, TILE, 1);
+          if (isWater(x - 1, y)) g.fillRect(px, py, 1, TILE);
+          if (isWater(x + 1, y)) g.fillRect(px + TILE - 1, py, 1, TILE);
+        }
 
         if (t === TILES.WATER) rowHasWater = 1;
       }
@@ -732,11 +757,14 @@ export function createRenderSystem(deps) {
       ctx.globalAlpha = 0.4;
       const colors = ['#d9852d', '#b84f2a', '#e1a33a'];
 
-      for (let y = vis.y0; y <= vis.y1; y += 4) {
-        for (let x = vis.x0; x <= vis.x1; x += 5) {
-          const n = (x * 7127 + y * 9151 + Math.floor(tick / 40) * 17) % 23;
+      // Denser leaf density (every ~17 cells vs the prior ~23) plus a small
+      // horizontal drift so leaves look wind-blown instead of static stamps.
+      for (let y = vis.y0; y <= vis.y1; y += 3) {
+        for (let x = vis.x0; x <= vis.x1; x += 4) {
+          const n = (x * 7127 + y * 9151 + Math.floor(tick / 40) * 17) % 17;
           if (n !== 0) continue;
-          const px = tileToPxX(x + 0.5, cam);
+          const drift = Math.sin((tick * 0.04) + x * 0.7 + y * 0.5) * 0.5;
+          const px = tileToPxX(x + 0.5 + drift, cam);
           const py = tileToPxY(y + 0.4, cam);
           ctx.fillStyle = colors[(x + y) % colors.length];
           ctx.fillRect(px, py, Math.max(1, cam.z * 1.5), Math.max(1, cam.z));
@@ -753,6 +781,91 @@ export function createRenderSystem(deps) {
     }
 
     ctx.restore();
+  }
+
+  // Summer-only night fireflies near grass/forest tiles. Hash-gated so the
+  // particle count is bounded by visible area, not a per-frame allocation.
+  function drawFireflies(season, tick, vis, ambient) {
+    if (seasonName(season) !== 'summer') return;
+    if (ambient > 0.5) return;
+    const ctx = getCtx();
+    const cam = getCam();
+    const world = getWorld();
+    if (!ctx || !cam || !vis || !world) return;
+    ctx.save();
+    for (let y = vis.y0; y <= vis.y1; y++) {
+      const rowStart = y * GRID_W;
+      for (let x = vis.x0; x <= vis.x1; x++) {
+        const t = world.tiles[rowStart + x];
+        if (t !== TILES.GRASS && t !== TILES.MEADOW && t !== TILES.FOREST && t !== TILES.FERTILE) continue;
+        const n = (x * 9301 + y * 49297 + Math.floor(tick / 30) * 53) % 47;
+        if (n !== 0) continue;
+        const flicker = ((x + y + Math.floor(tick / 6)) % 5) >= 2;
+        if (!flicker) continue;
+        const drift = Math.sin(tick * 0.05 + x * 0.4 + y * 0.7) * 0.3;
+        const px = tileToPxX(x + 0.5 + drift, cam);
+        const py = tileToPxY(y + 0.45, cam);
+        ctx.fillStyle = 'rgba(255, 232, 130, 0.95)';
+        ctx.fillRect(px, py, Math.max(1, cam.z), Math.max(1, cam.z));
+        ctx.fillStyle = 'rgba(255, 232, 130, 0.35)';
+        ctx.fillRect(px - cam.z, py - cam.z, Math.max(1, cam.z * 3), Math.max(1, cam.z * 3));
+      }
+    }
+    ctx.restore();
+  }
+
+  // Two soft circles per chimney/fire, phase-offset by hash2 so adjacent
+  // huts don't puff in lockstep. Drawn in the post-multiply pass so the
+  // alpha falloff reads against night without being darkened.
+  function drawSmokeWisps(b, baseX, baseY, tick, cam) {
+    const ctx = getCtx();
+    if (!ctx) return;
+    const phaseSeed = hash2(b.x | 0, b.y | 0);
+    ctx.save();
+    for (let i = 0; i < 2; i++) {
+      const cycle = 80;
+      const offset = (((tick + (phaseSeed >>> (i * 8)) % cycle) % cycle) + i * cycle * 0.5) % cycle;
+      const t = offset / cycle;
+      const rise = t * 22 * cam.z;
+      const drift = Math.sin(t * Math.PI * 2 + i) * 2.4 * cam.z;
+      const alpha = (1 - t) * 0.32;
+      if (alpha <= 0) continue;
+      ctx.globalAlpha = alpha;
+      ctx.fillStyle = 'rgba(220, 220, 224, 1)';
+      ctx.beginPath();
+      ctx.arc(baseX + drift, baseY - rise, (1.5 + t * 1.3) * cam.z, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.restore();
+  }
+
+  // Cached vignette gradient — only rebuild on viewport resize.
+  const vignetteCache = { canvas: null, w: 0, h: 0 };
+  function drawPostFx() {
+    const ctx = getCtx();
+    if (!ctx) return;
+    const W = getViewportW();
+    const H = getViewportH();
+    if (W <= 0 || H <= 0) return;
+    if (!vignetteCache.canvas || vignetteCache.w !== W || vignetteCache.h !== H) {
+      const off = makeCanvas(W, H);
+      const og = context2d(off);
+      if (!og) return;
+      const cx = W * 0.5;
+      const cy = H * 0.5;
+      const radius = Math.hypot(cx, cy);
+      const grd = og.createRadialGradient(cx, cy, radius * 0.55, cx, cy, radius);
+      grd.addColorStop(0, 'rgba(0, 0, 0, 0)');
+      grd.addColorStop(1, 'rgba(0, 0, 0, 0.42)');
+      og.fillStyle = grd;
+      og.fillRect(0, 0, W, H);
+      vignetteCache.canvas = off;
+      vignetteCache.w = W;
+      vignetteCache.h = H;
+    }
+    if (vignetteCache.canvas) {
+      ctx.drawImage(vignetteCache.canvas, 0, 0);
+    }
   }
 
   function drawShadow(tileX, tileY, footprintW = 1, footprintH = 1, screenRect = null) {
@@ -1252,7 +1365,7 @@ export function createRenderSystem(deps) {
       : Tileset.waterOverlay || [];
 
     if (frames.length) {
-      const frame = Math.floor((tick / 10) % frames.length);
+      const frame = Math.floor((tick / 8) % frames.length);
       drawWaterOverlay(frames, frame, vis);
     }
 
@@ -1414,6 +1527,10 @@ export function createRenderSystem(deps) {
         ctx.restore();
       }
 
+      // Post-multiply pass: any glow / lit-window / smoke effect that should
+      // *not* be darkened by the lightmap multiply lives here. The campfire
+      // glow already established this pattern; lit huts and smoke wisps now
+      // ride alongside it.
       for (const b of buildings) {
         if (b.kind === 'campfire') {
           const center = buildingCenter(b);
@@ -1438,9 +1555,35 @@ export function createRenderSystem(deps) {
             }
             ctx.restore();
           }
+          drawSmokeWisps(b, gx, gy - 6 * cam.z, tick, cam);
+        } else if (b.kind === 'hut' && b.built >= 1) {
+          const fp = getFootprint(b.kind);
+          const offsetX = Math.floor((ENTITY_TILE_PX - fp.w * TILE) * cam.z * 0.5);
+          const offsetY = Math.floor((ENTITY_TILE_PX - fp.h * TILE) * cam.z * 0.5);
+          const bx = tileToPxX(b.x, cam) - offsetX;
+          const by = tileToPxY(b.y, cam) - offsetY;
+          if (nightActive) {
+            // Window at (21, 17) size 2x3 inside the 32px sprite (matches
+            // drawBuildingAt's hut window litBox call).
+            const winCx = bx + 22 * cam.z;
+            const winCy = by + 18.5 * cam.z;
+            const halo = 7 * cam.z;
+            const grd = ctx.createRadialGradient(winCx, winCy, 0, winCx, winCy, halo);
+            grd.addColorStop(0, 'rgba(255, 218, 142, 0.55)');
+            grd.addColorStop(1, 'rgba(255, 195, 110, 0)');
+            ctx.fillStyle = grd;
+            ctx.beginPath(); ctx.arc(winCx, winCy, halo, 0, Math.PI * 2); ctx.fill();
+            ctx.fillStyle = 'rgba(255, 226, 160, 0.85)';
+            ctx.fillRect(bx + 21 * cam.z, by + 17 * cam.z, 2 * cam.z, 3 * cam.z);
+          }
+          // Chimney smoke from the upper-left corner of the roof so wisps
+          // don't overlap the window glow.
+          drawSmokeWisps(b, bx + 11 * cam.z, by + 4 * cam.z, tick, cam);
         }
       }
 
+      drawFireflies(season, tick, vis, ambient);
+      drawPostFx();
       drawQueuedVillagerLabels(ambient);
 
       if (el && storageTotals) {

--- a/src/app/render.js
+++ b/src/app/render.js
@@ -18,7 +18,15 @@ import {
 import { LIGHTING, clamp01, gradeLightmap } from './lighting.js';
 import { clamp, hash2 } from './rng.js';
 import { context2d } from './canvas.js';
-import { SHADOW_TEXTURE, Tileset, makeCanvas, normalizeSeason, seasonName } from './tileset.js';
+import {
+  SHADOW_TEXTURE,
+  Tileset,
+  VILLAGER_FRAME_COUNT,
+  makeCanvas,
+  normalizeSeason,
+  pickAccentColor,
+  seasonName
+} from './tileset.js';
 import {
   BUILDINGS,
   buildingCenter,
@@ -1158,17 +1166,34 @@ export function createRenderSystem(deps) {
                  : v.role === 'worker' ? Tileset.villagerSprites.worker
                  : v.role === 'explorer' ? Tileset.villagerSprites.explorer
                  : Tileset.villagerSprites.sleepy;
-    const f = frames[Math.floor((tick / 8) % 3)];
+    const frameCount = frames?.length || VILLAGER_FRAME_COUNT;
+    const isMoving = Array.isArray(v.path) && v.path.length > 0;
+    // Hold the neutral pose when the villager isn't moving so they don't
+    // step in place; otherwise cycle through all 4 frames.
+    const frameIdx = isMoving ? Math.floor((tick / 6) % frameCount) : 0;
+    const f = frames[frameIdx];
     const s = cam.z;
     const rect = entityDrawRect(v.x, v.y, cam);
     const spriteSize = 16 * s;
     const gx = Math.floor(rect.x + (rect.size - spriteSize) * 0.5);
-    const gy = Math.floor(rect.y + (rect.size - spriteSize) * 0.5);
+    const gyGround = Math.floor(rect.y + (rect.size - spriteSize) * 0.5);
+    // 1-px head-bob synced to the walk cadence so the body silhouette
+    // breathes in time with the gait. Shadow stays at the ground, sprite
+    // and accent overlay lift together.
+    const bobPx = isMoving && (frameIdx % 2 === 1) ? Math.round(s) : 0;
+    const gy = gyGround - bobPx;
     const light = useMultiply ? 1 : sampleLightAt(world, v.x, v.y);
-    drawShadow(v.x, v.y, 1, 1, { x: gx, y: gy, w: spriteSize, h: spriteSize });
+    drawShadow(v.x, v.y, 1, 1, { x: gx, y: gyGround, w: spriteSize, h: spriteSize });
     ctx.save();
     ctx.drawImage(f, 0, 0, 16, 16, gx, gy, spriteSize, spriteSize);
     applySpriteShadeLit(ctx, gx, gy, spriteSize, spriteSize, light);
+    // 1-px scarf accent at the neckline; deterministic per villager id so a
+    // village reads as a crowd of distinct people instead of clones.
+    if (Number.isFinite(v.id)) {
+      const accent = pickAccentColor(v.id);
+      ctx.fillStyle = shadeFillColorLit(accent, light);
+      ctx.fillRect(gx + 5 * s, gy + 7 * s, 6 * s, Math.max(1, s));
+    }
     if (v.inv) {
       const packColor = ITEM_COLORS[v.inv.type] || ITEM_COLORS.food;
       ctx.fillStyle = shadeFillColorLit(packColor, light);

--- a/src/app/rng.js
+++ b/src/app/rng.js
@@ -15,12 +15,29 @@ function setRandomSource(value) {
   R = value;
 }
 
+// Stateless 32-bit integer hash for deterministic per-tile/per-id picks. Does
+// not touch the global R, so safe to call from render hot paths and bake steps.
+function hash2(x, y = 0, z = 0) {
+  let h = (x | 0) ^ Math.imul((y | 0), 0x85ebca77) ^ Math.imul((z | 0), 0xc2b2ae3d);
+  h = Math.imul(h ^ (h >>> 16), 0x7feb352d);
+  h = Math.imul(h ^ (h >>> 15), 0x846ca68b);
+  return (h ^ (h >>> 16)) >>> 0;
+}
+
+// Returns a fresh deterministic float-RNG closure seeded from `seed`. Used at
+// asset-bake time so per-variant noise is reproducible without disturbing R.
+function seededFrom(seed) {
+  return mulberry32((seed >>> 0) || 1);
+}
+
 export {
   R,
   clamp,
+  hash2,
   irnd,
   mulberry32,
   rnd,
+  seededFrom,
   setRandomSource,
   uid
 };

--- a/src/app/tileset.js
+++ b/src/app/tileset.js
@@ -1,6 +1,17 @@
 import { ENTITY_TILE_PX, TILE } from './constants.js';
 import { context2d } from './canvas.js';
-import { irnd } from './rng.js';
+import { hash2, irnd, seededFrom } from './rng.js';
+
+// Per-tile variant count for ground kinds that support visual variation. Three
+// variants is enough to break the obvious 192×192 stamping pattern without
+// inflating the bake time meaningfully.
+const GROUND_VARIANTS = 3;
+const TREE_VARIANTS = 3;
+
+function makeIrand(rng) {
+  if (!rng) return irnd;
+  return (a, b) => ((rng() * (b - a + 1)) | 0) + a;
+}
 
 const SEASON_NAMES = ['spring', 'summer', 'autumn', 'winter'];
 
@@ -78,26 +89,26 @@ const SEASON_PALETTES = [
   {
     name: 'spring',
     grass: {
-      base: '#2d703b',
-      blades: ['#3f9a50', '#4fb660', '#77d26f', '#2f8444'],
-      shadow: '#1f4f2b',
-      flowers: ['#f8e7a1', '#ffc5df', '#d7f3ff']
+      base: '#2d6a3a',
+      blades: ['#449152', '#58a45e', '#85c180', '#327a44'],
+      shadow: '#1f4a2a',
+      flowers: ['#f0dd9a', '#f3bcd4', '#cfe9f6']
     },
     forest: {
-      base: '#285f35',
-      blades: ['#347a43', '#429a55', '#5ebd67'],
-      shadow: '#1c4426'
+      base: '#234f2c',
+      blades: ['#316f3d', '#418c4f', '#5ea66a'],
+      shadow: '#173a22'
     },
     fertile: {
-      base: '#347c43',
-      blades: ['#51b968', '#419e55', '#82dc7a'],
-      shadow: '#245f31'
+      base: '#327443',
+      blades: ['#56a566', '#418f50', '#86c780'],
+      shadow: '#225a31'
     },
     meadow: {
-      base: '#3c8548',
-      blades: ['#61bb6d', '#4aa75a', '#93e084'],
-      shadow: '#2b6235',
-      flowers: ['#fff3ac', '#ffb8d5', '#c9f0ff', '#e9c9ff']
+      base: '#3c7e47',
+      blades: ['#62ac6c', '#4a9658', '#94ce85'],
+      shadow: '#2a5e35',
+      flowers: ['#f6ecaa', '#f5b8d2', '#c5ecf6', '#dcc4ee']
     },
     marsh: {
       base: '#255940',
@@ -128,52 +139,52 @@ const SEASON_PALETTES = [
       specks: ['#c8d8e8', '#eef8ff']
     },
     tree: {
-      trunk: '#68401f',
-      barkDark: '#4d2d17',
-      leafDark: '#255d31',
-      leafMid: '#348143',
-      leafLight: '#62bd62',
-      accent: '#b6e89a',
+      trunk: '#5e3b1d',
+      barkDark: '#41260f',
+      leafDark: '#22552d',
+      leafMid: '#347340',
+      leafLight: '#6caa6c',
+      accent: '#bedbb0',
       snow: null
     },
     berry: {
-      leafDark: '#2f6938',
-      leafMid: '#3d8848',
-      leafLight: '#5cad5c',
-      fruit: '#b74c6b',
-      fruitLight: '#e27791',
+      leafDark: '#2c5f33',
+      leafMid: '#3a7a44',
+      leafLight: '#5da265',
+      fruit: '#a64458',
+      fruitLight: '#d3768c',
       snow: null
     },
     crop: {
-      stem: '#64ad55',
-      leaf: '#86cc6b',
-      head: '#d9c35c',
+      stem: '#6ba35a',
+      leaf: '#90c275',
+      head: '#d2b95a',
       frost: null
     }
   },
   {
     name: 'summer',
     grass: {
-      base: '#2f6d35',
-      blades: ['#3c8f43', '#4fa94f', '#6fc55f', '#2b7a3a'],
-      shadow: '#204c26',
-      flowers: ['#f4db7b', '#f6a6c8']
+      base: '#2c6533',
+      blades: ['#3e8744', '#4d9b4f', '#75b465', '#2d703a'],
+      shadow: '#1d4524',
+      flowers: ['#ecd07a', '#eda5c2']
     },
     forest: {
-      base: '#245b2d',
-      blades: ['#31733a', '#3e8e47', '#56aa55'],
-      shadow: '#193f20'
+      base: '#1f4d28',
+      blades: ['#306a39', '#3d8044', '#549858'],
+      shadow: '#15391c'
     },
     fertile: {
-      base: '#326f37',
-      blades: ['#4fa854', '#3f9349', '#7cc76d'],
-      shadow: '#214e28'
+      base: '#316b38',
+      blades: ['#509853', '#418548', '#80b573'],
+      shadow: '#1f4628'
     },
     meadow: {
-      base: '#3b7c3f',
-      blades: ['#5dab5c', '#4b9950', '#80cf6b'],
-      shadow: '#2a5830',
-      flowers: ['#f8df70', '#f2a6c0', '#fff2a0']
+      base: '#3a763f',
+      blades: ['#5d9b5d', '#4b8c50', '#82bd72'],
+      shadow: '#28522e',
+      flowers: ['#f0d176', '#e7a4be', '#f3e09a']
     },
     marsh: {
       base: '#254f38',
@@ -204,52 +215,52 @@ const SEASON_PALETTES = [
       specks: ['#c0cfdd', '#eaf3fb']
     },
     tree: {
-      trunk: '#5f381c',
-      barkDark: '#432614',
-      leafDark: '#214f27',
-      leafMid: '#2f7636',
-      leafLight: '#54a94f',
-      accent: '#83d06a',
+      trunk: '#56331c',
+      barkDark: '#3a2110',
+      leafDark: '#1d4624',
+      leafMid: '#2d6a33',
+      leafLight: '#549952',
+      accent: '#94c481',
       snow: null
     },
     berry: {
-      leafDark: '#2c5f32',
-      leafMid: '#39793e',
-      leafLight: '#58a654',
-      fruit: '#9f384f',
-      fruitLight: '#d45b73',
+      leafDark: '#28552c',
+      leafMid: '#356c39',
+      leafLight: '#5b9858',
+      fruit: '#94364a',
+      fruitLight: '#c8576c',
       snow: null
     },
     crop: {
-      stem: '#5f9f48',
-      leaf: '#7dbd55',
-      head: '#e2c75c',
+      stem: '#5f924a',
+      leaf: '#85b25e',
+      head: '#d6bc5a',
       frost: null
     }
   },
   {
     name: 'autumn',
     grass: {
-      base: '#6d6938',
-      blades: ['#817b3f', '#9c8740', '#b9873a', '#5f5e33'],
-      shadow: '#4b4828',
-      leaves: ['#d27b31', '#bf4d2d', '#e2a03c']
+      base: '#675f35',
+      blades: ['#7a6f3a', '#947c3d', '#a87a3a', '#5b552f'],
+      shadow: '#443f25',
+      leaves: ['#c66e2c', '#a8462a', '#d3923a']
     },
     forest: {
-      base: '#5f5b32',
-      blades: ['#806a34', '#a46f32', '#ba8436'],
-      shadow: '#3f3b22'
+      base: '#564e2c',
+      blades: ['#7a6233', '#9e6b34', '#b07d3a'],
+      shadow: '#3a3320'
     },
     fertile: {
-      base: '#6a6338',
-      blades: ['#8a7c42', '#a0853f', '#c08f3b'],
-      shadow: '#4a4428'
+      base: '#675e36',
+      blades: ['#86763f', '#9a7e3e', '#b58940'],
+      shadow: '#443d25'
     },
     meadow: {
-      base: '#74683a',
-      blades: ['#9b7f3d', '#b8893a', '#d09a45'],
-      shadow: '#51472a',
-      flowers: ['#e6b85c', '#d77a45']
+      base: '#6f6238',
+      blades: ['#94793c', '#ad853f', '#c39146'],
+      shadow: '#4a4028',
+      flowers: ['#d8a85a', '#c97044']
     },
     marsh: {
       base: '#455139',
@@ -280,26 +291,26 @@ const SEASON_PALETTES = [
       specks: ['#c3cfdb', '#eef5fb']
     },
     tree: {
-      trunk: '#5d3519',
-      barkDark: '#3f2210',
-      leafDark: '#8a3f24',
-      leafMid: '#b75f2d',
-      leafLight: '#e09a3a',
-      accent: '#f0c35b',
+      trunk: '#553118',
+      barkDark: '#371e0e',
+      leafDark: '#7c3923',
+      leafMid: '#a6552d',
+      leafLight: '#c98a3c',
+      accent: '#e2b15a',
       snow: null
     },
     berry: {
-      leafDark: '#5c4f2c',
-      leafMid: '#806b33',
-      leafLight: '#b9863c',
-      fruit: '#8e2f3e',
-      fruitLight: '#c85662',
+      leafDark: '#564a2b',
+      leafMid: '#766332',
+      leafLight: '#a87c3c',
+      fruit: '#852b39',
+      fruitLight: '#bb5160',
       snow: null
     },
     crop: {
-      stem: '#96783f',
-      leaf: '#b39145',
-      head: '#e0b854',
+      stem: '#8a703e',
+      leaf: '#a78743',
+      head: '#d2ab52',
       frost: null
     }
   },
@@ -381,21 +392,21 @@ const SEASON_PALETTES = [
   }
 ];
 
-function noisePixels(g, colors, count, alpha = 1) {
+function noisePixels(g, colors, count, alpha = 1, irand = irnd) {
   if (!g || !colors || !colors.length) return;
   const oldAlpha = g.globalAlpha;
   g.globalAlpha = alpha;
   for (let i = 0; i < count; i++) {
-    px(g, irnd(0, TILE - 1), irnd(0, TILE - 1), colors[i % colors.length]);
+    px(g, irand(0, TILE - 1), irand(0, TILE - 1), colors[i % colors.length]);
   }
   g.globalAlpha = oldAlpha;
 }
 
-function grassClumps(g, colors, count) {
+function grassClumps(g, colors, count, irand = irnd) {
   if (!g || !colors || !colors.length) return;
   for (let i = 0; i < count; i++) {
-    const x = irnd(0, TILE - 2);
-    const y = irnd(2, TILE - 3);
+    const x = irand(0, TILE - 2);
+    const y = irand(2, TILE - 3);
     const c = colors[i % colors.length];
     px(g, x, y, c);
     if (i % 3 === 0) px(g, x + 1, y, c);
@@ -412,13 +423,13 @@ function cornerShade(g, color) {
   g.globalAlpha = oldAlpha;
 }
 
-function snowDust(g, colors, count = 22) {
+function snowDust(g, colors, count = 22, irand = irnd) {
   if (!g || !colors || !colors.length) return;
   const oldAlpha = g.globalAlpha;
   g.globalAlpha = 0.55;
   for (let i = 0; i < count; i++) {
-    const x = irnd(0, TILE - 2);
-    const y = irnd(0, TILE - 2);
+    const x = irand(0, TILE - 2);
+    const y = irand(0, TILE - 2);
     const c = colors[i % colors.length];
     px(g, x, y, c);
     if (i % 4 === 0) px(g, x + 1, y, c);
@@ -426,24 +437,24 @@ function snowDust(g, colors, count = 22) {
   g.globalAlpha = oldAlpha;
 }
 
-function leafScatter(g, colors, count = 8) {
+function leafScatter(g, colors, count = 8, irand = irnd) {
   if (!g || !colors || !colors.length) return;
   for (let i = 0; i < count; i++) {
-    const x = irnd(1, TILE - 3);
-    const y = irnd(2, TILE - 3);
+    const x = irand(1, TILE - 3);
+    const y = irand(2, TILE - 3);
     const c = colors[i % colors.length];
     px(g, x, y, c);
     if (i % 2 === 0) px(g, x + 1, y, c);
   }
 }
 
-function flowerScatter(g, colors, count = 5) {
+function flowerScatter(g, colors, count = 5, irand = irnd) {
   if (!g || !colors || !colors.length) return;
   const oldAlpha = g.globalAlpha;
   g.globalAlpha = 0.9;
   for (let i = 0; i < count; i++) {
-    const x = irnd(1, TILE - 2);
-    const y = irnd(2, TILE - 3);
+    const x = irand(1, TILE - 2);
+    const y = irand(2, TILE - 3);
     const c = colors[i % colors.length];
     px(g, x, y, c);
     if (i % 3 === 0) px(g, x + 1, y, c);
@@ -451,15 +462,19 @@ function flowerScatter(g, colors, count = 5) {
   g.globalAlpha = oldAlpha;
 }
 
-function makeGroundTile(palette, kind) {
+function makeGroundTile(palette, kind, variantSeed = 0) {
   const c = makeCanvas(TILE, TILE);
   const g = context2d(c);
   if (!g) return c;
 
+  // Each variant gets its own deterministic RNG so blade/flower/leaf noise
+  // differs between variants but is reproducible across reloads.
+  const irand = makeIrand(seededFrom(variantSeed));
+
   const p = palette[kind] || palette.grass;
   rect(g, 0, 0, TILE, TILE, p.base);
 
-  grassClumps(g, p.blades || [], kind === 'forest' ? 32 : 42);
+  grassClumps(g, p.blades || [], kind === 'forest' ? 32 : 42, irand);
 
   if (kind === 'marsh' && p.puddle) {
     const oldAlpha = g.globalAlpha;
@@ -471,17 +486,17 @@ function makeGroundTile(palette, kind) {
   }
 
   if (palette.name === 'spring' && kind === 'meadow') {
-    flowerScatter(g, p.flowers, 8);
+    flowerScatter(g, p.flowers, 8, irand);
   } else if (palette.name === 'summer' && kind === 'meadow') {
-    flowerScatter(g, p.flowers, 5);
+    flowerScatter(g, p.flowers, 5, irand);
   }
 
   if (palette.name === 'autumn') {
-    leafScatter(g, p.leaves || palette.grass.leaves, kind === 'forest' ? 12 : 7);
+    leafScatter(g, p.leaves || palette.grass.leaves, kind === 'forest' ? 12 : 7, irand);
   }
 
   if (palette.name === 'winter') {
-    snowDust(g, p.snowFlecks || palette.grass.snowFlecks, kind === 'forest' ? 26 : 34);
+    snowDust(g, p.snowFlecks || palette.grass.snowFlecks, kind === 'forest' ? 26 : 34, irand);
   }
 
   cornerShade(g, p.shadow || palette.grass.shadow);
@@ -617,7 +632,90 @@ function drawCanopyBlob(g, x, y, w, h, color) {
   rect(g, x + 1, y + 1, w - 2, h - 2, color);
 }
 
-function drawTree(g, season = 0) {
+// Sun comes from the upper-left (LIGHT_VECTOR ≈ (-0.75, -0.65)), so canopy
+// rim highlights belong on the upper-left edge — that anchor point is shared
+// across all three silhouette variants so a forest reads as one lit scene.
+function drawCanopyRim(g, x, y, w, h, color) {
+  rect(g, x + 1, y, Math.max(2, w - 4), 1, color);
+  rect(g, x, y + 1, 1, Math.max(2, h - 4), color);
+}
+
+function drawTreeRound(g, p) {
+  rect(g, 14, 17, 5, 10, p.trunk);
+  rect(g, 13, 22, 3, 4, p.barkDark);
+  rect(g, 18, 21, 3, 5, p.barkDark);
+  rect(g, 12, 26, 4, 2, p.barkDark);
+  rect(g, 18, 26, 4, 2, p.barkDark);
+
+  drawCanopyBlob(g, 8, 8, 17, 13, p.leafDark);
+  drawCanopyBlob(g, 6, 13, 21, 10, p.leafMid);
+  drawCanopyBlob(g, 11, 5, 12, 10, p.leafMid);
+  rect(g, 12, 7, 7, 2, p.leafLight);
+  rect(g, 9, 15, 6, 2, p.leafLight);
+  rect(g, 18, 13, 5, 2, p.accent);
+  drawCanopyRim(g, 8, 6, 14, 4, p.accent);
+  px(g, 22, 18, p.leafDark);
+  px(g, 7, 17, p.leafDark);
+}
+
+function drawTreeConical(g, p) {
+  rect(g, 15, 19, 3, 8, p.trunk);
+  rect(g, 14, 23, 2, 4, p.barkDark);
+  rect(g, 18, 23, 2, 4, p.barkDark);
+
+  // Three stacked tiers, narrowing toward the top.
+  drawCanopyBlob(g, 9, 17, 15, 7, p.leafDark);
+  drawCanopyBlob(g, 11, 11, 11, 7, p.leafMid);
+  drawCanopyBlob(g, 13, 5, 7, 7, p.leafMid);
+  rect(g, 13, 17, 6, 2, p.leafLight);
+  rect(g, 14, 11, 5, 2, p.leafLight);
+  rect(g, 15, 6, 3, 2, p.accent);
+  drawCanopyRim(g, 11, 11, 6, 2, p.accent);
+  drawCanopyRim(g, 9, 17, 6, 2, p.accent);
+  px(g, 23, 22, p.leafDark);
+  px(g, 8, 22, p.leafDark);
+}
+
+function drawTreeSparse(g, p) {
+  rect(g, 14, 14, 4, 13, p.trunk);
+  rect(g, 13, 18, 2, 6, p.barkDark);
+  rect(g, 17, 20, 2, 4, p.barkDark);
+  rect(g, 12, 26, 4, 2, p.barkDark);
+  rect(g, 18, 26, 4, 2, p.barkDark);
+
+  // Branch silhouettes peeking through a thinner canopy.
+  rect(g, 8, 14, 6, 1, p.barkDark);
+  rect(g, 18, 12, 6, 1, p.barkDark);
+
+  drawCanopyBlob(g, 7, 7, 9, 8, p.leafDark);
+  drawCanopyBlob(g, 16, 8, 10, 9, p.leafDark);
+  drawCanopyBlob(g, 11, 4, 10, 8, p.leafMid);
+  rect(g, 8, 9, 5, 2, p.leafLight);
+  rect(g, 18, 10, 5, 2, p.leafLight);
+  rect(g, 13, 5, 5, 2, p.accent);
+  drawCanopyRim(g, 7, 5, 7, 3, p.accent);
+}
+
+function drawTreeWinter(g, p) {
+  rect(g, 14, 17, 5, 10, p.trunk);
+  rect(g, 13, 22, 3, 4, p.barkDark);
+  rect(g, 18, 21, 3, 5, p.barkDark);
+  rect(g, 12, 26, 4, 2, p.barkDark);
+  rect(g, 18, 26, 4, 2, p.barkDark);
+
+  rect(g, 15, 8, 2, 10, p.barkDark);
+  rect(g, 10, 12, 7, 2, p.barkDark);
+  rect(g, 17, 13, 7, 2, p.barkDark);
+  rect(g, 8, 9, 4, 2, p.snow);
+  rect(g, 19, 10, 7, 2, p.snow);
+  rect(g, 12, 5, 8, 3, p.leafLight);
+  rect(g, 9, 8, 14, 4, p.leafMid);
+  rect(g, 7, 13, 18, 4, p.leafDark);
+  rect(g, 10, 7, 8, 1, p.accent);
+  rect(g, 7, 12, 12, 1, p.accent);
+}
+
+function drawTreeVariant(g, season = 0, variant = 0) {
   if (!g) return;
   const palette = SEASON_PALETTES[normalizeSeason(season)];
   const p = palette.tree;
@@ -627,34 +725,15 @@ function drawTree(g, season = 0) {
   rect(g, 8, 25, 17, 3, '#000000');
   g.globalAlpha = 1;
 
-  rect(g, 14, 17, 5, 10, p.trunk);
-  rect(g, 13, 22, 3, 4, p.barkDark);
-  rect(g, 18, 21, 3, 5, p.barkDark);
-  rect(g, 12, 26, 4, 2, p.barkDark);
-  rect(g, 18, 26, 4, 2, p.barkDark);
-
   if (winter) {
-    rect(g, 15, 8, 2, 10, p.barkDark);
-    rect(g, 10, 12, 7, 2, p.barkDark);
-    rect(g, 17, 13, 7, 2, p.barkDark);
-    rect(g, 8, 9, 4, 2, p.snow);
-    rect(g, 19, 10, 7, 2, p.snow);
-    rect(g, 12, 5, 8, 3, p.leafLight);
-    rect(g, 9, 8, 14, 4, p.leafMid);
-    rect(g, 7, 13, 18, 4, p.leafDark);
-    rect(g, 10, 7, 8, 1, p.accent);
-    rect(g, 7, 12, 12, 1, p.accent);
+    drawTreeWinter(g, p);
     return;
   }
 
-  drawCanopyBlob(g, 8, 8, 17, 13, p.leafDark);
-  drawCanopyBlob(g, 6, 13, 21, 10, p.leafMid);
-  drawCanopyBlob(g, 11, 5, 12, 10, p.leafMid);
-  rect(g, 12, 7, 7, 2, p.leafLight);
-  rect(g, 9, 15, 6, 2, p.leafLight);
-  rect(g, 18, 13, 5, 2, p.accent);
-  px(g, 22, 18, p.leafDark);
-  px(g, 7, 17, p.leafDark);
+  const v = ((variant | 0) % TREE_VARIANTS + TREE_VARIANTS) % TREE_VARIANTS;
+  if (v === 1) drawTreeConical(g, p);
+  else if (v === 2) drawTreeSparse(g, p);
+  else drawTreeRound(g, p);
 }
 
 function drawBerry(g, season = 0) {
@@ -871,24 +950,34 @@ function buildTileset() {
       const palette = SEASON_PALETTES[s];
       const base = {};
 
-      base.grass = makeGroundTile(palette, 'grass');
-      base.forest = makeGroundTile(palette, 'forest');
-      base.fertile = makeGroundTile(palette, 'fertile');
-      base.meadow = makeGroundTile(palette, 'meadow');
-      base.marsh = makeGroundTile(palette, 'marsh');
-      base.sand = makeSandTile(palette);
-      base.snow = makeSnowTile(palette);
-      base.rock = makeRockTile(palette);
-      base.water = makeWaterBase(palette);
-      base.farmland = makeFarmlandTile(palette);
+      // Grassy tiles get GROUND_VARIANTS unique bakes so the static albedo
+      // doesn't read as a stamped grid. Variant 0 doubles as the legacy
+      // single-canvas fallback for any consumer that picks a fixed index.
+      const variants = (kind) => Array.from(
+        { length: GROUND_VARIANTS },
+        (_, v) => makeGroundTile(palette, kind, hash2(s, v, kind.charCodeAt(0)))
+      );
+      base.grass = variants('grass');
+      base.forest = variants('forest');
+      base.fertile = variants('fertile');
+      base.meadow = variants('meadow');
+      base.marsh = variants('marsh');
+      base.sand = [makeSandTile(palette)];
+      base.snow = [makeSnowTile(palette)];
+      base.rock = [makeRockTile(palette)];
+      base.water = [makeWaterBase(palette)];
+      base.farmland = [makeFarmlandTile(palette)];
 
       Tileset.baseBySeason[s] = base;
       Tileset.waterOverlayBySeason[s] = makeWaterOverlayFrames(palette);
 
-      Tileset.sprite.treeBySeason[s] = makeSprite(
-        ENTITY_TILE_PX,
-        ENTITY_TILE_PX,
-        g => drawTree(g, s)
+      Tileset.sprite.treeBySeason[s] = Array.from(
+        { length: TREE_VARIANTS },
+        (_, v) => makeSprite(
+          ENTITY_TILE_PX,
+          ENTITY_TILE_PX,
+          g => drawTreeVariant(g, s, v)
+        )
       );
 
       Tileset.sprite.berryBySeason[s] = makeSprite(
@@ -907,7 +996,7 @@ function buildTileset() {
     Tileset.base = Tileset.baseBySeason[0];
     Tileset.waterOverlay = Tileset.waterOverlayBySeason[0];
 
-    Tileset.sprite.tree = Tileset.sprite.treeBySeason[0];
+    Tileset.sprite.tree = Tileset.sprite.treeBySeason[0]?.[0] || null;
     Tileset.sprite.berry = Tileset.sprite.berryBySeason[0];
     Tileset.sprite.sprout = Tileset.sprite.sproutBySeason[0];
   } catch (e) {

--- a/src/app/tileset.js
+++ b/src/app/tileset.js
@@ -568,11 +568,15 @@ function makeWaterBase(palette) {
   return c;
 }
 
+const WATER_OVERLAY_FRAME_COUNT = 6;
+
 function makeWaterOverlayFrames(palette) {
   const frames = [];
   const p = palette.water;
 
-  for (let f = 0; f < 4; f++) {
+  // Phase-shifted sine waves give a smoother shimmer than a linear ripple
+  // step, and 6 frames hide the loop discontinuity better than 4.
+  for (let f = 0; f < WATER_OVERLAY_FRAME_COUNT; f++) {
     const c = makeCanvas(TILE, TILE);
     const g = context2d(c);
     if (!g) {
@@ -584,12 +588,15 @@ function makeWaterOverlayFrames(palette) {
     g.strokeStyle = p.ripple;
     g.lineWidth = 1;
 
+    const phase = (f / WATER_OVERLAY_FRAME_COUNT) * Math.PI * 2;
     for (let i = 0; i < 3; i++) {
-      const y = 6 + i * 9 + f;
+      const baseY = 5 + i * 7;
+      const offset = Math.sin(phase + i * (Math.PI / 2)) * 1.4;
+      const y = baseY + offset;
       g.beginPath();
       g.moveTo(-2, y);
-      g.quadraticCurveTo(TILE * 0.35, y + 3, TILE * 0.7, y);
-      g.quadraticCurveTo(TILE * 0.88, y - 2, TILE + 2, y + 1);
+      g.quadraticCurveTo(TILE * 0.35, y + 2.4 + offset * 0.4, TILE * 0.7, y);
+      g.quadraticCurveTo(TILE * 0.88, y - 1.6 - offset * 0.3, TILE + 2, y + 0.8);
       g.stroke();
     }
 

--- a/src/app/tileset.js
+++ b/src/app/tileset.js
@@ -807,6 +807,30 @@ function drawSproutOn(g, stage, season = 0) {
   }
 }
 function makeZoneGlyphs(){ const farm=makeCanvas(8,8), f=context2d(farm); rect(f,0,0,8,8,'rgba(0,0,0,0)'); px(f,3,6,'#9dd47a'); px(f,4,6,'#9dd47a'); px(f,3,5,'#73b85d'); px(f,4,5,'#73b85d'); px(f,3,4,'#5aa34b'); const cut=makeCanvas(8,8), c=context2d(cut); rect(c,0,0,8,8,'rgba(0,0,0,0)'); rect(c,2,2,4,1,'#caa56a'); rect(c,3,1,2,1,'#8f6934'); const mine=makeCanvas(8,8), m=context2d(mine); rect(m,0,0,8,8,'rgba(0,0,0,0)'); rect(m,2,2,4,1,'#9aa3ad'); rect(m,3,3,2,1,'#6d7782'); Tileset.zoneGlyphs={farm,cut,mine}; }
+// Symmetric 4-frame walk cycle: (neutral, right-step, neutral, left-step).
+// Even frames are mid-stride / standing-still poses, so a ticking villager
+// passes through a "feet together" pose between each step rather than
+// snapping straight from one extreme swing to the other.
+const VILLAGER_FRAME_COUNT = 4;
+
+function drawRoleSilhouette(g, kind) {
+  if (!g) return;
+  if (kind === 'farmer') {
+    // Hoe handle peeking up over the right shoulder.
+    rect(g, 11, 4, 1, 5, '#7a4d27');
+    px(g, 11, 4, '#3a2218');
+  } else if (kind === 'explorer') {
+    // Bow on back — a thin curved silhouette behind the body.
+    rect(g, 3, 6, 1, 5, '#d4c08a');
+    px(g, 4, 5, '#a08252');
+    px(g, 4, 11, '#a08252');
+  } else if (kind === 'worker') {
+    // Small pack outline behind the right shoulder.
+    rect(g, 12, 8, 2, 3, '#5a3820');
+    px(g, 12, 8, '#2a190e');
+  }
+}
+
 function makeVillagerFrames() {
   function role(options) {
     const {
@@ -815,12 +839,13 @@ function makeVillagerFrames() {
       pants,
       hair,
       hat,
+      kind = null,
       skin = '#f1d4b6'
     } = options;
 
     const frames = [];
 
-    for (let f = 0; f < 3; f++) {
+    for (let f = 0; f < VILLAGER_FRAME_COUNT; f++) {
       const c = makeCanvas(16, 16);
       const g = context2d(c);
       if (!g) {
@@ -828,13 +853,19 @@ function makeVillagerFrames() {
         continue;
       }
 
-      const armSwing = f === 1 ? 1 : f === 2 ? -1 : 0;
+      // f=0 / f=2 are mid-stride neutral poses; f=1 is a right step,
+      // f=3 a left step. Two neutrals per cycle smooth the gait.
+      const isStep = f === 1 || f === 3;
+      const armSwing = isStep ? (f === 1 ? 1 : -1) : 0;
       const legA = f === 1 ? 1 : 0;
-      const legB = f === 2 ? 1 : 0;
+      const legB = f === 3 ? 1 : 0;
 
       g.globalAlpha = 0.2;
       rect(g, 4, 14, 8, 1, '#000000');
       g.globalAlpha = 1;
+
+      // Role accessory sits beneath the body so arms occlude it correctly.
+      drawRoleSilhouette(g, kind);
 
       rect(g, 6, 4, 4, 4, skin);
       rect(g, 6, 3, 4, 2, hair);
@@ -870,7 +901,8 @@ function makeVillagerFrames() {
     shirtDark: '#2b7c42',
     pants: '#4b4631',
     hair: '#7a4d27',
-    hat: '#d6cf74'
+    hat: '#d6cf74',
+    kind: 'farmer'
   });
 
   Tileset.villagerSprites.worker = role({
@@ -878,7 +910,8 @@ function makeVillagerFrames() {
     shirtDark: '#704825',
     pants: '#3f3a32',
     hair: '#5a3820',
-    hat: '#8f7440'
+    hat: '#8f7440',
+    kind: 'worker'
   });
 
   Tileset.villagerSprites.explorer = role({
@@ -886,7 +919,8 @@ function makeVillagerFrames() {
     shirtDark: '#284d7a',
     pants: '#38394a',
     hair: '#3b2a1d',
-    hat: '#5a78a8'
+    hat: '#5a78a8',
+    kind: 'explorer'
   });
 
   Tileset.villagerSprites.sleepy = role({
@@ -894,8 +928,26 @@ function makeVillagerFrames() {
     shirtDark: '#555555',
     pants: '#3f3f4f',
     hair: '#444444',
-    hat: null
+    hat: null,
+    kind: null
   });
+}
+
+// Per-villager accent palette — picked deterministically by villager id so
+// the color stays stable across reloads. Drawn as a 1-px scarf overlay at
+// draw time, leaving the role frame caches shared.
+const ACCENT_PALETTE = Object.freeze([
+  '#c34a4a',
+  '#d68a3a',
+  '#3a8ec3',
+  '#a36ec5',
+  '#3aa37a',
+  '#d4b14a'
+]);
+
+function pickAccentColor(villagerId) {
+  const id = (villagerId | 0) >>> 0;
+  return ACCENT_PALETTE[hash2(id, 7) % ACCENT_PALETTE.length];
 }
 
 function drawDeer(g) {
@@ -1035,8 +1087,10 @@ function buildTileset() {
 export {
   Tileset,
   SHADOW_TEXTURE,
+  VILLAGER_FRAME_COUNT,
   buildTileset,
   makeCanvas,
+  pickAccentColor,
   px,
   rect,
   normalizeSeason,

--- a/tests/lighting.grading.test.js
+++ b/tests/lighting.grading.test.js
@@ -1,0 +1,90 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// lighting.js → environment.js asserts on AIV_TERRAIN / AIV_CONFIG at
+// module-load time. The stubs only need to satisfy load-time guards;
+// gradeLightmap is pure and never reads from them.
+function ensureBrowserStubs() {
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const {
+  DAWN_DUSK_TINT,
+  NEUTRAL_TINT,
+  NIGHT_TINT,
+  gradeLightmap
+} = await import('../src/app/lighting.js');
+
+test('gradeLightmap returns night tint at deep night', () => {
+  const t = gradeLightmap(0);
+  assert.equal(t.r, NIGHT_TINT.r);
+  assert.equal(t.g, NIGHT_TINT.g);
+  assert.equal(t.b, NIGHT_TINT.b);
+});
+
+test('gradeLightmap returns neutral at full daylight', () => {
+  const t = gradeLightmap(1.0);
+  assert.equal(t.r, NEUTRAL_TINT.r);
+  assert.equal(t.g, NEUTRAL_TINT.g);
+  assert.equal(t.b, NEUTRAL_TINT.b);
+});
+
+test('gradeLightmap reaches dawn/dusk warm tint near ambient 0.55', () => {
+  const t = gradeLightmap(0.55);
+  assert.equal(t.r, DAWN_DUSK_TINT.r);
+  assert.equal(t.g, DAWN_DUSK_TINT.g);
+  assert.equal(t.b, DAWN_DUSK_TINT.b);
+});
+
+test('gradeLightmap blends night → neutral around ambient 0.4', () => {
+  const t = gradeLightmap(0.4);
+  // At ambient = 0.4 the night→neutral lerp lands on neutral.
+  assert.ok(Math.abs(t.r - NEUTRAL_TINT.r) < 1e-6, `r ${t.r}`);
+  assert.ok(Math.abs(t.g - NEUTRAL_TINT.g) < 1e-6, `g ${t.g}`);
+  assert.ok(Math.abs(t.b - NEUTRAL_TINT.b) < 1e-6, `b ${t.b}`);
+});
+
+test('gradeLightmap warm tint pulls red above blue', () => {
+  // Sanity check on the dawn/dusk tint shape: red dominates, blue attenuates.
+  const t = gradeLightmap(0.55);
+  assert.ok(t.r > t.b, `expected r=${t.r} > b=${t.b}`);
+  assert.ok(t.r > t.g, `expected r=${t.r} > g=${t.g}`);
+});
+
+test('gradeLightmap night tint pulls blue above red', () => {
+  const t = gradeLightmap(0);
+  assert.ok(t.b > t.r, `expected b=${t.b} > r=${t.r}`);
+  assert.ok(t.b > t.g, `expected b=${t.b} > g=${t.g}`);
+});
+
+test('gradeLightmap clamps invalid input', () => {
+  // Non-finite / out-of-range values should not produce NaN tints.
+  const tNeg = gradeLightmap(-0.5);
+  const tInf = gradeLightmap(Infinity);
+  for (const t of [tNeg, tInf]) {
+    assert.ok(Number.isFinite(t.r));
+    assert.ok(Number.isFinite(t.g));
+    assert.ok(Number.isFinite(t.b));
+  }
+});
+
+test('gradeLightmap returns a tint per channel in [0, 1]', () => {
+  for (let a = 0; a <= 1; a += 0.05) {
+    const t = gradeLightmap(a);
+    for (const ch of ['r', 'g', 'b']) {
+      assert.ok(t[ch] >= 0 && t[ch] <= 1, `${ch} at a=${a} = ${t[ch]} out of [0,1]`);
+    }
+  }
+});

--- a/tests/rng.hash.test.js
+++ b/tests/rng.hash.test.js
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { hash2, seededFrom } from '../src/app/rng.js';
+
+test('hash2 is deterministic for the same inputs', () => {
+  assert.equal(hash2(0, 0), hash2(0, 0));
+  assert.equal(hash2(17, 42), hash2(17, 42));
+  assert.equal(hash2(-3, 5, 9), hash2(-3, 5, 9));
+});
+
+test('hash2 returns a non-negative 32-bit integer', () => {
+  for (let i = 0; i < 100; i++) {
+    const h = hash2(i, i * 7, i * 13);
+    assert.ok(h >= 0 && h <= 0xffffffff, `hash2 out of range: ${h}`);
+    assert.equal(h, h | 0 | 0 ? h : h, 'should be integer');
+    assert.ok(Number.isInteger(h));
+  }
+});
+
+test('hash2 distinguishes argument order (not symmetric)', () => {
+  // A symmetric hash would be a poor variant picker.
+  let asymmetricCount = 0;
+  for (let i = 1; i <= 50; i++) {
+    if (hash2(i, i + 1) !== hash2(i + 1, i)) asymmetricCount++;
+  }
+  assert.ok(asymmetricCount > 45, `expected most pairs to differ, got ${asymmetricCount}/50`);
+});
+
+test('hash2 distributes roughly uniformly over a small modulus', () => {
+  // Chi-square style sanity check: 16-bucket distribution over 100k samples
+  // should not have any bucket carrying more than ~12% of the mass.
+  const buckets = new Array(16).fill(0);
+  const N = 100_000;
+  for (let i = 0; i < N; i++) {
+    const x = i % 317;
+    const y = (i * 13 + 7) % 419;
+    buckets[hash2(x, y) % 16]++;
+  }
+  const expected = N / 16;
+  for (const count of buckets) {
+    const ratio = count / expected;
+    assert.ok(ratio > 0.85 && ratio < 1.15, `bucket count ${count} skews too far from ${expected}`);
+  }
+});
+
+test('seededFrom returns a deterministic float RNG', () => {
+  const a = seededFrom(42);
+  const b = seededFrom(42);
+  for (let i = 0; i < 10; i++) {
+    assert.equal(a(), b(), `seededFrom(42) sample ${i} should match`);
+  }
+});
+
+test('seededFrom yields floats in [0, 1)', () => {
+  const r = seededFrom(7);
+  for (let i = 0; i < 1000; i++) {
+    const v = r();
+    assert.ok(v >= 0 && v < 1, `out of range float: ${v}`);
+  }
+});
+
+test('seededFrom does not touch the global RNG', () => {
+  // Math.random() must be unaffected by calls into seededFrom().
+  const before = Math.random();
+  const r = seededFrom(99);
+  for (let i = 0; i < 500; i++) r();
+  const after = Math.random();
+  // We can't assert equality (Math.random is non-deterministic), but both
+  // values should still be in [0, 1) — proving Math.random is callable.
+  assert.ok(before >= 0 && before < 1);
+  assert.ok(after >= 0 && after < 1);
+});
+
+test('seededFrom(0) does not produce a stuck-at-zero sequence', () => {
+  const r = seededFrom(0);
+  let nonZero = 0;
+  for (let i = 0; i < 20; i++) if (r() !== 0) nonZero++;
+  assert.ok(nonZero >= 18, `seededFrom(0) should not produce all zeros, got ${nonZero}/20 non-zero`);
+});

--- a/tests/villager.accent.test.js
+++ b/tests/villager.accent.test.js
@@ -1,0 +1,94 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// tileset.js bakes sprites at module-load time. pickAccentColor itself is
+// pure (depends only on hash2), but the bake step still runs. Provide a
+// no-op canvas/context stub so SHADOW_TEXTURE and the seasonal sprite caches
+// can be constructed without throwing in node.
+function ensureBrowserStubs() {
+  const noopGradient = { addColorStop: () => {} };
+  const makeCtx = () => ({
+    imageSmoothingEnabled: false,
+    globalAlpha: 1,
+    globalCompositeOperation: 'source-over',
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    font: '',
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    fillRect: () => {},
+    strokeRect: () => {},
+    clearRect: () => {},
+    beginPath: () => {},
+    closePath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    arc: () => {},
+    quadraticCurveTo: () => {},
+    bezierCurveTo: () => {},
+    fill: () => {},
+    stroke: () => {},
+    save: () => {},
+    restore: () => {},
+    translate: () => {},
+    rotate: () => {},
+    scale: () => {},
+    drawImage: () => {},
+    createRadialGradient: () => noopGradient,
+    createLinearGradient: () => noopGradient,
+    createImageData: (w, h) => ({ data: new Uint8ClampedArray(w * h * 4), width: w, height: h }),
+    putImageData: () => {},
+    getImageData: (x, y, w, h) => ({ data: new Uint8ClampedArray(w * h * 4), width: w, height: h }),
+    measureText: () => ({ width: 0 }),
+    fillText: () => {},
+    strokeText: () => {}
+  });
+  const makeFakeCanvas = () => ({
+    width: 0,
+    height: 0,
+    style: {},
+    getContext: () => makeCtx(),
+    getBoundingClientRect: () => ({ width: 800, height: 600 })
+  });
+  if (!globalThis.document) {
+    globalThis.document = {
+      getElementById: makeFakeCanvas,
+      createElement: makeFakeCanvas
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  }
+}
+ensureBrowserStubs();
+
+const { pickAccentColor } = await import('../src/app/tileset.js');
+
+test('pickAccentColor is a pure function of villager id', () => {
+  for (let id = 1; id <= 50; id++) {
+    assert.equal(pickAccentColor(id), pickAccentColor(id));
+  }
+});
+
+test('pickAccentColor returns a hex string', () => {
+  for (let id = 1; id <= 30; id++) {
+    const c = pickAccentColor(id);
+    assert.match(c, /^#[0-9a-f]{6}$/i, `not a 6-digit hex: ${c}`);
+  }
+});
+
+test('pickAccentColor produces multiple distinct colors across ids', () => {
+  // The 6-color palette should be reachable from a small id sweep.
+  const seen = new Set();
+  for (let id = 0; id < 200; id++) seen.add(pickAccentColor(id));
+  assert.ok(seen.size >= 4, `expected ≥4 distinct accents, saw ${seen.size}`);
+});
+
+test('pickAccentColor handles non-finite ids without throwing', () => {
+  // The implementation coerces with `(id | 0) >>> 0`, so NaN/undefined map
+  // to 0 — still deterministic, still a valid color.
+  assert.match(pickAccentColor(NaN), /^#[0-9a-f]{6}$/i);
+  assert.match(pickAccentColor(undefined), /^#[0-9a-f]{6}$/i);
+  assert.equal(pickAccentColor(NaN), pickAccentColor(undefined));
+});


### PR DESCRIPTION
- Add stateless hash2(x, y, z) and seededFrom(seed) primitives in rng.js
  for deterministic per-tile/per-id picks that don't touch the global R.
- Refactor tileset noise helpers (grassClumps, noisePixels, flowerScatter,
  leafScatter, snowDust) to accept an irand parameter so each ground-tile
  variant gets its own reproducible noise stream.
- Bake GROUND_VARIANTS=3 unique canvases per grassy tile kind (grass,
  forest, fertile, meadow, marsh) in buildTileset; sand/snow/rock/water/
  farmland keep a single bake. Tileset.baseBySeason[s][kind] is now a
  canvas array; drawStaticAlbedo picks variant by hash2(x, y) % len.
- Split drawTree into three silhouette variants (round, conical, sparse)
  with an upper-left rim-light pass; keep a dedicated winter tree.
  Forest tiles pick variant per-cell by hash2(x, y, 17) % 3, so a forest
  patch reads as a mix of canopy shapes instead of stamped repeats.
- Tighten SEASON_PALETTES across spring/summer/autumn: pull saturated
  greens toward a sage-leaning family, drop forest base luminance ~5%
  so canopies read as shadow against grass, and quiet the autumn ochre
  band toward terracotta.
- Add tests/rng.hash.test.js covering hash2 determinism, distribution,
  asymmetry, and seededFrom isolation from the global RNG.