### PR TITLE
Phase 10: hydration tightening + fatigue (S10/S4/S5)

### DIFF
--- a/src/app/onArrive.js
+++ b/src/app/onArrive.js
@@ -24,6 +24,7 @@ import {
   SOCIAL_BASE_TICKS,
   STORAGE_IDLE_BASE,
   restDurationTicks,
+  workEffortMultiplier,
 } from './villagerAI.js';
 
 export function createOnArrive(opts) {
@@ -79,7 +80,14 @@ export function createOnArrive(opts) {
       : condition === 'recovering' ? 0.95
       : 1;
     const moodSpeed = 0.75 + v.happy * 0.5;
-    const speedMultiplier = v.speed * penalty * moodSpeed;
+    // Phase 10 (S4): tired villagers move slower. Multiplicative with the
+    // condition penalty so a starving + low-energy villager still moves
+    // slower than a starving but rested one.
+    const energy = Number.isFinite(v.energy) ? v.energy : 1;
+    const energyPenalty = energy < 0.30 ? 0.85
+      : energy < 0.50 ? 0.95
+      : 1;
+    const speedMultiplier = v.speed * penalty * moodSpeed * energyPenalty;
     const stepPx = getSpeedPxPerSec() * speedMultiplier * getSecondsPerTick();
     const step = stepPx / TILE;
     const dx = next.x - v.x, dy = next.y - v.y, dist = Math.hypot(dx, dy);
@@ -246,7 +254,11 @@ export function createOnArrive(opts) {
     }
     else if (v.state === 'harvest') {
       if (world.growth[i] > 0) {
-        let yieldAmount = 2;
+        // Phase 10 (S5): hungry/sick/tired harvesters bring back less. Floor
+        // at 1 so an arrived villager always returns *something* (zero-yield
+        // harvest would feel buggy and the tile is still consumed below).
+        const effort = workEffortMultiplier(v);
+        let yieldAmount = Math.max(1, Math.round(2 * effort));
         const { harvestBonus } = agricultureBonusesAt(cx, cy);
         if (harvestBonus > 0) {
           const whole = Math.floor(harvestBonus);

--- a/src/app/villagerAI.js
+++ b/src/app/villagerAI.js
@@ -23,7 +23,11 @@ export const FOOD_HUNGER_RECOVERY = 0.65;
 export const REST_BASE_TICKS = 90;
 export const REST_EXTRA_PER_ENERGY = 110;
 export const HYDRATION_VISIT_THRESHOLD = 0.46;
-export const HYDRATION_BUFF_TICKS = 320;
+// Phase 10 (S10): shorter buff window so the energy/hunger/mood bonus is a
+// punctual reward rather than the default state. With Phase 10's faster decay
+// villagers visit wells ~2× per day, but the buff still only covers ~5.5%
+// of the day instead of ~9%.
+export const HYDRATION_BUFF_TICKS = 200;
 export const SOCIAL_BASE_TICKS = 88;
 export const SOCIAL_COOLDOWN_TICKS = DAY_LENGTH * 0.2;
 export const STORAGE_IDLE_BASE = 70;
@@ -35,6 +39,21 @@ export const STORAGE_IDLE_COOLDOWN = DAY_LENGTH * 0.12;
 export function restDurationTicks(energy) {
   const e = Number.isFinite(energy) ? energy : 0;
   return REST_BASE_TICKS + Math.round(Math.max(0, 1 - e) * REST_EXTRA_PER_ENERGY);
+}
+
+// Phase 10 (S5): per-action work efficiency. Building labor (Phase 7)
+// accumulates by this fraction per tick instead of a flat 1, and harvest
+// yield is scaled by the same factor (with a min of 1 food). Single source of
+// truth so villagerTick.js and onArrive.js can't drift.
+export function workEffortMultiplier(v) {
+  const condition = v?.condition || 'normal';
+  const conditionMult = condition === 'sick' ? 0.5
+    : condition === 'starving' ? 0.7
+    : condition === 'hungry' ? 0.9
+    : 1;
+  const energy = Number.isFinite(v?.energy) ? v.energy : 1;
+  const energyMult = energy < 0.30 ? 0.85 : 1;
+  return conditionMult * energyMult;
 }
 
 // Night-anchored sleep predicate (audit S1). Pure function so tests can

--- a/src/app/villagerTick.js
+++ b/src/app/villagerTick.js
@@ -20,7 +20,8 @@ import {
   STORAGE_IDLE_BASE,
   STORAGE_IDLE_COOLDOWN,
   restDurationTicks,
-  wantsToSleep
+  wantsToSleep,
+  workEffortMultiplier
 } from './villagerAI.js';
 
 // Tick-only knobs (decay rates / per-frame deltas) live next to the function
@@ -35,8 +36,13 @@ const REST_MOOD_TICK = 0.0009;
 const REST_FINISH_MOOD = 0.05;
 const REST_HUNGER_MULT = 0.42;
 
-const HYDRATION_DECAY = 0.00018;
-const HYDRATION_LOW = 0.28;
+// Phase 10 (S10): tightened decay + dehydrated threshold so dry stretches
+// matter. The pre-Phase-10 0.00018/tick reached the visit threshold (0.46)
+// only once per day; 0.00028/tick puts that ~1929 ticks after drinking, so
+// wells get visited ~2× per day and the dehydrated penalty (raised to 0.32)
+// is reachable in normal play instead of just edge cases.
+const HYDRATION_DECAY = 0.00028;
+const HYDRATION_LOW = 0.32;
 const HYDRATION_HUNGER_MULT = 0.9;
 const HYDRATION_FATIGUE_BONUS = 0.8;
 const HYDRATION_DEHYDRATED_PENALTY = 1.12;
@@ -367,7 +373,11 @@ export function createVillagerTick(opts) {
         } else {
           const def = BUILDINGS[b.kind] || {};
           const laborGoal = def.buildLaborTicks | 0;
-          b.laborProgress = (b.laborProgress | 0) + 1;
+          // Phase 10 (S5): tired/sick villagers contribute less labor per
+          // tick. Drop the `| 0` truncation so the fractional accumulation
+          // is preserved across ticks; the `>=` completion check still
+          // works fine on a float.
+          b.laborProgress = (b.laborProgress || 0) + workEffortMultiplier(v);
           noteBuildingActivity(b, 'use');
           if (b.laborProgress >= laborGoal) {
             b.built = 1;

--- a/tests/hydration.tuning.phase10.test.js
+++ b/tests/hydration.tuning.phase10.test.js
@@ -1,0 +1,99 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// villagerAI.js → simulation.js → environment.js asserts on AIV_TERRAIN /
+// AIV_CONFIG at module-load time. Mirror the stub pattern from the other
+// phase-10 tests so the import resolves.
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = {
+      getElementById: () => ({
+        getContext: () => ({ imageSmoothingEnabled: true }),
+        getBoundingClientRect: () => ({ width: 800, height: 600 }),
+        style: {},
+        width: 0,
+        height: 0,
+      }),
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  }
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const { HYDRATION_BUFF_TICKS, HYDRATION_VISIT_THRESHOLD } = await import('../src/app/villagerAI.js');
+
+// Phase 10 (S10): pre-Phase-10 villagers were >0.90 hydrated for ~76% of the
+// day at decay 0.00018/tick + 320-tick buff. The new constants tighten that
+// so dry stretches matter — buff is shorter, decay is faster, and the
+// dehydrated penalty kicks in earlier.
+
+// Mirror of the constants in src/app/villagerTick.js. Kept here as plain
+// numbers so a regression that drifts the .js value is caught loudly without
+// reaching into the module's internals (those constants aren't exported on
+// purpose — only the tick function consumes them).
+const HYDRATION_DECAY = 0.00028;
+const HYDRATION_LOW = 0.32;
+
+test('S10: hydration buff is tightened from 320 to 200 ticks', () => {
+  assert.equal(HYDRATION_BUFF_TICKS, 200,
+    'shorter buff → energy/hunger/mood bonus is a punctual reward, not a default state');
+});
+
+test('S10: visit threshold is unchanged so the well decision still triggers at 0.46', () => {
+  assert.equal(HYDRATION_VISIT_THRESHOLD, 0.46);
+});
+
+test('S10: decay rate reaches the visit threshold within ~half a day', () => {
+  // (1.0 - 0.46) / 0.00028 ≈ 1929 ticks. A 3600-tick day means a villager
+  // would seek a well roughly twice per day, not once.
+  const ticksToVisit = (1 - HYDRATION_VISIT_THRESHOLD) / HYDRATION_DECAY;
+  assert.ok(ticksToVisit < 2000,
+    `decay rate must reach visit threshold within ~1929 ticks, got ${ticksToVisit}`);
+  assert.ok(ticksToVisit > 1500,
+    `but not so fast that villagers thrash on wells (cooldown is ~576), got ${ticksToVisit}`);
+});
+
+test('S10: dehydration is reachable in normal play, not just edge cases', () => {
+  // (1.0 - 0.32) / 0.00028 ≈ 2429 ticks → about 67% of a day. A villager
+  // who skips a well visit will spend the late part of the day under the
+  // dehydration penalty (energy drain ×1.12, mood loss).
+  const ticksToDehydrated = (1 - HYDRATION_LOW) / HYDRATION_DECAY;
+  assert.ok(ticksToDehydrated < 3000,
+    `dehydrated state must be reachable within a single day's drain, got ${ticksToDehydrated}`);
+});
+
+test('S10: simulating decay over the buff window leaves the buff expired', () => {
+  // After drinking, hydrationBuffTicks=200. After 200 ticks of decrement
+  // it should be 0 (i.e., no longer "hydrated buff").
+  let buff = HYDRATION_BUFF_TICKS;
+  for (let i = 0; i < HYDRATION_BUFF_TICKS; i++) {
+    if (buff > 0) buff--;
+  }
+  assert.equal(buff, 0, 'buff timer counts down to zero across exactly its duration');
+});
+
+test('S10: simulating ~2000 ticks of decay pushes a full villager below visit threshold', () => {
+  // (1.0 - 0.46) / 0.00028 ≈ 1929 ticks. Using a slightly higher bound here
+  // so the assertion is robust against tiny rate adjustments.
+  let hydration = 1;
+  const TICKS = 2000;
+  for (let i = 0; i < TICKS; i++) {
+    hydration = Math.max(0, hydration - HYDRATION_DECAY);
+  }
+  assert.ok(hydration < HYDRATION_VISIT_THRESHOLD,
+    `after ${TICKS} ticks (~55% of a day) a villager should be seeking a well, got hydration=${hydration}`);
+});

--- a/tests/movement.fatigue.phase10.test.js
+++ b/tests/movement.fatigue.phase10.test.js
@@ -1,0 +1,166 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// Mirrors the load-time stubs from movement.speed.test.js: onArrive.js →
+// simulation.js → environment.js asserts on AIV_TERRAIN / AIV_CONFIG, and
+// world.js → canvas.js touches `document` / `window`. None of these are
+// exercised by stepAlong.
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = {
+      getElementById: () => ({
+        getContext: () => ({ imageSmoothingEnabled: true }),
+        getBoundingClientRect: () => ({ width: 800, height: 600 }),
+        style: {},
+        width: 0,
+        height: 0,
+      }),
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  }
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const { createOnArrive } = await import('../src/app/onArrive.js');
+const { TILE } = await import('../src/app/constants.js');
+
+const TICKS_PER_SEC = 6;
+const SECONDS_PER_TICK = 1 / TICKS_PER_SEC;
+const SPEED_PX_PER_SEC = 0.08 * 32 * TICKS_PER_SEC;
+
+function makeState() {
+  return {
+    units: { buildings: [], itemsOnGround: [] },
+    stocks: { totals: {}, reserved: {} },
+    time: { tick: 0, speedIdx: 0 },
+    world: {},
+  };
+}
+
+function makeSystem(state) {
+  const noop = () => {};
+  return createOnArrive({
+    state,
+    pathfind: () => null,
+    idx: () => 0,
+    finishJob: noop,
+    suppressJob: noop,
+    releaseReservedMaterials: noop,
+    spendCraftMaterials: noop,
+    cancelHaulJobsForBuilding: noop,
+    findAnimalById: () => null,
+    removeAnimal: noop,
+    resolveHuntYield: () => ({}),
+    chooseFleeTarget: () => null,
+    queueAnimalLabel: noop,
+    findHuntApproachPath: () => null,
+    consumeFood: noop,
+    handleVillagerFed: noop,
+    findNearestBuilding: () => null,
+    agricultureBonusesAt: () => ({}),
+    findEntryTileNear: () => null,
+    getBuildingById: () => null,
+    setActiveBuilding: noop,
+    noteBuildingActivity: noop,
+    buildingAt: () => null,
+    dropItem: noop,
+    removeItemAtIndex: noop,
+    itemTileIndex: () => -1,
+    markStaticDirty: noop,
+    markEmittersDirty: noop,
+    onZoneTileSown: noop,
+    getSecondsPerTick: () => SECONDS_PER_TICK,
+    getSpeedPxPerSec: () => SPEED_PX_PER_SEC,
+  });
+}
+
+function makeVillager(overrides = {}) {
+  return {
+    x: 0,
+    y: 0,
+    path: [{ x: 1000, y: 0 }],
+    condition: 'normal',
+    happy: 0.5,
+    speed: 1,
+    energy: 1,
+    ...overrides,
+  };
+}
+
+function expectedStep({ penalty, moodSpeed, energyPenalty }) {
+  return (SPEED_PX_PER_SEC * 1 * penalty * moodSpeed * energyPenalty * SECONDS_PER_TICK) / TILE;
+}
+
+test('S4: well-rested villager (energy ≥ 0.5) walks at the no-penalty speed', () => {
+  const { stepAlong } = makeSystem(makeState());
+  for (const energy of [1.0, 0.75, 0.5]) {
+    const v = makeVillager({ energy });
+    stepAlong(v);
+    const step = expectedStep({ penalty: 1, moodSpeed: 1.0, energyPenalty: 1 });
+    assert.equal(v.x, step, `energy=${energy} should walk full speed`);
+  }
+});
+
+test('S4: a moderately tired villager (0.30 ≤ energy < 0.50) walks 5% slower', () => {
+  const { stepAlong } = makeSystem(makeState());
+  const v = makeVillager({ energy: 0.4 });
+  stepAlong(v);
+  const step = expectedStep({ penalty: 1, moodSpeed: 1.0, energyPenalty: 0.95 });
+  assert.equal(v.x, step);
+});
+
+test('S4: an exhausted villager (energy < 0.30) walks 15% slower', () => {
+  const { stepAlong } = makeSystem(makeState());
+  const v = makeVillager({ energy: 0.1 });
+  stepAlong(v);
+  const step = expectedStep({ penalty: 1, moodSpeed: 1.0, energyPenalty: 0.85 });
+  assert.equal(v.x, step);
+});
+
+test('S4: energy penalty is multiplicative with the condition penalty', () => {
+  // A starving + exhausted villager should be slower than a starving + rested
+  // one, but neither should be slower than a sick villager (which keeps its
+  // 0.45× condition penalty as the hardest brake).
+  const { stepAlong } = makeSystem(makeState());
+
+  const starvingRested = makeVillager({ condition: 'starving', energy: 1 });
+  const starvingTired = makeVillager({ condition: 'starving', energy: 0.1 });
+  stepAlong(starvingRested);
+  stepAlong(starvingTired);
+
+  assert.ok(starvingTired.x < starvingRested.x,
+    'low-energy starving villager moves slower than rested starving one');
+
+  const expectedRested = expectedStep({ penalty: 0.7, moodSpeed: 1.0, energyPenalty: 1 });
+  const expectedTired = expectedStep({ penalty: 0.7, moodSpeed: 1.0, energyPenalty: 0.85 });
+  assert.equal(starvingRested.x, expectedRested);
+  assert.equal(starvingTired.x, expectedTired);
+});
+
+test('S4: existing villagers without an energy field still walk at full speed (back-compat)', () => {
+  // The B11 movement.speed test villager has no `energy` field; the
+  // Number.isFinite guard treats that as 1.0 so the existing test still
+  // passes after Phase 10.
+  const { stepAlong } = makeSystem(makeState());
+  const v = {
+    x: 0, y: 0, path: [{ x: 1000, y: 0 }],
+    condition: 'normal', happy: 0.5, speed: 1,
+  };
+  stepAlong(v);
+  const step = expectedStep({ penalty: 1, moodSpeed: 1.0, energyPenalty: 1 });
+  assert.equal(v.x, step);
+});

--- a/tests/work.fatigue.phase10.test.js
+++ b/tests/work.fatigue.phase10.test.js
@@ -1,0 +1,417 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// Same browser-stub preamble as build.laborResume.phase7.test.js.
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = {
+      getElementById: () => ({
+        getContext: () => ({ imageSmoothingEnabled: true }),
+        getBoundingClientRect: () => ({ width: 800, height: 600 }),
+        style: {},
+        width: 0,
+        height: 0,
+      }),
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  }
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const { workEffortMultiplier } = await import('../src/app/villagerAI.js');
+const { createVillagerTick } = await import('../src/app/villagerTick.js');
+const { createOnArrive } = await import('../src/app/onArrive.js');
+const { BUILDINGS, ensureBuildingData } = await import('../src/app/world.js');
+const { TILES, ITEM, ZONES } = await import('../src/app/constants.js');
+
+// --- workEffortMultiplier unit tests --------------------------------------
+
+test('S5: workEffortMultiplier returns 1.0 for a healthy, rested villager', () => {
+  assert.equal(workEffortMultiplier({ condition: 'normal', energy: 1 }), 1);
+  assert.equal(workEffortMultiplier({ condition: 'normal', energy: 0.5 }), 1);
+  // Exactly 0.30 is *not* below the threshold (the cutoff is `< 0.30`).
+  assert.equal(workEffortMultiplier({ condition: 'normal', energy: 0.3 }), 1);
+});
+
+test('S5: workEffortMultiplier penalises hungry/starving/sick conditions', () => {
+  assert.equal(workEffortMultiplier({ condition: 'hungry', energy: 1 }), 0.9);
+  assert.equal(workEffortMultiplier({ condition: 'starving', energy: 1 }), 0.7);
+  assert.equal(workEffortMultiplier({ condition: 'sick', energy: 1 }), 0.5);
+});
+
+test('S5: low energy compounds with condition multiplicatively', () => {
+  // starving (0.7) × low-energy (0.85) = 0.595
+  const m = workEffortMultiplier({ condition: 'starving', energy: 0.1 });
+  assert.ok(Math.abs(m - 0.595) < 1e-12, `expected 0.595, got ${m}`);
+});
+
+test('S5: workEffortMultiplier handles missing fields safely', () => {
+  // No condition / no energy → treated as healthy + full energy.
+  assert.equal(workEffortMultiplier({}), 1);
+  assert.equal(workEffortMultiplier({ condition: undefined, energy: undefined }), 1);
+});
+
+// --- Building labor ----------------------------------------------------------
+
+function makeState({ buildings = [], jobs = [], villagers = [], totals = {} } = {}) {
+  return {
+    units: { buildings, jobs, villagers, itemsOnGround: [] },
+    stocks: { totals: { food: 0, wood: 0, stone: 0, ...totals }, reserved: {} },
+    time: { tick: 0, dayTime: 0, speedIdx: 0 },
+    bb: null,
+    world: {
+      tiles: new Uint8Array(0),
+      trees: new Uint8Array(0),
+      rocks: new Uint8Array(0),
+      growth: new Uint16Array(0),
+      berries: new Uint8Array(0),
+    },
+  };
+}
+
+function makeFinishJob(jobs) {
+  return (v, remove = false) => {
+    const job = v.targetJob;
+    if (job) {
+      job.assigned = Math.max(0, (job.assigned || 0) - 1);
+      if (remove) {
+        const ji = jobs.indexOf(job);
+        if (ji !== -1) jobs.splice(ji, 1);
+      }
+    }
+    v.targetJob = null;
+  };
+}
+
+function makeVillagerTickSystem(state) {
+  const noop = () => {};
+  const finishJob = makeFinishJob(state.units.jobs);
+  return createVillagerTick({
+    state,
+    policy: { style: { jobScoring: { restEnergyThreshold: 0.0 } }, routine: {} },
+    pathfind: () => null,
+    ambientAt: () => 'day',
+    nearbyWarmth: () => false,
+    agricultureBonusesAt: () => ({ growthBonus: 0, harvestBonus: 0, moodBonus: 0 }),
+    getBuildingById: (id) => state.units.buildings.find((b) => b.id === id) || null,
+    noteBuildingActivity: (b) => {
+      if (b) {
+        ensureBuildingData(b);
+        b.activity.lastUse = state.time.tick;
+      }
+    },
+    endBuildingStay: (v) => {
+      if (v.activeBuildingId) {
+        const prev = state.units.buildings.find((b) => b.id === v.activeBuildingId);
+        if (prev) {
+          ensureBuildingData(prev);
+          prev.activity.occupants = Math.max(0, (prev.activity.occupants || 0) - 1);
+        }
+        v.activeBuildingId = null;
+      }
+      v.targetBuilding = null;
+    },
+    cancelHaulJobsForBuilding: noop,
+    finishJob,
+    markStaticDirty: noop,
+    markEmittersDirty: noop,
+    issueStarveToast: noop,
+    enterSickState: noop,
+    suppressJob: noop,
+    noteJobAssignmentChanged: noop,
+    getJobCreationConfig: () => ({}),
+    findEntryTileNear: () => null,
+    findNearestBuilding: () => null,
+    buildingCenter: (b) => ({ x: b.x, y: b.y }),
+    findHuntApproachPath: () => null,
+    findAnimalById: () => null,
+    buildingAt: () => null,
+    tryEquipBow: () => false,
+    tryHydrateAtWell: () => false,
+    tryCampfireSocial: () => false,
+    tryStorageIdle: () => false,
+    foragingJob: () => false,
+    goRest: () => false,
+    seekEmergencyFood: () => false,
+    consumeFood: () => false,
+    findPanicHarvestJob: () => null,
+    pickJobFor: () => null,
+    maybeInterruptJob: () => false,
+    tryStartPregnancy: noop,
+    completePregnancy: noop,
+    promoteChildToAdult: noop,
+    handleIdleRoam: () => false,
+    stepAlong: noop,
+  });
+}
+
+function makeHutBuilding(overrides = {}) {
+  const b = {
+    id: 1,
+    kind: 'hut',
+    x: 0,
+    y: 0,
+    built: 0,
+    store: { wood: 0, stone: 0, food: 0 },
+    spent: { wood: 10, stone: 0 },
+    pending: { wood: 0, stone: 0 },
+    progress: 10,
+    laborProgress: 0,
+    ...overrides,
+  };
+  ensureBuildingData(b);
+  return b;
+}
+
+function makeBuilder(job, overrides = {}) {
+  return {
+    id: 'v1',
+    x: 0,
+    y: 0,
+    path: [],
+    state: 'building',
+    targetJob: job,
+    role: 'worker',
+    speed: 1,
+    inv: null,
+    hunger: 0.1,
+    energy: 0.8,
+    happy: 0.6,
+    hydration: 0.7,
+    condition: 'normal',
+    starveStage: 0,
+    activeBuildingId: 1,
+    thought: '',
+    ageTicks: 100,
+    lifeStage: 'adult',
+    ...overrides,
+  };
+}
+
+test('S5: a healthy builder accumulates 1.0 labor per tick (regression guard)', () => {
+  const b = makeHutBuilding();
+  const job = { id: 1, type: 'build', bid: 1, x: 0, y: 0, prio: 1, assigned: 0 };
+  const state = makeState({ buildings: [b], jobs: [job] });
+  const { villagerTick } = makeVillagerTickSystem(state);
+  const v = makeBuilder(job);
+  state.units.villagers.push(v);
+
+  for (let i = 0; i < 10; i++) {
+    villagerTick(v);
+    state.time.tick++;
+  }
+  // Float compare with tolerance (since we no longer truncate to int).
+  assert.ok(Math.abs(b.laborProgress - 10) < 1e-9,
+    `healthy builder accumulates 1.0 per tick, got ${b.laborProgress}`);
+});
+
+test('S5: a starving builder accumulates only 0.7 labor per tick', () => {
+  const b = makeHutBuilding();
+  const job = { id: 1, type: 'build', bid: 1, x: 0, y: 0, prio: 1, assigned: 0 };
+  const state = makeState({ buildings: [b], jobs: [job] });
+  const { villagerTick } = makeVillagerTickSystem(state);
+  // condition='starving' but starveStage=1 so we don't trip urgentFood (which
+  // would yank the villager out of building state before we can measure).
+  const v = makeBuilder(job, {
+    condition: 'starving',
+    starveStage: 1,
+    hunger: 1.0,
+    energy: 0.8,
+  });
+  state.units.villagers.push(v);
+
+  for (let i = 0; i < 10; i++) {
+    villagerTick(v);
+    state.time.tick++;
+  }
+  assert.ok(Math.abs(b.laborProgress - 7) < 1e-9,
+    `starving builder accumulates ~0.7/tick (10 ticks → 7), got ${b.laborProgress}`);
+});
+
+test('S5: a starving + exhausted builder accumulates ~0.595 labor per tick', () => {
+  const b = makeHutBuilding();
+  const job = { id: 1, type: 'build', bid: 1, x: 0, y: 0, prio: 1, assigned: 0 };
+  const state = makeState({ buildings: [b], jobs: [job] });
+  const { villagerTick } = makeVillagerTickSystem(state);
+  const v = makeBuilder(job, {
+    condition: 'starving',
+    starveStage: 1,
+    hunger: 1.0,
+    energy: 0.1, // below 0.30 → 0.85 energy penalty
+  });
+  state.units.villagers.push(v);
+
+  for (let i = 0; i < 10; i++) {
+    villagerTick(v);
+    state.time.tick++;
+  }
+  // 10 × 0.7 × 0.85 = 5.95. Allow a small tolerance for energy clamp drift
+  // (villagerTick mutates v.energy each tick).
+  assert.ok(b.laborProgress < 7,
+    `starving + exhausted builder must be slower than a healthy starving one (>7), got ${b.laborProgress}`);
+  assert.ok(b.laborProgress > 4.5,
+    `starving + exhausted builder still makes meaningful progress (~5.95), got ${b.laborProgress}`);
+});
+
+test('S5: a sick builder takes ~2× as many ticks to finish a hut as a healthy one', () => {
+  // Sick = 0.5 multiplier, so 60 labor takes 120 ticks instead of 60.
+  function ticksToFinish(condition) {
+    const b = makeHutBuilding();
+    const job = { id: 1, type: 'build', bid: 1, x: 0, y: 0, prio: 1, assigned: 0 };
+    const state = makeState({ buildings: [b], jobs: [job] });
+    const { villagerTick } = makeVillagerTickSystem(state);
+    const v = makeBuilder(job, condition === 'sick'
+      ? { condition: 'sick', sickTimer: 5000, energy: 0.8, hunger: 1.05, starveStage: 1 }
+      : { condition: 'normal' });
+    state.units.villagers.push(v);
+    let ticks = 0;
+    while (b.built < 1 && ticks < 500) {
+      villagerTick(v);
+      state.time.tick++;
+      ticks++;
+    }
+    return ticks;
+  }
+
+  const healthy = ticksToFinish('normal');
+  const sick = ticksToFinish('sick');
+  assert.equal(healthy, BUILDINGS.hut.buildLaborTicks,
+    `healthy builder finishes in exactly buildLaborTicks (${BUILDINGS.hut.buildLaborTicks}), got ${healthy}`);
+  assert.ok(sick >= healthy * 1.8,
+    `sick builder takes at least ~1.8× as long as healthy, got sick=${sick} vs healthy=${healthy}`);
+});
+
+// --- Harvest yield -----------------------------------------------------------
+
+function makeWorldWithCrop() {
+  // 1×1 world with a single farmland tile that has fully-grown crops.
+  return {
+    tiles: new Uint8Array([TILES.FARMLAND]),
+    trees: new Uint8Array([0]),
+    rocks: new Uint8Array([0]),
+    growth: new Uint16Array([200]),
+    berries: new Uint8Array([0]),
+    zone: new Uint8Array([ZONES.FARM]),
+  };
+}
+
+function makeOnArriveForHarvest(state, dropped) {
+  const noop = () => {};
+  const finishJob = makeFinishJob(state.units.jobs);
+  return createOnArrive({
+    state,
+    pathfind: () => null,
+    idx: () => 0,
+    finishJob,
+    suppressJob: noop,
+    releaseReservedMaterials: noop,
+    spendCraftMaterials: () => true,
+    cancelHaulJobsForBuilding: noop,
+    findAnimalById: () => null,
+    removeAnimal: noop,
+    resolveHuntYield: () => ({ meat: 0, pelts: 0 }),
+    chooseFleeTarget: () => null,
+    queueAnimalLabel: noop,
+    findHuntApproachPath: () => null,
+    consumeFood: () => false,
+    handleVillagerFed: noop,
+    findNearestBuilding: () => null,
+    // No bonus tile so harvest yield is purely the workEffort * 2 base.
+    agricultureBonusesAt: () => ({ growthBonus: 0, harvestBonus: 0, moodBonus: 0 }),
+    findEntryTileNear: () => null,
+    getBuildingById: () => null,
+    setActiveBuilding: noop,
+    noteBuildingActivity: noop,
+    buildingAt: () => null,
+    dropItem: (x, y, type, qty) => {
+      if (type === ITEM.FOOD) dropped.push(qty);
+    },
+    removeItemAtIndex: noop,
+    itemTileIndex: { get: () => undefined },
+    markStaticDirty: noop,
+    markEmittersDirty: noop,
+    onZoneTileSown: noop,
+    getSecondsPerTick: () => 1 / 6,
+    getSpeedPxPerSec: () => 0.08 * 32 * 6,
+  });
+}
+
+function makeHarvester(overrides = {}) {
+  return {
+    id: 'h1',
+    x: 0,
+    y: 0,
+    path: [],
+    state: 'harvest',
+    targetJob: null,
+    role: 'worker',
+    speed: 1,
+    inv: null,
+    hunger: 0.1,
+    energy: 0.8,
+    happy: 0.6,
+    hydration: 0.7,
+    condition: 'normal',
+    starveStage: 0,
+    targetI: 0,
+    thought: '',
+    ageTicks: 100,
+    lifeStage: 'adult',
+    ...overrides,
+  };
+}
+
+test('S5: a healthy harvester yields the full base of 2 food', () => {
+  const state = makeState();
+  state.world = makeWorldWithCrop();
+  const dropped = [];
+  const { onArrive } = makeOnArriveForHarvest(state, dropped);
+  const v = makeHarvester();
+  onArrive(v);
+  assert.deepEqual(dropped, [2], 'healthy harvester yields 2 food (base * 1.0)');
+});
+
+test('S5: a sick harvester yields the floored minimum of 1 food', () => {
+  const state = makeState();
+  state.world = makeWorldWithCrop();
+  const dropped = [];
+  const { onArrive } = makeOnArriveForHarvest(state, dropped);
+  const v = makeHarvester({ condition: 'sick' });
+  onArrive(v);
+  // round(2 × 0.5) = 1; the Math.max(1, …) floor would also catch this case.
+  assert.deepEqual(dropped, [1], 'sick harvester yields 1 food (floored)');
+});
+
+test('S5: a starving harvester yields 1 food (round(2*0.7) = 1)', () => {
+  const state = makeState();
+  state.world = makeWorldWithCrop();
+  const dropped = [];
+  const { onArrive } = makeOnArriveForHarvest(state, dropped);
+  const v = makeHarvester({ condition: 'starving' });
+  onArrive(v);
+  assert.deepEqual(dropped, [1], 'starving harvester yields 1 food');
+});
+
+test('S5: a hungry harvester still yields the full 2 food (round(2*0.9)=2)', () => {
+  const state = makeState();
+  state.world = makeWorldWithCrop();
+  const dropped = [];
+  const { onArrive } = makeOnArriveForHarvest(state, dropped);
+  const v = makeHarvester({ condition: 'hungry' });
+  onArrive(v);
+  assert.deepEqual(dropped, [2], 'hungry harvester rounds back up to 2');
+});


### PR DESCRIPTION
Make existing hydration, energy, and condition systems felt by the player
now that Phases 1–9 have correct baselines.

- S10 hydration: decay 0.00018→0.00028 and dehydrated threshold 0.28→0.32
  in villagerTick.js; HYDRATION_BUFF_TICKS 320→200 in villagerAI.js. Wells
  now get visited ~2× per day instead of once, the buff covers ~5.5% of
  the day instead of ~9%, and dehydration is reachable in normal play.
- S4 movement fatigue: stepAlong gains a stepped energy penalty (0.85×
  below 0.30, 0.95× below 0.50, 1.0× otherwise), multiplicative with the
  existing condition penalty.
- S5 work fatigue: new workEffortMultiplier(v) combining condition (sick
  0.5 / starving 0.7 / hungry 0.9) and a 0.85× factor below 0.30 energy.
  Phase 7's b.laborProgress increment now uses it so a sick builder takes
  ~2× as long; harvest yield scales by the same factor with a min of 1.

Tests cover: tightened hydration constants and decay math, the four
energy-penalty bands in stepAlong (multiplicative with condition),
workEffortMultiplier unit checks, building labor accumulation rates per
condition, and harvest yield per condition. All 161 tests pass.