### PR TITLE
Phase 11: idle behavior + priority convention cleanup (S11/S14/B13)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -936,16 +936,12 @@ const {
   consumeFood,
   seekEmergencyFood,
   foragingJob,
-  goRest,
-  tryHydrateAtWell,
-  tryCampfireSocial,
-  tryStorageIdle,
-  tryEquipBow,
   enterSickState,
   maybeInterruptJob,
   findPanicHarvestJob,
   pickJobFor,
-  handleIdleRoam
+  chooseIdleBeforeJobs,
+  chooseIdleAfterJobs
 } = _villagerAI;
 
 const TICKS_PER_SEC = policy.routine.ticksPerSecond || 6;
@@ -1055,12 +1051,9 @@ const _villagerTick = createVillagerTick({
   findHuntApproachPath,
   findAnimalById,
   buildingAt,
-  tryEquipBow,
-  tryHydrateAtWell,
-  tryCampfireSocial,
-  tryStorageIdle,
+  chooseIdleBeforeJobs,
+  chooseIdleAfterJobs,
   foragingJob,
-  goRest,
   seekEmergencyFood,
   consumeFood,
   findPanicHarvestJob,
@@ -1069,7 +1062,6 @@ const _villagerTick = createVillagerTick({
   tryStartPregnancy,
   completePregnancy,
   promoteChildToAdult,
-  handleIdleRoam,
   stepAlong
 });
 

--- a/src/app/planner.js
+++ b/src/app/planner.js
@@ -474,6 +474,15 @@ export function createPlanner(opts) {
     return true;
   }
 
+  // Phase 11 (B13): per-tier resource gates deduct each pushed plan's wood
+  // and stone cost from the running `available` pool, so a later tier sees
+  // resources committed by an earlier tier in the same tick. Without this,
+  // two tiers could both pass meetsProgressionRequirements against the same
+  // wood; the downstream budget loop in planBuildings would skip the second
+  // tier's plan, but applyProgressionPlanner had already stamped it as
+  // `unlocked = true` and put it on cooldown — leaving progression stuck.
+  // tierState.unlocked / cooldownUntil semantics are unchanged: they still
+  // track only what was actually queued (`addedForTier > 0`).
   function applyProgressionPlanner(buildQueue, bb, plannedTotals, anchor) {
     const villagers = state.units.villagers;
     const tick = state.time.tick;
@@ -520,10 +529,17 @@ export function createPlanner(opts) {
         const anchorOffset = plan.anchorOffset || tier.anchorOffset || null;
         const tierAnchor = plan.anchor || tier.anchor || defaultAnchor;
         const planAnchor = anchorOffset ? { x: (tierAnchor.x || 0) + (anchorOffset.x || 0), y: (tierAnchor.y || 0) + (anchorOffset.y || 0) } : tierAnchor;
-        const priority = Number.isFinite(plan.priority) ? plan.priority : (Number.isFinite(tier.priority) ? tier.priority : 2);
+        // Phase 11 (S14): buildQueue uses highest-priority-wins. Default 8 is
+        // a "neutral progression" band, well below famine pushes (~9.5+).
+        const priority = Number.isFinite(plan.priority) ? plan.priority : (Number.isFinite(tier.priority) ? tier.priority : 8);
         buildQueue.push({ priority, kind: plan.kind, anchor: planAnchor, reason: plan.reason || tier.reason || 'progress milestone', radius: plan.radius || tier.radius || 18, context: plan.context || tier.context });
         additionalTargets[plan.kind] = Math.max(additionalTargets[plan.kind] || 0, target);
         addedForTier++; injected++;
+        const def = BUILDINGS[plan.kind];
+        if (def) {
+          if (Number.isFinite(def.wood)) available.wood = Math.max(0, available.wood - def.wood);
+          if (Number.isFinite(def.stone)) available.stone = Math.max(0, available.stone - def.stone);
+        }
       }
       if (addedForTier > 0) {
         tierState.unlocked = true;
@@ -680,27 +696,32 @@ export function createPlanner(opts) {
 
     const buildQueue = [];
     const progressionTargets = applyProgressionPlanner(buildQueue, bb, plannedTotals, anchor);
+    // Phase 11 (S14) priority bands (highest-priority-wins):
+    //   ~9.5+ critical / famine survival
+    //   ~7-9   urgent / standard progression milestones
+    //   ~4-6   nominal building queue
+    //   ~1-3   low / deferred (e.g., redundant storage during famine)
     if (plannedTotals.hut < hutTarget && (!lowEnergy || hutCounts.total < hutTargetBase)) {
       const fatiguePenalty = lowEnergy ? 1 : 0;
-      buildQueue.push({ priority: 1 + fatiguePenalty, kind: 'hut', anchor: { x: anchor.x + 2, y: anchor.y + 1 }, reason: 'shelter plan' });
+      buildQueue.push({ priority: 9 - fatiguePenalty, kind: 'hut', anchor: { x: anchor.x + 2, y: anchor.y + 1 }, reason: 'shelter plan' });
     }
     if (desiredFarmplots > plannedTotals.farmplot) {
       const farmAnchor = zoneCentroid(ZONES.FARM) || anchor;
-      const farmPriority = famine ? 0.5 : (approachingWinter ? 1 : 2);
+      const farmPriority = famine ? 9.5 : (approachingWinter ? 9 : 8);
       buildQueue.push({ priority: farmPriority, kind: 'farmplot', anchor: farmAnchor, reason: 'support crops', radius: 14 });
     }
     if (wellTarget > plannedTotals.well && (availableWood > TUNING.wellWoodBuffer || availableStone > 0) && (!famine || approachingWinter)) {
       const farmAnchor = zoneCentroid(ZONES.FARM) || anchor;
-      const prio = approachingWinter ? 2.5 : 3;
+      const prio = approachingWinter ? 7.5 : 7;
       buildQueue.push({ priority: prio, kind: 'well', anchor: farmAnchor, reason: approachingWinter ? 'prepare for winter water' : 'hydrate farms', radius: 16 });
     }
     if (plannedTotals.storage < storageTarget && (woodBufferOk || storageCounts.built === 0) && (!famine || storageCounts.total === 0)) {
-      buildQueue.push({ priority: famine ? 6 : 4, kind: 'storage', anchor: { x: anchor.x - 2, y: anchor.y }, reason: 'extra storage', radius: 18 });
+      buildQueue.push({ priority: famine ? 4 : 6, kind: 'storage', anchor: { x: anchor.x - 2, y: anchor.y }, reason: 'extra storage', radius: 18 });
     }
     if (hunterTarget > plannedTotals.hunterLodge) {
       const hotspot = wildlifeInfo.hotspot || anchor;
       buildQueue.push({
-        priority: famine ? 0.4 : 1.8,
+        priority: famine ? 9.6 : 8.2,
         kind: 'hunterLodge',
         anchor: { x: hotspot.x, y: hotspot.y },
         reason: famine ? 'hunt to survive' : 'secure wild food',
@@ -709,7 +730,8 @@ export function createPlanner(opts) {
       });
     }
 
-    buildQueue.sort((a, b) => a.priority - b.priority);
+    // Phase 11 (S14): highest priority placed first.
+    buildQueue.sort((a, b) => b.priority - a.priority);
 
     const targetByKind = {
       hut: hutTarget,
@@ -1031,5 +1053,13 @@ export function createPlanner(opts) {
     }
   }
 
-  return { planZones, planBuildings, generateJobs, hasRipeCrops };
+  return {
+    planZones,
+    planBuildings,
+    generateJobs,
+    hasRipeCrops,
+    // Phase 11 (B13): exposed for targeted resource-bookkeeping tests.
+    _applyProgressionPlanner: applyProgressionPlanner,
+    _progressionMemory: progressionMemory,
+  };
 }

--- a/src/app/villagerAI.js
+++ b/src/app/villagerAI.js
@@ -716,6 +716,55 @@ export function createVillagerAI(opts) {
     return bs > minScore ? best : null;
   }
 
+  // Phase 11 (S11): consolidated pre-job idle decision tree. Returns true
+  // when the villager was put on a path; caller should `return` to end the
+  // tick. Branches are evaluated in priority order:
+  //   1. Bow equip — only when fully idle and no food pressure.
+  //   2. Energy-driven rest — fires REGARDLESS of v.state or v.targetJob, so
+  //      a fatigued villager mid-task is sent home (audit B1).
+  //   3. Night-anchored sleep — pulls idle villagers to bed at night (S1).
+  //   4. Hydrate at well — preempts available work; only blocked by urgentFood.
+  //   5. Night campfire social — forced night branch.
+  function chooseIdleBeforeJobs(v, ctx) {
+    const { urgentFood, needsFood, nightNow, deepNight, ambientNow, effectiveRest } = ctx;
+    if (v.state === 'idle' && !urgentFood && !needsFood && !v.targetJob) {
+      if (tryEquipBow(v)) return true;
+    }
+    // audit B1: single source of truth for the rest decision; intentionally
+    // not gated on v.state === 'idle' so mid-task fatigue still routes home.
+    if (v.energy < effectiveRest) {
+      if (goRest(v)) return true;
+    }
+    if (v.state === 'idle' && !v.targetJob
+        && wantsToSleep(v, { nightNow, deepNight, urgentFood })) {
+      v._fellAsleepAtNight = nightNow;
+      if (goRest(v)) return true;
+    }
+    if (v.state === 'idle' && !urgentFood) {
+      if (tryHydrateAtWell(v)) return true;
+    }
+    if (nightNow && v.state === 'idle' && !needsFood && !urgentFood && !v.targetJob) {
+      if (tryCampfireSocial(v, { ambientNow, forceNight: true })) return true;
+    }
+    return false;
+  }
+
+  // Phase 11 (S11): consolidated post-job idle decision tree. Always returns
+  // true (the final handleIdleRoam fallback always acts). Branches:
+  //   1. Storage idle — only when no job was picked and the queue is empty.
+  //   2. Daytime campfire social.
+  //   3. Roam fallback (rally point / wander toward food / random walk).
+  function chooseIdleAfterJobs(v, ctx) {
+    const { urgentFood, needsFood, ambientNow, jobs, hasPickedJob, stage } = ctx;
+    if (!hasPickedJob && v.state === 'idle' && !urgentFood && !v.targetJob && jobs.length === 0) {
+      if (tryStorageIdle(v)) return true;
+    }
+    if (v.state === 'idle' && !needsFood && !urgentFood && !v.targetJob) {
+      if (tryCampfireSocial(v, { ambientNow })) return true;
+    }
+    return handleIdleRoam(v, { stage, needsFood, urgentFood });
+  }
+
   return {
     findNearestBuilding,
     nearbyWarmth,
@@ -737,6 +786,8 @@ export function createVillagerAI(opts) {
     tryCampfireSocial,
     tryStorageIdle,
     tryEquipBow,
+    chooseIdleBeforeJobs,
+    chooseIdleAfterJobs,
     scoreExistingJobForVillager,
     maybeInterruptJob,
     findPanicHarvestJob,

--- a/src/app/villagerTick.js
+++ b/src/app/villagerTick.js
@@ -20,7 +20,6 @@ import {
   STORAGE_IDLE_BASE,
   STORAGE_IDLE_COOLDOWN,
   restDurationTicks,
-  wantsToSleep,
   workEffortMultiplier
 } from './villagerAI.js';
 
@@ -80,12 +79,9 @@ export function createVillagerTick(opts) {
     findHuntApproachPath,
     findAnimalById,
     buildingAt,
-    tryEquipBow,
-    tryHydrateAtWell,
-    tryCampfireSocial,
-    tryStorageIdle,
+    chooseIdleBeforeJobs,
+    chooseIdleAfterJobs,
     foragingJob,
-    goRest,
     seekEmergencyFood,
     consumeFood,
     findPanicHarvestJob,
@@ -94,7 +90,6 @@ export function createVillagerTick(opts) {
     tryStartPregnancy,
     completePregnancy,
     promoteChildToAdult,
-    handleIdleRoam,
     stepAlong
   } = opts;
 
@@ -422,31 +417,23 @@ export function createVillagerTick(opts) {
     if ((urgentFood || needsFood) && v.state === 'idle' && !v.targetJob) {
       panicHarvestJob = findPanicHarvestJob(v);
     }
-    if (v.state === 'idle' && !urgentFood && !needsFood && !v.targetJob) {
-      if (tryEquipBow(v)) return;
-    }
-    // Single source of truth for the rest decision (audit B1). The scoring
-    // knob style.energyFatigueThreshold is intentionally NOT consulted here;
-    // it controls job-scoring penalties and the blackboard fatigue flag.
+    // audit B1 + S1 + S11: single rest-decision predicate plus the pre-job idle
+    // cascade (bow / energy-rest / night-sleep / hydrate / night-social) live
+    // in chooseIdleBeforeJobs in villagerAI.js. style.energyFatigueThreshold is
+    // intentionally NOT consulted here; it controls job-scoring penalties and
+    // the blackboard fatigue flag, not the rest decision.
     const restThreshold = Number.isFinite(style.restEnergyThreshold) ? style.restEnergyThreshold : 0.26;
     const restFatigueBoost = Number.isFinite(style.restFatigueBoost) ? style.restFatigueBoost : 0.04;
     const fatigueFlag = !!blackboard?.energy?.fatigue;
     const effectiveRest = fatigueFlag ? restThreshold + restFatigueBoost : restThreshold;
-    if (v.energy < effectiveRest) { if (goRest(v)) return; }
-    // Audit S1: night-anchored sleep. Pulls idle villagers to bed at night so
-    // day/night has felt meaning. Sits before hydrate/social so sleep wins
-    // when a villager wants to be in bed.
-    if (v.state === 'idle' && !v.targetJob
-        && wantsToSleep(v, { nightNow, deepNight: isDeepNight(dayTime), urgentFood })) {
-      v._fellAsleepAtNight = nightNow;
-      if (goRest(v)) return;
-    }
-    if (v.state === 'idle' && !urgentFood) {
-      if (tryHydrateAtWell(v)) return;
-    }
-    if (nightNow && v.state === 'idle' && !needsFood && !urgentFood && !v.targetJob) {
-      if (tryCampfireSocial(v, { ambientNow, forceNight: true })) return;
-    }
+    if (chooseIdleBeforeJobs(v, {
+      urgentFood,
+      needsFood,
+      nightNow,
+      deepNight: isDeepNight(dayTime),
+      ambientNow,
+      effectiveRest
+    })) return;
     const reprioritizeMargin = Number.isFinite(style.reprioritizeMargin) ? style.reprioritizeMargin : 0.06;
     if (maybeInterruptJob(v, { blackboard, margin: reprioritizeMargin })) return;
     if (v.path && v.path.length > 0) { stepAlong(v); return; }
@@ -548,13 +535,15 @@ export function createVillagerTick(opts) {
       }
       v._nextPathTick = tick + 12;
     }
-    if (!j && v.state === 'idle' && !urgentFood && !v.targetJob && jobs.length === 0) {
-      if (tryStorageIdle(v)) return;
-    }
-    if (v.state === 'idle' && !needsFood && !urgentFood && !v.targetJob) {
-      if (tryCampfireSocial(v, { ambientNow })) return;
-    }
-    if (handleIdleRoam(v, { stage, needsFood, urgentFood })) return;
+    // S11: post-job idle cascade (storage idle / day social / roam fallback).
+    if (chooseIdleAfterJobs(v, {
+      urgentFood,
+      needsFood,
+      ambientNow,
+      jobs,
+      hasPickedJob: !!j,
+      stage
+    })) return;
   }
 
   return { villagerTick };

--- a/src/policy/policy.js
+++ b/src/policy/policy.js
@@ -84,12 +84,17 @@ const DEFAULT_HUNGER_THRESHOLDS = Object.freeze({
   coldSeasonTightening: 0.05
 });
 
+// Phase 11 (S14): tier priorities follow the buildQueue convention —
+// highest-priority-wins. Earlier-tier entries (stockpile) outrank later
+// tiers (infrastructure) when both are queued in the same tick.
+// Note: style.jobScoring.priorityMoodWeight is unrelated; that knob weights
+// per-job mood scoring, not the buildQueue ordering used here.
 const DEFAULT_PROGRESS_TIERS = Object.freeze([
   {
     id: 'stockpile',
     minPopulation: 2,
     requires: { wood: 12 },
-    priority: 1.4,
+    priority: 8.6,
     plans: [
       { kind: 'storage', target: 1, reason: 'stash essential supplies', radius: 16 }
     ]
@@ -98,7 +103,7 @@ const DEFAULT_PROGRESS_TIERS = Object.freeze([
     id: 'housing',
     minPopulation: 4,
     requires: { wood: 16 },
-    priority: 1.7,
+    priority: 8.3,
     plans: [
       { kind: 'hut', target: 2, reason: 'give villagers beds', radius: 18 }
     ]
@@ -107,7 +112,7 @@ const DEFAULT_PROGRESS_TIERS = Object.freeze([
     id: 'workshops',
     minPopulation: 5,
     requires: { wood: 18, stone: 2 },
-    priority: 2.1,
+    priority: 7.9,
     plans: [
       { kind: 'hunterLodge', target: 1, reason: 'organize hunts', radius: 18 }
     ]
@@ -116,7 +121,7 @@ const DEFAULT_PROGRESS_TIERS = Object.freeze([
     id: 'infrastructure',
     minPopulation: 6,
     requires: { wood: 20, stone: 6 },
-    priority: 2.6,
+    priority: 7.4,
     plans: [
       { kind: 'well', target: 1, reason: 'secure water and mood', radius: 18 },
       { kind: 'farmplot', target: 3, reason: 'grow steady crops', radius: 18 }

--- a/tests/build.laborResume.phase7.test.js
+++ b/tests/build.laborResume.phase7.test.js
@@ -163,12 +163,9 @@ function makeVillagerTick(state) {
     findHuntApproachPath: () => null,
     findAnimalById: () => null,
     buildingAt: () => null,
-    tryEquipBow: () => false,
-    tryHydrateAtWell: () => false,
-    tryCampfireSocial: () => false,
-    tryStorageIdle: () => false,
+    chooseIdleBeforeJobs: () => false,
+    chooseIdleAfterJobs: () => false,
     foragingJob: () => false,
-    goRest: () => false,
     seekEmergencyFood: () => false,
     consumeFood: () => false,
     findPanicHarvestJob: () => null,
@@ -177,7 +174,6 @@ function makeVillagerTick(state) {
     tryStartPregnancy: noop,
     completePregnancy: noop,
     promoteChildToAdult: noop,
-    handleIdleRoam: () => false,
     stepAlong: noop,
   });
 }

--- a/tests/idleCascade.phase11.test.js
+++ b/tests/idleCascade.phase11.test.js
@@ -1,0 +1,242 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// villagerAI → simulation → environment asserts on AIV_TERRAIN / AIV_CONFIG
+// at module-load time; world.js → canvas.js touches `document` / `window`.
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = {
+      getElementById: () => ({
+        getContext: () => ({ imageSmoothingEnabled: true }),
+        getBoundingClientRect: () => ({ width: 800, height: 600 }),
+        style: {},
+        width: 0,
+        height: 0,
+      }),
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  }
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const { createVillagerAI, HYDRATION_VISIT_THRESHOLD } = await import('../src/app/villagerAI.js');
+const { GRID_W } = await import('../src/app/constants.js');
+
+let nextBuildingId = 1;
+function makeBuilding(kind, x = 0, y = 0) {
+  return {
+    id: nextBuildingId++,
+    kind,
+    x,
+    y,
+    w: 1,
+    h: 1,
+    built: 1,
+    progress: 1,
+    activity: { occupants: 0, lastUse: 0 },
+    effects: {},
+  };
+}
+
+function makeAI({ buildings = [] } = {}) {
+  const noop = () => {};
+  const buildingsByKind = new Map();
+  for (const b of buildings) {
+    if (!buildingsByKind.has(b.kind)) buildingsByKind.set(b.kind, []);
+    buildingsByKind.get(b.kind).push(b);
+  }
+  const state = {
+    units: { buildings, jobs: [], villagers: [], itemsOnGround: [], animals: [] },
+    stocks: { totals: { food: 0, wood: 0, stone: 0 }, reserved: {} },
+    time: { tick: 1000, dayTime: 1200 },
+    world: {
+      tiles: new Uint8Array(GRID_W * GRID_W),
+      zone: new Uint8Array(GRID_W * GRID_W),
+      growth: new Uint8Array(GRID_W * GRID_W),
+      berries: new Uint8Array(GRID_W * GRID_W),
+      trees: new Uint8Array(GRID_W * GRID_W),
+      rocks: new Uint8Array(GRID_W * GRID_W),
+    },
+    bb: {},
+  };
+  // Pathfind always returns a one-step path so any "go to building" helper succeeds.
+  const pathfind = (sx, sy, dx, dy) => [{ x: dx, y: dy }];
+  const ai = createVillagerAI({
+    state,
+    policy: { style: { jobScoring: {}, hunger: {}, jobCreation: {} }, sliders: {} },
+    pathfind,
+    passable: () => true,
+    Toast: { show: noop },
+    addJob: noop,
+    finishJob: (v) => { v.targetJob = null; },
+    noteJobAssignmentChanged: noop,
+    availableToReserve: () => 1,
+    reserveMaterials: () => true,
+    releaseReservedMaterials: noop,
+    findAnimalById: () => null,
+    findEntryTileNear: (b) => ({ x: b.x, y: b.y }),
+    getBuildingById: (id) => buildings.find((b) => b.id === id) || null,
+    buildingsByKind,
+    idx: (x, y) => y * GRID_W + x,
+    ambientAt: (dt) => (dt > 1100 && dt < 1700 ? 'night' : 'day'),
+    isNightTime: () => true,
+  });
+  return { ai, state };
+}
+
+function makeVillager(overrides = {}) {
+  return {
+    x: 0,
+    y: 0,
+    inv: null,
+    equippedBow: false,
+    hunger: 0.5,
+    energy: 0.9,
+    happy: 0.7,
+    hydration: 1.0,
+    hydrationBuffTicks: 0,
+    nextHydrateTick: 0,
+    nextSocialTick: 0,
+    nextStorageIdleTick: 0,
+    nextStarveWarning: 0,
+    socialTimer: 0,
+    restTimer: 0,
+    condition: 'normal',
+    starveStage: 0,
+    sickTimer: 0,
+    recoveryTimer: 0,
+    state: 'idle',
+    lifeStage: 'adult',
+    path: null,
+    targetJob: null,
+    targetBuilding: null,
+    activeBuildingId: null,
+    reservedPickup: null,
+    _nextPathTick: 0,
+    _wanderFailures: new Map(),
+    _forageFailures: new Map(),
+    thought: '',
+    ...overrides,
+  };
+}
+
+const DEFAULT_BEFORE_CTX = {
+  urgentFood: false,
+  needsFood: false,
+  nightNow: false,
+  deepNight: false,
+  ambientNow: 'day',
+  effectiveRest: 0.26,
+};
+
+const DEFAULT_AFTER_CTX = {
+  urgentFood: false,
+  needsFood: false,
+  ambientNow: 'day',
+  jobs: [],
+  hasPickedJob: false,
+  stage: 0,
+};
+
+test('S11: chooseIdleBeforeJobs prefers low-energy rest over sleep / hydrate / social', () => {
+  const buildings = [makeBuilding('hut', 0, 0), makeBuilding('well', 1, 0), makeBuilding('campfire', 2, 0)];
+  const { ai } = makeAI({ buildings });
+  const v = makeVillager({ energy: 0.1, hydration: 0.2 });
+  const acted = ai.chooseIdleBeforeJobs(v, { ...DEFAULT_BEFORE_CTX, nightNow: true, deepNight: true, ambientNow: 'night' });
+  assert.equal(acted, true);
+  assert.equal(v.state, 'rest', 'low-energy rest must outrank sleep/hydrate/social');
+});
+
+test('S11: low-energy rest fires even when villager is mid-task (audit B1 anomaly)', () => {
+  const buildings = [makeBuilding('hut', 0, 0)];
+  const { ai } = makeAI({ buildings });
+  const v = makeVillager({ energy: 0.1, state: 'chop', targetJob: { type: 'chop' } });
+  const acted = ai.chooseIdleBeforeJobs(v, DEFAULT_BEFORE_CTX);
+  assert.equal(acted, true, 'rest is intentionally not gated on idle/!targetJob');
+  assert.equal(v.state, 'rest');
+});
+
+test('S11: night-anchored sleep fires when energy fine but nightNow', () => {
+  const buildings = [makeBuilding('hut', 0, 0), makeBuilding('well', 1, 0), makeBuilding('campfire', 2, 0)];
+  const { ai } = makeAI({ buildings });
+  const v = makeVillager({ energy: 0.5, hydration: 1.0 });
+  const acted = ai.chooseIdleBeforeJobs(v, { ...DEFAULT_BEFORE_CTX, nightNow: true, deepNight: true, ambientNow: 'night' });
+  assert.equal(acted, true);
+  assert.equal(v.state, 'rest');
+  assert.equal(v._fellAsleepAtNight, true, 'night-sleep marks the wake-at-dawn flag');
+});
+
+test('S11: hydrate fires in daylight when not urgent and hydration is low', () => {
+  const buildings = [makeBuilding('well', 1, 0), makeBuilding('campfire', 2, 0)];
+  const { ai } = makeAI({ buildings });
+  const v = makeVillager({ energy: 0.9, hydration: HYDRATION_VISIT_THRESHOLD - 0.1 });
+  const acted = ai.chooseIdleBeforeJobs(v, DEFAULT_BEFORE_CTX);
+  assert.equal(acted, true);
+  assert.equal(v.state, 'hydrate');
+});
+
+test('S11: hydrate is suppressed by urgentFood', () => {
+  const buildings = [makeBuilding('well', 1, 0)];
+  const { ai } = makeAI({ buildings });
+  const v = makeVillager({ energy: 0.9, hydration: 0.1 });
+  const acted = ai.chooseIdleBeforeJobs(v, { ...DEFAULT_BEFORE_CTX, urgentFood: true });
+  assert.equal(acted, false, 'urgentFood blocks hydrate (and every later branch)');
+  assert.equal(v.state, 'idle');
+});
+
+test('S11: night-social fires when nightNow, well-fed, hydrated, and a campfire exists', () => {
+  const buildings = [makeBuilding('campfire', 2, 0)];
+  const { ai } = makeAI({ buildings });
+  const v = makeVillager({ energy: 0.9, hydration: 1.0 });
+  const acted = ai.chooseIdleBeforeJobs(v, { ...DEFAULT_BEFORE_CTX, nightNow: true, ambientNow: 'night' });
+  assert.equal(acted, true);
+  assert.equal(v.state, 'socialize');
+});
+
+test('S11: chooseIdleBeforeJobs returns false when no branch can act', () => {
+  const { ai } = makeAI({ buildings: [] });
+  const v = makeVillager({ energy: 0.9, hydration: 1.0 });
+  const acted = ai.chooseIdleBeforeJobs(v, DEFAULT_BEFORE_CTX);
+  assert.equal(acted, false, 'no branch fires; caller should fall through to job pickup');
+  assert.equal(v.state, 'idle');
+});
+
+test('S11: chooseIdleAfterJobs prefers storage idle when idle and queue empty', () => {
+  const buildings = [makeBuilding('storage', 3, 0), makeBuilding('campfire', 2, 0)];
+  const { ai } = makeAI({ buildings });
+  const v = makeVillager();
+  const acted = ai.chooseIdleAfterJobs(v, DEFAULT_AFTER_CTX);
+  assert.equal(acted, true);
+  assert.equal(v.state, 'storage_idle');
+});
+
+test('S11: storage idle does NOT fire when a job was picked this tick', () => {
+  const buildings = [makeBuilding('storage', 3, 0)];
+  const { ai } = makeAI({ buildings });
+  const v = makeVillager();
+  const acted = ai.chooseIdleAfterJobs(v, { ...DEFAULT_AFTER_CTX, hasPickedJob: true });
+  // Falls through to roam fallback (always true). Storage state must NOT be set.
+  assert.equal(acted, true);
+  assert.notEqual(v.state, 'storage_idle');
+});
+
+test('S11: chooseIdleAfterJobs always returns true via roam fallback', () => {
+  const { ai } = makeAI({ buildings: [] });
+  const v = makeVillager();
+  const acted = ai.chooseIdleAfterJobs(v, DEFAULT_AFTER_CTX);
+  assert.equal(acted, true, 'roam fallback always acts');
+});

--- a/tests/planner.priorityConvention.phase11.test.js
+++ b/tests/planner.priorityConvention.phase11.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// Phase 11 (S14): buildQueue and progression tier priorities both follow the
+// "highest-priority-wins" convention. These tests lock in (a) the priority
+// magnitudes pushed by planBuildings, (b) the sort direction, and (c) the
+// ordering between famine pushes, normal pushes, and progression tiers.
+
+const policyModule = await import('../src/policy/policy.js');
+const { policy } = policyModule;
+
+test('S14: progression tier priorities sit in the urgent band (>=7) and descend with tier order', () => {
+  const tiers = policy.progression.tiers;
+  const ids = tiers.map((t) => t.id);
+  assert.deepEqual(ids, ['stockpile', 'housing', 'workshops', 'infrastructure']);
+  for (const tier of tiers) {
+    assert.ok(tier.priority >= 7, `tier ${tier.id} priority=${tier.priority} must be in urgent band (>=7)`);
+    assert.ok(tier.priority < 9.5, `tier ${tier.id} priority=${tier.priority} must be below famine band (<9.5)`);
+  }
+  const byId = Object.fromEntries(tiers.map((t) => [t.id, t.priority]));
+  assert.ok(byId.stockpile > byId.housing, 'stockpile outranks housing');
+  assert.ok(byId.housing > byId.workshops, 'housing outranks workshops');
+  assert.ok(byId.workshops > byId.infrastructure, 'workshops outranks infrastructure');
+});
+
+test('S14: buildQueue descending sort puts famine items first', () => {
+  // Mirrors planBuildings push values exactly. Famine survival > urgent > nominal > deferred.
+  const queue = [
+    { kind: 'storage', priority: 6 },             // normal
+    { kind: 'farmplot', priority: 9.5 },          // famine
+    { kind: 'hut', priority: 9 },                 // not fatigued
+    { kind: 'hunterLodge', priority: 9.6 },       // famine
+    { kind: 'well', priority: 7 },                // normal
+    { kind: 'well', priority: 7.5 },              // approaching winter
+    { kind: 'farmplot', priority: 8 },            // normal
+    { kind: 'storage', priority: 4 },             // famine deferred
+    { kind: 'hut', priority: 8 },                 // fatigued
+    { kind: 'farmplot', priority: 9 },            // approaching winter
+    { kind: 'hunterLodge', priority: 8.2 },       // normal
+  ];
+  // Same comparator as planner.js:712 after Phase 11.
+  queue.sort((a, b) => b.priority - a.priority);
+  const order = queue.map((q) => `${q.kind}@${q.priority}`);
+  assert.equal(order[0], 'hunterLodge@9.6', 'famine hunterLodge wins');
+  assert.equal(order[1], 'farmplot@9.5', 'famine farmplot is second');
+  assert.equal(order[2], 'hut@9', 'not-fatigued hut beats winter farmplot tie via stable sort');
+  assert.equal(order[order.length - 1], 'storage@4', 'famine storage is the deferred tail');
+});
+
+test('S14: progression tier priorities slot below famine pushes but above default plan fallback (8 not given)', () => {
+  // The applyProgressionPlanner default fallback is 8 (used when neither
+  // plan.priority nor tier.priority is finite). Stockpile (8.6) must beat
+  // that fallback so progression doesn't get drowned by neutral defaults.
+  const tiers = policy.progression.tiers;
+  for (const tier of tiers) {
+    if (tier.id === 'infrastructure') continue;
+    assert.ok(tier.priority > 7.4, `${tier.id} (${tier.priority}) must outrank infrastructure baseline`);
+  }
+  // Famine items at 9.5+ must still beat the highest tier (stockpile=8.6).
+  const stockpile = tiers.find((t) => t.id === 'stockpile');
+  assert.ok(9.5 > stockpile.priority, 'famine farmplot (9.5) must outrank stockpile tier (8.6)');
+  assert.ok(9.6 > stockpile.priority, 'famine hunterLodge (9.6) must outrank stockpile tier (8.6)');
+});

--- a/tests/planner.progressionResourceBudget.phase11.test.js
+++ b/tests/planner.progressionResourceBudget.phase11.test.js
@@ -1,0 +1,150 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// Phase 11 (B13): applyProgressionPlanner deducts each pushed plan's wood
+// and stone cost from the running `available` pool, so a later tier sees
+// resources committed by an earlier tier in the same tick. Without the fix,
+// two tiers can both pass meetsProgressionRequirements against the same
+// wood and the planner stamps both as `unlocked = true` + cooldown'd, even
+// though the downstream budget loop will only place one.
+
+// Browser stubs for transitive imports (matches forage.emergencyJobLifecycle.phase5).
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = { getElementById: () => ({ getContext: () => ({ imageSmoothingEnabled: true }), getBoundingClientRect: () => ({ width: 800, height: 600 }), style: {}, width: 0, height: 0 }) };
+  }
+  if (!globalThis.window) globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  if (!globalThis.AIV_TERRAIN) globalThis.AIV_TERRAIN = { generateTerrain: () => ({}), makeHillshade: () => new Uint8ClampedArray(0) };
+  if (!globalThis.AIV_CONFIG) globalThis.AIV_CONFIG = { WORLDGEN_DEFAULTS: {}, SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 } };
+}
+ensureBrowserStubs();
+
+const { createPlanner } = await import('../src/app/planner.js');
+const { GRID_W, GRID_H } = await import('../src/app/constants.js');
+
+function makePlanner({ availableWood, availableStone = 100, villagers = 6, tiers }) {
+  const buildings = [];
+  const jobs = [];
+  const villagerList = Array.from({ length: villagers }, (_, i) => ({ id: i + 1, x: 5, y: 5 }));
+  const state = {
+    units: { buildings, jobs, villagers: villagerList, animals: [] },
+    stocks: { totals: { food: 0, wood: availableWood, stone: availableStone }, reserved: {} },
+    time: { tick: 1000, dayTime: 1000 },
+    world: {
+      tiles: new Uint8Array(GRID_W * GRID_H),
+      zone: new Uint8Array(GRID_W * GRID_H),
+      growth: new Uint8Array(GRID_W * GRID_H),
+      berries: new Uint8Array(GRID_W * GRID_H),
+      trees: new Uint8Array(GRID_W * GRID_H),
+      rocks: new Uint8Array(GRID_W * GRID_H),
+    },
+    bb: {
+      villagers,
+      availableFood: 100,
+      availableWood,
+      availableStone,
+    },
+  };
+  const policy = {
+    sliders: { food: 0.5, build: 0.5, explore: 0.3 },
+    style: { jobScoring: {}, hunger: {}, jobCreation: {} },
+    progression: {
+      hysteresisTicks: 240,
+      resourceHysteresis: 0.18,
+      maxPlansPerTick: 2,
+      tiers,
+    },
+  };
+  const noop = () => {};
+  const planner = createPlanner({
+    state,
+    policy,
+    pathfind: () => null,
+    addJob: noop,
+    hasSimilarJob: () => false,
+    noteJobRemoved: noop,
+    requestBuildHauls: noop,
+    countBuildingsByKind: (kind) => ({ total: buildings.filter((b) => b.kind === kind).length, built: 0 }),
+    ensureBlackboardSnapshot: () => state.bb,
+    getJobCreationConfig: () => ({}),
+    violatesSpacing: () => false,
+    zoneCanEverWork: () => true,
+    zoneHasWorkNow: () => false,
+    updateZoneRow: noop,
+    markZoneOverlayDirty: noop,
+    markStaticDirty: noop,
+    availableToReserve: (resource) => state.stocks.totals[resource] || 0,
+    reserveMaterials: () => true,
+    releaseReservedMaterials: noop,
+    addBuilding: noop,
+    Toast: { show: noop },
+    toTile: (n) => n | 0,
+  });
+  return { planner, state };
+}
+
+test('B13: when wood is tight, the second tier is NOT unlocked or cooldown-stamped', () => {
+  // stockpile: storage costs 8 wood; housing: hut costs 10 wood.
+  // available = 16 wood: stockpile passes (16 ≥ 12), pushes storage, deducts to 8.
+  // housing then sees wood=8, fails the requires.wood=16 check, no push.
+  const tiers = [
+    { id: 'stockpile', minPopulation: 2, requires: { wood: 12 }, priority: 8.6, plans: [{ kind: 'storage', target: 1 }] },
+    { id: 'housing', minPopulation: 4, requires: { wood: 16 }, priority: 8.3, plans: [{ kind: 'hut', target: 2 }] },
+  ];
+  const { planner, state } = makePlanner({ availableWood: 16, tiers });
+  const queue = [];
+  planner._applyProgressionPlanner(queue, state.bb, {}, { x: 5, y: 5 });
+
+  assert.equal(queue.length, 1, 'only one tier should successfully push (stockpile)');
+  assert.equal(queue[0].kind, 'storage');
+
+  const memory = planner._progressionMemory;
+  const stockpileState = memory.get('stockpile');
+  const housingState = memory.get('housing');
+  assert.ok(stockpileState?.unlocked === true, 'stockpile is unlocked (it shipped)');
+  assert.ok(stockpileState.cooldownUntil > 1000, 'stockpile cooldown is set');
+
+  // The whole point of B13: housing should NOT be flagged as shipped.
+  assert.notEqual(housingState?.unlocked, true,
+    'housing must not be flagged unlocked when its plan was budget-skipped');
+  assert.ok(!housingState || (housingState.cooldownUntil ?? 0) <= 1000,
+    'housing must not be put on cooldown when its plan was budget-skipped');
+});
+
+test('B13: when wood is plenty, both tiers ship and both get cooldown-stamped', () => {
+  const tiers = [
+    { id: 'stockpile', minPopulation: 2, requires: { wood: 12 }, priority: 8.6, plans: [{ kind: 'storage', target: 1 }] },
+    { id: 'housing', minPopulation: 4, requires: { wood: 16 }, priority: 8.3, plans: [{ kind: 'hut', target: 2 }] },
+  ];
+  const { planner, state } = makePlanner({ availableWood: 30, tiers });
+  const queue = [];
+  planner._applyProgressionPlanner(queue, state.bb, {}, { x: 5, y: 5 });
+
+  // maxPlansPerTick=2 caps the queue length even when more tiers are eligible.
+  assert.equal(queue.length, 2, 'both tiers ship when wood is plenty');
+  assert.ok(queue.some((q) => q.kind === 'storage'));
+  assert.ok(queue.some((q) => q.kind === 'hut'));
+
+  const memory = planner._progressionMemory;
+  assert.equal(memory.get('stockpile')?.unlocked, true);
+  assert.equal(memory.get('housing')?.unlocked, true);
+});
+
+test('B13: stone cost is also deducted (well/hunterLodge case)', () => {
+  // hunterLodge costs 10 wood + 2 stone; well costs 0 wood + 6 stone.
+  // Set stone = 6: hunterLodge ships first (deducts 2 stone → 4 left).
+  // Then well requires { stone: 6 }; sees 4, fails.
+  const tiers = [
+    { id: 'workshops', minPopulation: 2, requires: { wood: 10, stone: 2 }, priority: 7.9, plans: [{ kind: 'hunterLodge', target: 1 }] },
+    { id: 'infrastructure', minPopulation: 2, requires: { wood: 0, stone: 6 }, priority: 7.4, plans: [{ kind: 'well', target: 1 }] },
+  ];
+  const { planner, state } = makePlanner({ availableWood: 30, availableStone: 6, tiers });
+  const queue = [];
+  planner._applyProgressionPlanner(queue, state.bb, {}, { x: 5, y: 5 });
+
+  assert.equal(queue.length, 1, 'only workshops ships; infrastructure budget-blocked on stone');
+  assert.equal(queue[0].kind, 'hunterLodge');
+
+  const memory = planner._progressionMemory;
+  assert.notEqual(memory.get('infrastructure')?.unlocked, true);
+});

--- a/tests/work.fatigue.phase10.test.js
+++ b/tests/work.fatigue.phase10.test.js
@@ -140,12 +140,9 @@ function makeVillagerTickSystem(state) {
     findHuntApproachPath: () => null,
     findAnimalById: () => null,
     buildingAt: () => null,
-    tryEquipBow: () => false,
-    tryHydrateAtWell: () => false,
-    tryCampfireSocial: () => false,
-    tryStorageIdle: () => false,
+    chooseIdleBeforeJobs: () => false,
+    chooseIdleAfterJobs: () => false,
     foragingJob: () => false,
-    goRest: () => false,
     seekEmergencyFood: () => false,
     consumeFood: () => false,
     findPanicHarvestJob: () => null,
@@ -154,7 +151,6 @@ function makeVillagerTickSystem(state) {
     tryStartPregnancy: noop,
     completePregnancy: noop,
     promoteChildToAdult: noop,
-    handleIdleRoam: () => false,
     stepAlong: noop,
   });
 }


### PR DESCRIPTION
S11: extracted the implicit idle behavior cascade into two named helpers in
villagerAI.js. chooseIdleBeforeJobs covers bow-equip / energy-rest / night
sleep / hydrate / night-social; chooseIdleAfterJobs covers storage-idle /
day-social / roam fallback. Each branch is documented; the audit B1 rest
anomaly (fires regardless of v.state and v.targetJob) is now explicitly
called out.

S14: unified buildQueue and progression tier priorities to highest-wins.
Sort comparator flipped to descending; pushed values remapped via 10 - x to
preserve exact ordering. Bands documented near the sort: ~9.5+ critical,
~7-9 urgent, ~4-6 nominal, ~1-3 deferred.

B13: applyProgressionPlanner now deducts each pushed plan's wood and stone
cost from the running available pool, so a later tier sees what an earlier
tier committed. Previously, two tiers could both pass the resource gate
against the same wood, and the second tier would get unlocked + cooldown'd
even though the downstream budget loop skipped its plan.

Tests added: idleCascade.phase11 (10), planner.priorityConvention.phase11
(3), planner.progressionResourceBudget.phase11 (3). All 177 tests pass and
lint is clean.

https://claude.ai/code/session_01GzMdnD5heLgX5Sn65PwBvL