### PR TITLE
Phase 12: performance pass (B23/B25/S12/S13)

### DIFF
--- a/public/debugkit.js
+++ b/public/debugkit.js
@@ -44,6 +44,7 @@
   let appGetLightingProbe = null;
   let appGetPipeline = null;
   let appEnterSafeMode = null;
+  let appGetPerf = null;
 
   const doc = document;
   const win = window;
@@ -1297,6 +1298,10 @@
       } else {
         add('WARN', 'No lighting probe from app. Provide getLightingProbe() in DebugKit.configure().');
       }
+      const perfSnap = appGetPerf ? appGetPerf() : null;
+      if (perfSnap) {
+        add('STATE', 'Tick perf (ms, EMA)', perfSnap);
+      }
     } catch (err) {
       add('ERROR', 'Diag failed', fmt(err));
     }
@@ -2057,6 +2062,7 @@
     if (typeof opts.getLightingProbe === 'function') appGetLightingProbe = opts.getLightingProbe;
     if (typeof opts.getPipeline === 'function') appGetPipeline = opts.getPipeline;
     if (typeof opts.onSafeMode === 'function') appEnterSafeMode = opts.onSafeMode;
+    if (typeof opts.getPerf === 'function') appGetPerf = opts.getPerf;
     return state;
   };
 

--- a/src/app.js
+++ b/src/app.js
@@ -37,12 +37,17 @@ import { STARVE_THRESH, createVillagerAI } from './app/villagerAI.js';
 import { createOnArrive } from './app/onArrive.js';
 import {
   BUILDINGS,
-  agricultureBonusesAt as _agricultureBonusesAt,
+  agricultureGrowthAt as _agricultureGrowthAt,
+  agricultureHarvestAt as _agricultureHarvestAt,
+  agricultureMoodAt as _agricultureMoodAt,
   buildingAtIn,
   buildingCenter,
   buildingEntryTiles,
   ensureBuildingData,
   getFootprint,
+  paintBuildingFootprint,
+  rebuildBuildingOccupancy,
+  tileOccupiedByBuildingFast,
   tileOccupiedByBuildingIn,
   validateFootprintPlacementIn
 } from './app/world.js';
@@ -125,6 +130,9 @@ function indexBuilding(b){
 function reindexAllBuildings(){
   buildingsByKind.clear();
   for(const b of buildings) indexBuilding(b);
+  // Phase 12 (S13): loadGame replaces the buildings array wholesale; the
+  // bitmap has to be rebuilt to match.
+  rebuildBuildingOccupancy(world, buildings);
 }
 let emittersDirty = true;
 function markEmittersDirty(){ emittersDirty = true; }
@@ -337,6 +345,9 @@ function generateWorldBase(seed){
     rocks:terrain.rocks,
     berries:terrain.berries,
     growth:new Uint8Array(GRID_SIZE),
+    // Phase 12 (S13): per-tile flag, painted by paintBuildingFootprint.
+    // Pathfinder reads this directly so passable() doesn't scan all buildings.
+    buildingOccupancy:new Uint8Array(GRID_SIZE),
     season:0,
     tSeason:0,
     aux,
@@ -369,6 +380,7 @@ function generateWorldBase(seed){
 function resetVolatileState(){
   jobs.length=0; buildings.length=0; itemsOnGround.length=0; animals.length=0; markItemsDirty();
   buildingsByKind.clear();
+  if(world?.buildingOccupancy) world.buildingOccupancy.fill(0);
   clearActiveZoneJobs();
   if(typeof tickRunner !== 'undefined') tickRunner.reset();
   markEmittersDirty();
@@ -514,11 +526,16 @@ function addBuilding(kind,x,y,opts={}){
   };
   buildings.push(b);
   indexBuilding(b);
+  paintBuildingFootprint(world, b);
   if(b.kind==='campfire' && b.built>=1) markEmittersDirty();
   return b;
 }
 
 function tileOccupiedByBuilding(x, y, ignoreId=null){
+  // Pathfinding and animal callers don't pass ignoreId, so the bitmap fast
+  // path covers the hot loops; placement validation that needs ignoreId
+  // falls back to the linear scan.
+  if(ignoreId === null) return tileOccupiedByBuildingFast(world, x, y);
   return tileOccupiedByBuildingIn(buildings, x, y, ignoreId);
 }
 
@@ -581,8 +598,18 @@ function endBuildingStay(v){
   v.targetBuilding=null;
 }
 
-function agricultureBonusesAt(x,y){
-  return _agricultureBonusesAt(buildings, x, y);
+// Phase 12 (B25): specialized accessors that only iterate the building kinds
+// contributing to each bonus, via the existing buildingsByKind index. The
+// combined `agricultureBonusesAt` was dropped in favour of these — tests
+// still import it directly from world.js.
+function agricultureMoodAt(x,y){
+  return _agricultureMoodAt(buildingsByKind, x, y);
+}
+function agricultureGrowthAt(x,y){
+  return _agricultureGrowthAt(buildingsByKind, x, y);
+}
+function agricultureHarvestAt(x,y){
+  return _agricultureHarvestAt(buildingsByKind, x, y);
 }
 
 /* ==================== UI & Sheets ==================== */
@@ -658,6 +685,7 @@ const _pathfinder = createPathfinder({
 });
 const passable = _pathfinder.passable;
 const pathfind = _pathfinder.pathfind;
+const pathfindToRegion = _pathfinder.pathfindToRegion;
 function centerCamera(x,y){
   cam.z = 2.2;
   cam.x = x - W / (TILE * cam.z) * 0.5;
@@ -702,7 +730,7 @@ function seasonTick(){
     // bonuses layer on top so wells/farmplots partially mitigate winter.
     let delta = 1.2 * seasonalGrowthMultiplier(world.season, world.tSeason / SEASON_LEN);
     if(hasFarmBoosters){
-      const { growthBonus } = agricultureBonusesAt(x,y);
+      const growthBonus = agricultureGrowthAt(x,y);
       if(growthBonus>0){
         const whole=Math.floor(growthBonus);
         delta += whole;
@@ -855,6 +883,7 @@ void _isJobSuppressed;
 const _animalsSystem = createAnimalsSystem({
   state: gameState,
   pathfind,
+  pathfindToRegion,
   tileOccupiedByBuilding,
   idx,
   dropItem
@@ -966,7 +995,7 @@ const _onArriveSystem = createOnArrive({
   consumeFood,
   handleVillagerFed,
   findNearestBuilding,
-  agricultureBonusesAt,
+  agricultureHarvestAt,
   findEntryTileNear,
   getBuildingById,
   setActiveBuilding,
@@ -988,7 +1017,8 @@ const _debugKitBridge = createDebugKitBridge({
   state: gameState,
   ensureVillagerNumber,
   applyShadingMode,
-  markStaticDirty
+  markStaticDirty,
+  getPerfMetrics: () => (typeof tickRunner !== 'undefined' && tickRunner ? tickRunner.getMetrics() : null),
 });
 const { ensureDebugKitConfigured } = _debugKitBridge;
 _debugKitBridge.attachToWindow();
@@ -1032,7 +1062,7 @@ const _villagerTick = createVillagerTick({
   pathfind,
   ambientAt,
   nearbyWarmth,
-  agricultureBonusesAt,
+  agricultureMoodAt,
   getBuildingById,
   noteBuildingActivity,
   endBuildingStay,

--- a/src/app/animals.js
+++ b/src/app/animals.js
@@ -31,7 +31,7 @@ const DEFAULT_ANIMAL_BEHAVIOR = {
 export function createAnimalsSystem(opts) {
   const {
     state,
-    pathfind,
+    pathfindToRegion,
     tileOccupiedByBuilding,
     idx,
   } = opts;
@@ -234,31 +234,35 @@ export function createAnimalsSystem(opts) {
     return { meat, pelts: R() < hideChance ? 1 : 0 };
   }
 
-  function findHuntApproachPath(v, animal, { range = HUNT_RANGE, maxPath = 320 } = {}) {
+  // Phase 12 (B23): a single A*-to-region search instead of one pathfind per
+  // candidate tile in the 9×9 box around the animal. The predicate accepts
+  // the first walkable, in-range, unobstructed tile reached from the
+  // villager; the heuristic — Manhattan distance to the animal minus the
+  // hunt range, floored at 0 — is admissible because reaching any in-range
+  // tile takes at least that many steps from the current node.
+  function findHuntApproachPath(v, animal, { range = HUNT_RANGE, maxPath = 2000 } = {}) {
     if (!v || !animal) return null;
+    if (typeof pathfindToRegion !== 'function') return null;
     const world = getWorld();
-    const ax = Math.round(animal.x);
-    const ay = Math.round(animal.y);
-    const radius = Math.max(1, Math.ceil(range));
-    let best = null;
-    for (let dy = -radius; dy <= radius; dy++) {
-      for (let dx = -radius; dx <= radius; dx++) {
-        const tx = ax + dx, ty = ay + dy;
-        const dist = Math.hypot(tx - animal.x, ty - animal.y);
-        if (dist > range) continue;
-        if (tx < 0 || ty < 0 || tx >= GRID_W || ty >= GRID_H) continue;
-        if (tileOccupiedByBuilding(tx, ty)) continue;
-        const tile = world.tiles[idx(tx, ty)];
-        if (tile === TILES.WATER) continue;
-        if (!WALKABLE.has(tile)) continue;
-        const p = pathfind(v.x | 0, v.y | 0, tx, ty, maxPath);
-        if (!p) continue;
-        if (!best || p.length < best.score) {
-          best = { path: p, score: p.length, dest: { x: tx, y: ty } };
-        }
-      }
-    }
-    return best;
+    const ax = animal.x;
+    const ay = animal.y;
+    const rangeSq = range * range;
+    const axR = Math.round(ax);
+    const ayR = Math.round(ay);
+    const isTarget = (tx, ty) => {
+      if (tx < 0 || ty < 0 || tx >= GRID_W || ty >= GRID_H) return false;
+      const dxr = tx - ax, dyr = ty - ay;
+      if (dxr * dxr + dyr * dyr > rangeSq) return false;
+      if (tileOccupiedByBuilding(tx, ty)) return false;
+      const tile = world.tiles[idx(tx, ty)];
+      if (tile === TILES.WATER) return false;
+      return WALKABLE.has(tile);
+    };
+    const heuristic = (x, y) => {
+      const d = Math.abs(x - axR) + Math.abs(y - ayR) - range;
+      return d > 0 ? d : 0;
+    };
+    return pathfindToRegion(v.x | 0, v.y | 0, isTarget, maxPath, heuristic);
   }
 
   // Audit Phase 6: ambient food creation removed. Hungry-villager proximity no

--- a/src/app/debugkit.js
+++ b/src/app/debugkit.js
@@ -7,6 +7,7 @@ export function createDebugKitBridge(opts) {
     ensureVillagerNumber,
     applyShadingMode,
     markStaticDirty,
+    getPerfMetrics,
   } = opts;
 
   let debugKitInstance = null;
@@ -131,6 +132,22 @@ export function createDebugKitBridge(opts) {
     }
   }
 
+  function debugKitGetPerf() {
+    if (typeof getPerfMetrics !== 'function') return null;
+    const m = getPerfMetrics();
+    if (!m) return null;
+    const out = {
+      ticks: m.__ticks || 0,
+      buildings: Array.isArray(state?.units?.buildings) ? state.units.buildings.length : 0,
+      villagers: Array.isArray(state?.units?.villagers) ? state.units.villagers.length : 0,
+    };
+    for (const k of Object.keys(m)) {
+      if (k.startsWith('__')) continue;
+      out[k] = Number.isFinite(m[k]) ? +m[k].toFixed(3) : 0;
+    }
+    return out;
+  }
+
   function debugKitGetState() {
     const world = getWorld();
     const villagers = getVillagers();
@@ -183,6 +200,7 @@ export function createDebugKitBridge(opts) {
         getLightingProbe: debugKitGetLightingProbe,
         onSafeMode: debugKitEnterSafeMode,
         getState: debugKitGetState,
+        getPerf: debugKitGetPerf,
       });
     } catch (err) {
       console.warn('DebugKit configure failed', err);
@@ -250,6 +268,7 @@ export function createDebugKitBridge(opts) {
     debugKitGetLightingProbe,
     debugKitEnterSafeMode,
     debugKitGetState,
+    debugKitGetPerf,
     configureDebugKitBridge,
     installDebugKitWatcher,
     ensureDebugKitConfigured,

--- a/src/app/onArrive.js
+++ b/src/app/onArrive.js
@@ -46,7 +46,7 @@ export function createOnArrive(opts) {
     consumeFood,
     handleVillagerFed,
     findNearestBuilding,
-    agricultureBonusesAt,
+    agricultureHarvestAt,
     findEntryTileNear,
     getBuildingById,
     setActiveBuilding,
@@ -259,7 +259,7 @@ export function createOnArrive(opts) {
         // harvest would feel buggy and the tile is still consumed below).
         const effort = workEffortMultiplier(v);
         let yieldAmount = Math.max(1, Math.round(2 * effort));
-        const { harvestBonus } = agricultureBonusesAt(cx, cy);
+        const harvestBonus = agricultureHarvestAt(cx, cy);
         if (harvestBonus > 0) {
           const whole = Math.floor(harvestBonus);
           yieldAmount += whole;

--- a/src/app/pathfinding.js
+++ b/src/app/pathfinding.js
@@ -8,10 +8,17 @@ export function createPathfinder(deps) {
   const getTick = deps.getTick;
   const perf = deps.perf || { log: false };
 
+  // Phase 12: A* uses gScore + heap; BFS region search reuses qx/qy.
+  // `touched` lets us reset only the cells we wrote, avoiding 36k-entry
+  // .fill()s per call.
   const PF = {
     qx: new Int16Array(GRID_SIZE),
     qy: new Int16Array(GRID_SIZE),
-    came: new Int32Array(GRID_SIZE)
+    came: new Int32Array(GRID_SIZE),
+    gScore: new Int32Array(GRID_SIZE),
+    heapNode: new Int32Array(GRID_SIZE + 1),
+    heapF: new Int32Array(GRID_SIZE + 1),
+    touched: new Int32Array(GRID_SIZE),
   };
 
   function passable(x, y) {
@@ -21,43 +28,65 @@ export function createPathfinder(deps) {
     return WALKABLE.has(getWorld().tiles[i]);
   }
 
-  function pathfind(sx, sy, tx, ty, limit = 400) {
-    sx = Math.round(clamp(sx, 0, GRID_W - 1));
-    sy = Math.round(clamp(sy, 0, GRID_H - 1));
-    tx = Math.round(clamp(tx, 0, GRID_W - 1));
-    ty = Math.round(clamp(ty, 0, GRID_H - 1));
-    const tStart = perf.log ? performance.now() : 0;
-    if (sx === tx && sy === ty) {
-      if (perf.log && (getTick() % 60) === 0) console.log(`pathfind 0.00ms`);
-      return [{ x: tx, y: ty }];
+  function logTime(tStart) {
+    if (!perf.log) return;
+    if ((getTick() % 60) !== 0) return;
+    const tEnd = performance.now();
+    console.log(`pathfind ${(tEnd - tStart).toFixed(2)}ms`);
+  }
+
+  function resetTouched(touchedCount) {
+    const touched = PF.touched;
+    const came = PF.came;
+    const gScore = PF.gScore;
+    for (let t = 0; t < touchedCount; t++) {
+      const ti = touched[t];
+      came[ti] = -1;
+      gScore[ti] = -1;
     }
-    const Wm = GRID_W, Hm = GRID_H;
-    const qx = PF.qx, qy = PF.qy, came = PF.came;
-    came.fill(-1);
-    let qs = 0, qe = 0;
-    qx[qe] = sx; qy[qe] = sy; qe++;
-    came[sy * Wm + sx] = sx + sy * Wm;
-    let found = false, steps = 0;
-    while (qs < qe && steps < limit) {
-      const x = qx[qs], y = qy[qs]; qs++; steps++;
-      for (const d of DIR4) {
-        const nx = x + d[0], ny = y + d[1];
-        if (nx < 0 || ny < 0 || nx >= Wm || ny >= Hm) continue;
-        const ni = ny * Wm + nx;
-        if (came[ni] !== -1) continue;
-        if (!passable(nx, ny)) continue;
-        came[ni] = y * Wm + x;
-        qx[qe] = nx; qy[qe] = ny; qe++;
-        if (nx === tx && ny === ty) { found = true; qs = qe; break; }
-      }
+  }
+
+  // Binary min-heap on parallel Int32Arrays of (f, node). Lower f wins; ties
+  // are left to insertion order (good enough for grid pathfinding correctness).
+  function heapPush(size, fScore, node) {
+    let i = ++size;
+    PF.heapF[i] = fScore;
+    PF.heapNode[i] = node;
+    while (i > 1) {
+      const parent = i >> 1;
+      if (PF.heapF[parent] <= PF.heapF[i]) break;
+      const tmpF = PF.heapF[parent], tmpN = PF.heapNode[parent];
+      PF.heapF[parent] = PF.heapF[i]; PF.heapNode[parent] = PF.heapNode[i];
+      PF.heapF[i] = tmpF; PF.heapNode[i] = tmpN;
+      i = parent;
     }
-    if (!found) {
-      if (perf.log && (getTick() % 60) === 0) {
-        const tEnd = performance.now();
-        console.log(`pathfind ${(tEnd - tStart).toFixed(2)}ms`);
-      }
-      return null;
+    return size;
+  }
+
+  function heapPop(size) {
+    const top = PF.heapNode[1];
+    PF.heapF[1] = PF.heapF[size];
+    PF.heapNode[1] = PF.heapNode[size];
+    size--;
+    let i = 1;
+    while (true) {
+      const l = i << 1;
+      const r = l + 1;
+      let smallest = i;
+      if (l <= size && PF.heapF[l] < PF.heapF[smallest]) smallest = l;
+      if (r <= size && PF.heapF[r] < PF.heapF[smallest]) smallest = r;
+      if (smallest === i) break;
+      const tmpF = PF.heapF[i], tmpN = PF.heapNode[i];
+      PF.heapF[i] = PF.heapF[smallest]; PF.heapNode[i] = PF.heapNode[smallest];
+      PF.heapF[smallest] = tmpF; PF.heapNode[smallest] = tmpN;
+      i = smallest;
     }
+    return { node: top, size };
+  }
+
+  function reconstructPath(sx, sy, tx, ty) {
+    const Wm = GRID_W;
+    const came = PF.came;
     const path = [];
     let cx = tx, cy = ty, ci = cy * Wm + cx;
     while (!(cx === sx && cy === sy)) {
@@ -69,12 +98,158 @@ export function createPathfinder(deps) {
       cy = (pi / Wm) | 0; cx = pi % Wm; ci = cy * Wm + cx;
     }
     path.reverse();
-    if (perf.log && (getTick() % 60) === 0) {
-      const tEnd = performance.now();
-      console.log(`pathfind ${(tEnd - tStart).toFixed(2)}ms`);
-    }
     return path;
   }
 
-  return { passable, pathfind, PF };
+  // Phase 12 (S12): A* with Manhattan heuristic. Path length is identical to
+  // the previous BFS (4-connected uniform cost; Manhattan is admissible &
+  // consistent), but expansions on long open paths drop ~5–10×.
+  function pathfind(sx, sy, tx, ty, limit = 400) {
+    sx = Math.round(clamp(sx, 0, GRID_W - 1));
+    sy = Math.round(clamp(sy, 0, GRID_H - 1));
+    tx = Math.round(clamp(tx, 0, GRID_W - 1));
+    ty = Math.round(clamp(ty, 0, GRID_H - 1));
+    const tStart = perf.log ? performance.now() : 0;
+    if (sx === tx && sy === ty) {
+      logTime(tStart);
+      return [{ x: tx, y: ty }];
+    }
+    const Wm = GRID_W, Hm = GRID_H;
+    const came = PF.came, gScore = PF.gScore, touched = PF.touched;
+    let touchedCount = 0;
+
+    const startI = sy * Wm + sx;
+    came[startI] = startI;
+    gScore[startI] = 0;
+    touched[touchedCount++] = startI;
+
+    let heapSize = 0;
+    const startH = Math.abs(sx - tx) + Math.abs(sy - ty);
+    heapSize = heapPush(heapSize, startH, startI);
+
+    let found = false;
+    let expansions = 0;
+    while (heapSize > 0 && expansions < limit) {
+      const popped = heapPop(heapSize);
+      heapSize = popped.size;
+      const ci = popped.node;
+      const cx = ci % Wm;
+      const cy = (ci / Wm) | 0;
+      expansions++;
+      if (cx === tx && cy === ty) { found = true; break; }
+      const cg = gScore[ci];
+      for (const d of DIR4) {
+        const nx = cx + d[0], ny = cy + d[1];
+        if (nx < 0 || ny < 0 || nx >= Wm || ny >= Hm) continue;
+        const ni = ny * Wm + nx;
+        if (came[ni] !== -1) continue;
+        if (!passable(nx, ny)) continue;
+        came[ni] = ci;
+        gScore[ni] = cg + 1;
+        touched[touchedCount++] = ni;
+        const f = (cg + 1) + Math.abs(nx - tx) + Math.abs(ny - ty);
+        heapSize = heapPush(heapSize, f, ni);
+      }
+    }
+
+    if (!found) {
+      resetTouched(touchedCount);
+      logTime(tStart);
+      return null;
+    }
+    const path = reconstructPath(sx, sy, tx, ty);
+    resetTouched(touchedCount);
+    logTime(tStart);
+    return path;
+  }
+
+  // Phase 12 (B23): single search that terminates on the first walkable tile
+  // matching `isTarget`. Replaces findHuntApproachPath's 9×9 pathfind loop.
+  // If a `heuristic(x,y)` is provided, runs A* with that as the f-score
+  // heuristic (admissible heuristic guarantees first-hit is optimal in step
+  // count); otherwise falls back to BFS, which is also optimal but expands
+  // radially.
+  function pathfindToRegion(sx, sy, isTarget, limit = 400, heuristic = null) {
+    sx = Math.round(clamp(sx, 0, GRID_W - 1));
+    sy = Math.round(clamp(sy, 0, GRID_H - 1));
+    const tStart = perf.log ? performance.now() : 0;
+    if (typeof isTarget !== 'function') return null;
+    const Wm = GRID_W, Hm = GRID_H;
+    const came = PF.came, gScore = PF.gScore, touched = PF.touched;
+    let touchedCount = 0;
+    const startI = sy * Wm + sx;
+    came[startI] = startI;
+    gScore[startI] = 0;
+    touched[touchedCount++] = startI;
+
+    let foundX = -1, foundY = -1;
+    if (isTarget(sx, sy)) { foundX = sx; foundY = sy; }
+
+    if (foundX < 0) {
+      const useAStar = typeof heuristic === 'function';
+      if (useAStar) {
+        let heapSize = 0;
+        heapSize = heapPush(heapSize, heuristic(sx, sy) | 0, startI);
+        let expansions = 0;
+        while (heapSize > 0 && expansions < limit && foundX < 0) {
+          const popped = heapPop(heapSize);
+          heapSize = popped.size;
+          const ci = popped.node;
+          const cx = ci % Wm;
+          const cy = (ci / Wm) | 0;
+          expansions++;
+          if (isTarget(cx, cy)) { foundX = cx; foundY = cy; break; }
+          const cg = gScore[ci];
+          for (const d of DIR4) {
+            const nx = cx + d[0], ny = cy + d[1];
+            if (nx < 0 || ny < 0 || nx >= Wm || ny >= Hm) continue;
+            const ni = ny * Wm + nx;
+            if (came[ni] !== -1) continue;
+            if (!passable(nx, ny)) continue;
+            came[ni] = ci;
+            gScore[ni] = cg + 1;
+            touched[touchedCount++] = ni;
+            const f = (cg + 1) + (heuristic(nx, ny) | 0);
+            heapSize = heapPush(heapSize, f, ni);
+          }
+        }
+      } else {
+        const qx = PF.qx, qy = PF.qy;
+        let qs = 0, qe = 0;
+        qx[qe] = sx; qy[qe] = sy; qe++;
+        let steps = 0;
+        while (foundX < 0 && qs < qe && steps < limit) {
+          const x = qx[qs], y = qy[qs]; qs++; steps++;
+          for (const d of DIR4) {
+            const nx = x + d[0], ny = y + d[1];
+            if (nx < 0 || ny < 0 || nx >= Wm || ny >= Hm) continue;
+            const ni = ny * Wm + nx;
+            if (came[ni] !== -1) continue;
+            if (!passable(nx, ny)) continue;
+            came[ni] = y * Wm + x;
+            touched[touchedCount++] = ni;
+            if (isTarget(nx, ny)) { foundX = nx; foundY = ny; break; }
+            qx[qe] = nx; qy[qe] = ny; qe++;
+          }
+        }
+      }
+    }
+
+    if (foundX < 0) {
+      resetTouched(touchedCount);
+      logTime(tStart);
+      return null;
+    }
+    const path = reconstructPath(sx, sy, foundX, foundY);
+    resetTouched(touchedCount);
+    logTime(tStart);
+    if (!path) return null;
+    return { path, dest: { x: foundX, y: foundY } };
+  }
+
+  // Initialize sentinels once. resetTouched maintains them per-call.
+  PF.came.fill(-1);
+  PF.gScore.fill(-1);
+
+  return { passable, pathfind, pathfindToRegion, PF };
 }

--- a/src/app/tick.js
+++ b/src/app/tick.js
@@ -3,6 +3,38 @@ import { computeBlackboard } from '../ai/blackboard.js';
 
 const PLANNER_INTERVAL = { zones: 90, build: 120 };
 
+// Phase 12: per-subsystem timing surfaced via DebugKit. EMA so the displayed
+// numbers don't flicker frame-to-frame.
+const PERF_EMA_ALPHA = 0.05;
+const PERF_KEYS = [
+  'tickTotal',
+  'jobs',
+  'season',
+  'blackboard',
+  'planZones',
+  'planBuildings',
+  'animals',
+  'nocturnal',
+  'villagerTick',
+  'pendingBirths'
+];
+
+function createPerfMetrics() {
+  const metrics = { __ticks: 0 };
+  for (const k of PERF_KEYS) metrics[k] = 0;
+  return metrics;
+}
+
+function emaUpdate(metrics, key, sample) {
+  const prev = metrics[key] || 0;
+  metrics[key] = prev + (sample - prev) * PERF_EMA_ALPHA;
+}
+
+const _hasPerfNow = (typeof performance !== 'undefined' && typeof performance.now === 'function');
+function nowMs() {
+  return _hasPerfNow ? performance.now() : 0;
+}
+
 export function createTickRunner(deps) {
   const {
     state,
@@ -35,6 +67,8 @@ export function createTickRunner(deps) {
   let lastBlackboardLogTick = state.time.tick;
   let lastZonePlanTick = state.time.tick - PLANNER_INTERVAL.zones;
   let lastBuildPlanTick = state.time.tick - PLANNER_INTERVAL.build;
+  const metrics = createPerfMetrics();
+  state.__perf = metrics;
 
   function ensureBlackboardSnapshot() {
     const cadence = Number.isFinite(policy?.routine?.blackboardCadenceTicks)
@@ -90,13 +124,21 @@ export function createTickRunner(deps) {
     const villagers = state.units.villagers;
 
     for (let s = 0; s < steps; s++) {
+      const tickStart = nowMs();
       state.time.tick++;
       state.time.dayTime = (state.time.dayTime + 1) % DAY_LENGTH;
       const tick = state.time.tick;
       const ambientNow = ambientAt(state.time.dayTime);
 
+      let t0 = nowMs();
       if (jobInterval > 0 && tick % jobInterval === 0) generateJobs();
+      emaUpdate(metrics, 'jobs', nowMs() - t0);
+
+      t0 = nowMs();
       if (seasonInterval > 0 && tick % seasonInterval === 0) seasonTick();
+      emaUpdate(metrics, 'season', nowMs() - t0);
+
+      t0 = nowMs();
       if (blackboardInterval > 0 && (tick - lastBlackboardTick) >= blackboardInterval) {
         state.bb = computeBlackboard(state, policy);
         lastBlackboardTick = tick;
@@ -105,25 +147,49 @@ export function createTickRunner(deps) {
           lastBlackboardLogTick = tick;
         }
       }
+      emaUpdate(metrics, 'blackboard', nowMs() - t0);
+
+      t0 = nowMs();
       if ((tick - lastZonePlanTick) >= PLANNER_INTERVAL.zones) {
         planZones(state.bb);
         lastZonePlanTick = tick;
       }
+      emaUpdate(metrics, 'planZones', nowMs() - t0);
+
+      t0 = nowMs();
       if ((tick - lastBuildPlanTick) >= PLANNER_INTERVAL.build) {
         planBuildings(state.bb);
         lastBuildPlanTick = tick;
       }
+      emaUpdate(metrics, 'planBuildings', nowMs() - t0);
 
+      t0 = nowMs();
       updateAnimals();
-      updateNocturnalEntities(ambientNow);
+      emaUpdate(metrics, 'animals', nowMs() - t0);
 
+      t0 = nowMs();
+      updateNocturnalEntities(ambientNow);
+      emaUpdate(metrics, 'nocturnal', nowMs() - t0);
+
+      t0 = nowMs();
       for (const v of villagers) {
         processVillagerItemPickup(v);
         villagerTick(v);
       }
+      emaUpdate(metrics, 'villagerTick', nowMs() - t0);
+
+      t0 = nowMs();
       flushPendingBirths();
+      emaUpdate(metrics, 'pendingBirths', nowMs() - t0);
+
+      emaUpdate(metrics, 'tickTotal', nowMs() - tickStart);
+      metrics.__ticks++;
     }
   }
 
-  return { runFrame, reset, ensureBlackboardSnapshot };
+  function getMetrics() {
+    return metrics;
+  }
+
+  return { runFrame, reset, ensureBlackboardSnapshot, getMetrics };
 }

--- a/src/app/villagerTick.js
+++ b/src/app/villagerTick.js
@@ -60,7 +60,7 @@ export function createVillagerTick(opts) {
     pathfind,
     ambientAt,
     nearbyWarmth,
-    agricultureBonusesAt,
+    agricultureMoodAt,
     getBuildingById,
     noteBuildingActivity,
     endBuildingStay,
@@ -158,7 +158,7 @@ export function createVillagerTick(opts) {
     let energyDelta = -ENERGY_DRAIN_BASE;
     const moodEnergyBoost = moodMotivation(v) * 0.00045;
     let happyDelta = warm ? 0.001 : -0.0002;
-    const { moodBonus } = agricultureBonusesAt(tileX, tileY);
+    const moodBonus = agricultureMoodAt(tileX, tileY);
     if (moodBonus) { happyDelta += moodBonus; }
     if (warm && nightNow) {
       happyDelta += NIGHT_CAMPFIRE_MOOD_TICK;

--- a/src/app/world.js
+++ b/src/app/world.js
@@ -197,6 +197,56 @@ export function tileOccupiedByBuildingIn(buildings, x, y, ignoreId = null) {
   return false;
 }
 
+// Phase 12 (S13): per-tile bitmap so pathfinding's per-neighbor passable check
+// runs in O(1) instead of scanning every building. Validation paths that need
+// `ignoreId` semantics keep using `tileOccupiedByBuildingIn`.
+export function paintBuildingFootprint(world, b) {
+  if (!world?.buildingOccupancy || !b) return;
+  const fp = getFootprint(b.kind);
+  const w = world.width || GRID_W;
+  const h = world.height || GRID_H;
+  for (let yy = 0; yy < fp.h; yy++) {
+    const gy = b.y + yy;
+    if (gy < 0 || gy >= h) continue;
+    for (let xx = 0; xx < fp.w; xx++) {
+      const gx = b.x + xx;
+      if (gx < 0 || gx >= w) continue;
+      world.buildingOccupancy[gy * w + gx] = 1;
+    }
+  }
+}
+
+export function clearBuildingFootprint(world, b) {
+  if (!world?.buildingOccupancy || !b) return;
+  const fp = getFootprint(b.kind);
+  const w = world.width || GRID_W;
+  const h = world.height || GRID_H;
+  for (let yy = 0; yy < fp.h; yy++) {
+    const gy = b.y + yy;
+    if (gy < 0 || gy >= h) continue;
+    for (let xx = 0; xx < fp.w; xx++) {
+      const gx = b.x + xx;
+      if (gx < 0 || gx >= w) continue;
+      world.buildingOccupancy[gy * w + gx] = 0;
+    }
+  }
+}
+
+export function tileOccupiedByBuildingFast(world, x, y) {
+  if (!world?.buildingOccupancy) return false;
+  const w = world.width || GRID_W;
+  const h = world.height || GRID_H;
+  if (x < 0 || y < 0 || x >= w || y >= h) return false;
+  return world.buildingOccupancy[y * w + x] !== 0;
+}
+
+export function rebuildBuildingOccupancy(world, buildings) {
+  if (!world?.buildingOccupancy) return;
+  world.buildingOccupancy.fill(0);
+  if (!buildings) return;
+  for (const b of buildings) paintBuildingFootprint(world, b);
+}
+
 export function buildingAtIn(buildings, x, y) {
   for (const b of buildings) {
     const fp = getFootprint(b.kind);
@@ -236,13 +286,14 @@ export function validateFootprintPlacementIn(buildings, world, kind, tx, ty, opt
   return null;
 }
 
+function influenceFor(radius, dist) {
+  if (radius > 0) { return dist > radius ? 0 : Math.max(0, 1 - dist / (radius + 1)); }
+  return dist === 0 ? 1 : 0;
+}
+
 export function agricultureBonusesAt(buildings, x, y) {
   let growthBonus = 0, harvestBonus = 0, moodBonus = 0;
   if (!buildings.length) return { growthBonus, harvestBonus, moodBonus };
-  const influenceFor = (radius, dist) => {
-    if (radius > 0) { return dist > radius ? 0 : Math.max(0, 1 - dist / (radius + 1)); }
-    return dist === 0 ? 1 : 0;
-  };
   for (const b of buildings) {
     if (b.built < 1) continue;
     const def = BUILDINGS[b.kind] || {};
@@ -268,4 +319,61 @@ export function agricultureBonusesAt(buildings, x, y) {
     }
   }
   return { growthBonus, harvestBonus, moodBonus };
+}
+
+// Phase 12 (B25): specialized accessors so the per-tick villager mood path
+// only iterates the kinds that actually contribute. `buildingsByKind` is the
+// existing per-kind index in app.js; pass it directly for O(huts+wells)
+// scans instead of O(all buildings).
+function accumulateBonusFromGroup(group, x, y, fn) {
+  if (!group || !group.length) return 0;
+  let total = 0;
+  for (const b of group) {
+    if (b.built < 1) continue;
+    const def = BUILDINGS[b.kind] || {};
+    const eff = def.effects || {};
+    total += fn(b, def, eff, distanceToFootprint(x, y, b));
+  }
+  return total;
+}
+
+export function agricultureMoodAt(buildingsByKind, x, y) {
+  if (!buildingsByKind) return 0;
+  let total = 0;
+  total += accumulateBonusFromGroup(buildingsByKind.get('hut'), x, y, (_b, _def, eff, dist) => {
+    if (!eff.moodBonus) return 0;
+    const inf = influenceFor(eff.radius | 0, dist);
+    return inf > 0 ? eff.moodBonus * inf : 0;
+  });
+  total += accumulateBonusFromGroup(buildingsByKind.get('well'), x, y, (_b, _def, eff, dist) => {
+    if (!eff.moodBonus) return 0;
+    const inf = influenceFor(eff.hydrationRadius | 0, dist);
+    return inf > 0 ? eff.moodBonus * inf : 0;
+  });
+  return total;
+}
+
+export function agricultureGrowthAt(buildingsByKind, x, y) {
+  if (!buildingsByKind) return 0;
+  let total = 0;
+  total += accumulateBonusFromGroup(buildingsByKind.get('farmplot'), x, y, (_b, _def, eff, dist) => {
+    if (!eff.growthBonus) return 0;
+    const inf = influenceFor(eff.radius | 0, dist);
+    return inf > 0 ? eff.growthBonus * inf : 0;
+  });
+  total += accumulateBonusFromGroup(buildingsByKind.get('well'), x, y, (_b, _def, eff, dist) => {
+    if (!eff.hydrationGrowthBonus) return 0;
+    const inf = influenceFor(eff.hydrationRadius | 0, dist);
+    return inf > 0 ? eff.hydrationGrowthBonus * inf : 0;
+  });
+  return total;
+}
+
+export function agricultureHarvestAt(buildingsByKind, x, y) {
+  if (!buildingsByKind) return 0;
+  return accumulateBonusFromGroup(buildingsByKind.get('farmplot'), x, y, (_b, _def, eff, dist) => {
+    if (!eff.harvestBonus) return 0;
+    const inf = influenceFor(eff.radius | 0, dist);
+    return inf > 0 ? eff.harvestBonus * inf : 0;
+  });
 }

--- a/tests/animals.huntApproach.phase12.test.js
+++ b/tests/animals.huntApproach.phase12.test.js
@@ -1,0 +1,142 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// animals.js → canvas.js touches document/window. Provide stubs before the
+// dynamic imports the same way the hunting/idleCascade tests do.
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = {
+      getElementById: () => ({
+        getContext: () => ({ imageSmoothingEnabled: true }),
+        getBoundingClientRect: () => ({ width: 800, height: 600 }),
+        style: {}, width: 0, height: 0,
+      }),
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  }
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const { GRID_W, GRID_H, GRID_SIZE, HUNT_RANGE, TILES, WALKABLE } = await import('../src/app/constants.js');
+const { createPathfinder } = await import('../src/app/pathfinding.js');
+const { createAnimalsSystem } = await import('../src/app/animals.js');
+
+function makeStubState() {
+  return {
+    world: {
+      tiles: new Uint8Array(GRID_SIZE),
+      trees: new Uint8Array(GRID_SIZE),
+      rocks: new Uint8Array(GRID_SIZE),
+      berries: new Uint8Array(GRID_SIZE),
+      width: GRID_W,
+      height: GRID_H,
+    },
+    units: { animals: [], villagers: [] },
+    queue: { villagerLabels: [] },
+    time: { tick: 0 },
+  };
+}
+
+function makeSystem(state, blocked = new Set()) {
+  const idx = (x, y) => (x < 0 || y < 0 || x >= GRID_W || y >= GRID_H ? -1 : y * GRID_W + x);
+  const tileOccupiedByBuilding = (x, y) => blocked.has(y * GRID_W + x);
+  const pf = createPathfinder({
+    idx,
+    tileOccupiedByBuilding,
+    getWorld: () => state.world,
+    getTick: () => state.time.tick,
+    perf: { log: false },
+  });
+  return createAnimalsSystem({
+    state,
+    pathfind: pf.pathfind,
+    pathfindToRegion: pf.pathfindToRegion,
+    tileOccupiedByBuilding,
+    idx,
+  });
+}
+
+test('B23: findHuntApproachPath returns a path whose endpoint is in range and walkable', () => {
+  const state = makeStubState();
+  const animal = { id: 'a1', type: 'deer', x: 30, y: 30 };
+  state.units.animals.push(animal);
+  const v = { id: 'v1', x: 10, y: 10 };
+  const sys = makeSystem(state);
+  const result = sys.findHuntApproachPath(v, animal, { range: HUNT_RANGE });
+  assert.ok(result, 'expected an approach path');
+  assert.ok(Array.isArray(result.path) && result.path.length > 0);
+  const last = result.path[result.path.length - 1];
+  const dx = (last.x | 0) - animal.x;
+  const dy = (last.y | 0) - animal.y;
+  const dist = Math.hypot(dx, dy);
+  assert.ok(dist <= HUNT_RANGE + 0.01, `endpoint must be in HUNT_RANGE; got ${dist}`);
+  // dest field should match the path endpoint coordinates.
+  assert.equal(result.dest.x, last.x | 0);
+  assert.equal(result.dest.y, last.y | 0);
+});
+
+test('B23: findHuntApproachPath returns null when animal is fully surrounded by buildings', () => {
+  const state = makeStubState();
+  const animal = { id: 'a1', type: 'deer', x: 30, y: 30 };
+  const v = { id: 'v1', x: 10, y: 10 };
+  // Box every in-range tile around the animal with buildings.
+  const blocked = new Set();
+  const r = Math.ceil(HUNT_RANGE) + 1;
+  for (let dy = -r; dy <= r; dy++) {
+    for (let dx = -r; dx <= r; dx++) {
+      const tx = animal.x + dx;
+      const ty = animal.y + dy;
+      const dist = Math.hypot(dx, dy);
+      if (dist <= HUNT_RANGE) blocked.add(ty * GRID_W + tx);
+    }
+  }
+  const sys = makeSystem(state, blocked);
+  const result = sys.findHuntApproachPath(v, animal, { range: HUNT_RANGE });
+  assert.equal(result, null);
+});
+
+test('B23: findHuntApproachPath skips water tiles', () => {
+  const state = makeStubState();
+  const animal = { id: 'a1', type: 'deer', x: 30, y: 30 };
+  const v = { id: 'v1', x: 25, y: 25 };
+  // Make every in-range tile water EXCEPT one walkable tile.
+  for (let dy = -4; dy <= 4; dy++) {
+    for (let dx = -4; dx <= 4; dx++) {
+      const tx = animal.x + dx;
+      const ty = animal.y + dy;
+      if (Math.hypot(dx, dy) <= HUNT_RANGE) {
+        state.world.tiles[ty * GRID_W + tx] = TILES.WATER;
+      }
+    }
+  }
+  // Carve one approach tile.
+  state.world.tiles[animal.y * GRID_W + (animal.x - 3)] = TILES.GRASS;
+  const sys = makeSystem(state);
+  const result = sys.findHuntApproachPath(v, animal, { range: HUNT_RANGE });
+  assert.ok(result, 'expected the single non-water tile to be reached');
+  const last = result.path[result.path.length - 1];
+  assert.equal(last.x | 0, animal.x - 3);
+  assert.equal(last.y | 0, animal.y);
+  assert.ok(WALKABLE.has(state.world.tiles[(last.y | 0) * GRID_W + (last.x | 0)]));
+});
+
+test('B23: returns null when v or animal is missing', () => {
+  const state = makeStubState();
+  const sys = makeSystem(state);
+  assert.equal(sys.findHuntApproachPath(null, { x: 1, y: 1 }), null);
+  assert.equal(sys.findHuntApproachPath({ x: 1, y: 1 }, null), null);
+});

--- a/tests/build.laborResume.phase7.test.js
+++ b/tests/build.laborResume.phase7.test.js
@@ -92,7 +92,7 @@ function makeOnArrive(state) {
     consumeFood: () => false,
     handleVillagerFed: noop,
     findNearestBuilding: () => null,
-    agricultureBonusesAt: () => ({ growthBonus: 0, harvestBonus: 0, moodBonus: 0 }),
+    agricultureHarvestAt: () => 0,
     findEntryTileNear: () => null,
     getBuildingById: (id) => state.units.buildings.find((b) => b.id === id) || null,
     setActiveBuilding: (v, b) => {
@@ -129,7 +129,7 @@ function makeVillagerTick(state) {
     pathfind: () => null,
     ambientAt: () => 'day',
     nearbyWarmth: () => false,
-    agricultureBonusesAt: () => ({ growthBonus: 0, harvestBonus: 0, moodBonus: 0 }),
+    agricultureMoodAt: () => 0,
     getBuildingById: (id) => state.units.buildings.find((b) => b.id === id) || null,
     noteBuildingActivity: (b) => {
       if (b) {

--- a/tests/movement.fatigue.phase10.test.js
+++ b/tests/movement.fatigue.phase10.test.js
@@ -71,7 +71,7 @@ function makeSystem(state) {
     consumeFood: noop,
     handleVillagerFed: noop,
     findNearestBuilding: () => null,
-    agricultureBonusesAt: () => ({}),
+    agricultureHarvestAt: () => 0,
     findEntryTileNear: () => null,
     getBuildingById: () => null,
     setActiveBuilding: noop,

--- a/tests/movement.speed.test.js
+++ b/tests/movement.speed.test.js
@@ -81,7 +81,7 @@ function makeSystem(state) {
     consumeFood: noop,
     handleVillagerFed: noop,
     findNearestBuilding: () => null,
-    agricultureBonusesAt: () => ({}),
+    agricultureHarvestAt: () => 0,
     findEntryTileNear: () => null,
     getBuildingById: () => null,
     setActiveBuilding: noop,

--- a/tests/pathfinding.aStar.phase12.test.js
+++ b/tests/pathfinding.aStar.phase12.test.js
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { GRID_W, GRID_H, GRID_SIZE, TILES } from '../src/app/constants.js';
+import { createPathfinder } from '../src/app/pathfinding.js';
+
+function emptyWorld() {
+  return {
+    tiles: new Uint8Array(GRID_SIZE), // all GRASS (=0) → walkable
+    width: GRID_W,
+    height: GRID_H,
+  };
+}
+
+function makePathfinder(world, blocked = new Set()) {
+  return createPathfinder({
+    idx: (x, y) => (x < 0 || y < 0 || x >= GRID_W || y >= GRID_H ? -1 : y * GRID_W + x),
+    tileOccupiedByBuilding: (x, y) => blocked.has(y * GRID_W + x),
+    getWorld: () => world,
+    getTick: () => 0,
+    perf: { log: false },
+  });
+}
+
+test('S12: pathfind returns shortest path on an empty grid', () => {
+  const world = emptyWorld();
+  const { pathfind } = makePathfinder(world);
+  const p = pathfind(2, 2, 8, 5);
+  assert.ok(Array.isArray(p), 'expected a path array');
+  // Manhattan distance on 4-connected grid = optimal step count.
+  assert.equal(p.length, 9);
+});
+
+test('S12: pathfind on a wall finds the same length as the BFS reference', () => {
+  // Vertical wall at x=10 from y=0..15, with a gap at y=16. Optimal path
+  // length from (5,5) to (15,5) on a 4-connected grid:
+  //   right to x=10 blocked → must go down to y=16, across to x=15, back up to y=5.
+  //   = (10-5) blocked → step around: (5..15)x detour through y=16
+  // Manhattan |15-5|+|5-5|=10. With wall, we go (5,5) → (5,16) → (15,16) → (15,5)
+  //   waypoints = 11 + 10 + 11 = 32 (zig-zag steps; each step is 1 waypoint).
+  const world = emptyWorld();
+  const blocked = new Set();
+  for (let y = 0; y <= 15; y++) blocked.add(y * GRID_W + 10);
+  const { pathfind } = makePathfinder(world, blocked);
+  const p = pathfind(5, 5, 15, 5);
+  assert.ok(Array.isArray(p), 'expected a path');
+  // Optimal length when forced around a 16-tall wall at x=10.
+  // Down 11, right 10, up 11 = 32 steps.
+  assert.equal(p.length, 32);
+});
+
+test('S12: pathfind returns null when target is unreachable within limit', () => {
+  // Box the goal tile in entirely.
+  const world = emptyWorld();
+  const blocked = new Set();
+  for (const [dx, dy] of [[1, 0], [-1, 0], [0, 1], [0, -1]]) {
+    blocked.add((20 + dy) * GRID_W + (20 + dx));
+  }
+  const { pathfind } = makePathfinder(world, blocked);
+  const p = pathfind(0, 0, 20, 20);
+  assert.equal(p, null);
+});
+
+test('S12: pathfind returns single-tile path for start==goal', () => {
+  const world = emptyWorld();
+  const { pathfind } = makePathfinder(world);
+  const p = pathfind(7, 7, 7, 7);
+  assert.equal(p.length, 1);
+});
+
+test('S12: water tiles block the path', () => {
+  const world = emptyWorld();
+  // Wall of water at x=10 from y=0..15.
+  for (let y = 0; y <= 15; y++) world.tiles[y * GRID_W + 10] = TILES.WATER;
+  const { pathfind } = makePathfinder(world);
+  const p = pathfind(5, 5, 15, 5);
+  assert.ok(p, 'expected path around water wall');
+  // Same detour as the building-wall case above.
+  assert.equal(p.length, 32);
+});
+
+test('S12: repeated pathfinds do not leak state between calls', () => {
+  const world = emptyWorld();
+  const { pathfind } = makePathfinder(world);
+  const a = pathfind(0, 0, 12, 0);
+  const b = pathfind(0, 0, 12, 0);
+  assert.equal(a.length, b.length);
+  // Path with a different goal should be re-derived correctly. Manhattan
+  // distance 12 → 12 path entries (start tile not included in path).
+  const c = pathfind(0, 0, 0, 12);
+  assert.equal(c.length, 12);
+});

--- a/tests/pathfinding.bench.phase12.test.js
+++ b/tests/pathfinding.bench.phase12.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { GRID_W, GRID_H, GRID_SIZE } from '../src/app/constants.js';
+import { createPathfinder } from '../src/app/pathfinding.js';
+import { paintBuildingFootprint } from '../src/app/world.js';
+
+// Phase 12 perf smoke test. Not a tight bound — guards against regressions
+// (e.g. accidental .fill(GRID_SIZE) in the hot loop) while tolerating CI
+// jitter. The threshold is intentionally generous; if you breach it you've
+// almost certainly broken something serious.
+
+test('Phase 12: 200 random pathfinds on a populated 192×192 map complete in < 5s', () => {
+  const world = {
+    tiles: new Uint8Array(GRID_SIZE),
+    width: GRID_W,
+    height: GRID_H,
+    buildingOccupancy: new Uint8Array(GRID_SIZE),
+  };
+
+  // Sprinkle ~30 buildings (2x2 footprints) deterministically across the map.
+  const buildings = [];
+  for (let i = 0; i < 30; i++) {
+    const x = ((i * 17) % (GRID_W - 4)) + 2;
+    const y = ((i * 29) % (GRID_H - 4)) + 2;
+    buildings.push({ id: i + 1, kind: 'hut', x, y, built: 1 });
+  }
+  for (const b of buildings) paintBuildingFootprint(world, b);
+
+  const idx = (x, y) => (x < 0 || y < 0 || x >= GRID_W || y >= GRID_H ? -1 : y * GRID_W + x);
+  const tileOccupiedByBuilding = (x, y) => world.buildingOccupancy[y * GRID_W + x] !== 0;
+
+  const { pathfind } = createPathfinder({
+    idx,
+    tileOccupiedByBuilding,
+    getWorld: () => world,
+    getTick: () => 0,
+    perf: { log: false },
+  });
+
+  const N = 200;
+  // Deterministic pseudorandom source so the benchmark is stable across runs.
+  let seed = 0xdeadbeef;
+  const next = () => {
+    seed = (seed * 1664525 + 1013904223) >>> 0;
+    return seed;
+  };
+  const start = performance.now();
+  let resolved = 0;
+  for (let i = 0; i < N; i++) {
+    const sx = next() % GRID_W;
+    const sy = next() % GRID_H;
+    const tx = next() % GRID_W;
+    const ty = next() % GRID_H;
+    const p = pathfind(sx, sy, tx, ty, 600);
+    if (p) resolved++;
+  }
+  const elapsed = performance.now() - start;
+  // Most random pairs should be reachable; at minimum, the call must complete.
+  assert.ok(resolved > 0, 'expected at least one resolved path');
+  assert.ok(elapsed < 5000, `200 pathfinds took ${elapsed.toFixed(1)}ms (>5s)`);
+});

--- a/tests/work.fatigue.phase10.test.js
+++ b/tests/work.fatigue.phase10.test.js
@@ -106,7 +106,7 @@ function makeVillagerTickSystem(state) {
     pathfind: () => null,
     ambientAt: () => 'day',
     nearbyWarmth: () => false,
-    agricultureBonusesAt: () => ({ growthBonus: 0, harvestBonus: 0, moodBonus: 0 }),
+    agricultureMoodAt: () => 0,
     getBuildingById: (id) => state.units.buildings.find((b) => b.id === id) || null,
     noteBuildingActivity: (b) => {
       if (b) {
@@ -327,7 +327,7 @@ function makeOnArriveForHarvest(state, dropped) {
     handleVillagerFed: noop,
     findNearestBuilding: () => null,
     // No bonus tile so harvest yield is purely the workEffort * 2 base.
-    agricultureBonusesAt: () => ({ growthBonus: 0, harvestBonus: 0, moodBonus: 0 }),
+    agricultureHarvestAt: () => 0,
     findEntryTileNear: () => null,
     getBuildingById: () => null,
     setActiveBuilding: noop,

--- a/tests/world.agricultureSplit.phase12.test.js
+++ b/tests/world.agricultureSplit.phase12.test.js
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  agricultureBonusesAt,
+  agricultureGrowthAt,
+  agricultureHarvestAt,
+  agricultureMoodAt,
+} from '../src/app/world.js';
+
+function makeBuilding(kind, x, y, id) {
+  return { id, kind, x, y, built: 1 };
+}
+
+function buildIndex(buildings) {
+  const map = new Map();
+  for (const b of buildings) {
+    let arr = map.get(b.kind);
+    if (!arr) { arr = []; map.set(b.kind, arr); }
+    arr.push(b);
+  }
+  return map;
+}
+
+test('B25: split accessors agree with combined agricultureBonusesAt across a mixed village', () => {
+  // Build a layout with one of each contributing kind plus a campfire (which
+  // must NOT contribute via this path — Phase 4 (B26) explicitly removed it).
+  const buildings = [
+    makeBuilding('hut', 4, 4, 1),
+    makeBuilding('farmplot', 10, 6, 2),
+    makeBuilding('well', 7, 9, 3),
+    makeBuilding('campfire', 2, 2, 4),
+    makeBuilding('storage', 14, 14, 5),
+  ];
+  const index = buildIndex(buildings);
+
+  for (let y = 0; y < 16; y++) {
+    for (let x = 0; x < 16; x++) {
+      const combined = agricultureBonusesAt(buildings, x, y);
+      const mood = agricultureMoodAt(index, x, y);
+      const growth = agricultureGrowthAt(index, x, y);
+      const harvest = agricultureHarvestAt(index, x, y);
+      assert.ok(Math.abs(mood - combined.moodBonus) < 1e-9,
+        `mood mismatch at ${x},${y}: ${mood} vs ${combined.moodBonus}`);
+      assert.ok(Math.abs(growth - combined.growthBonus) < 1e-9,
+        `growth mismatch at ${x},${y}: ${growth} vs ${combined.growthBonus}`);
+      assert.ok(Math.abs(harvest - combined.harvestBonus) < 1e-9,
+        `harvest mismatch at ${x},${y}: ${harvest} vs ${combined.harvestBonus}`);
+    }
+  }
+});
+
+test('B25: split accessors return 0 for missing index', () => {
+  assert.equal(agricultureMoodAt(null, 0, 0), 0);
+  assert.equal(agricultureGrowthAt(null, 0, 0), 0);
+  assert.equal(agricultureHarvestAt(null, 0, 0), 0);
+});
+
+test('B25: unbuilt buildings do not contribute', () => {
+  const buildings = [
+    { id: 1, kind: 'hut', x: 0, y: 0, built: 0 },
+    { id: 2, kind: 'farmplot', x: 0, y: 0, built: 0 },
+    { id: 3, kind: 'well', x: 0, y: 0, built: 0 },
+  ];
+  const index = buildIndex(buildings);
+  assert.equal(agricultureMoodAt(index, 0, 0), 0);
+  assert.equal(agricultureGrowthAt(index, 0, 0), 0);
+  assert.equal(agricultureHarvestAt(index, 0, 0), 0);
+});
+
+test('B25: harvestAt only sees farmplots, not wells', () => {
+  const buildings = [makeBuilding('well', 3, 3, 1)];
+  const index = buildIndex(buildings);
+  // Right on top of the well — wells contribute mood + growth, never harvest.
+  assert.equal(agricultureHarvestAt(index, 3, 3), 0);
+  assert.ok(agricultureMoodAt(index, 3, 3) > 0);
+  assert.ok(agricultureGrowthAt(index, 3, 3) > 0);
+});

--- a/tests/world.occupancyBitmap.phase12.test.js
+++ b/tests/world.occupancyBitmap.phase12.test.js
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  paintBuildingFootprint,
+  clearBuildingFootprint,
+  rebuildBuildingOccupancy,
+  tileOccupiedByBuildingFast,
+  tileOccupiedByBuildingIn,
+} from '../src/app/world.js';
+
+function makeWorld(w = 16, h = 16) {
+  return {
+    width: w,
+    height: h,
+    buildingOccupancy: new Uint8Array(w * h),
+  };
+}
+
+function makeBuilding(kind, x, y, id, built = 1) {
+  return { id, kind, x, y, built };
+}
+
+test('S13: paintBuildingFootprint marks every footprint tile', () => {
+  const world = makeWorld();
+  const hut = makeBuilding('hut', 5, 7, 1);
+  paintBuildingFootprint(world, hut);
+  // hut footprint is 2x2 — see FOOTPRINT in world.js
+  for (let dy = 0; dy < 2; dy++) {
+    for (let dx = 0; dx < 2; dx++) {
+      assert.equal(tileOccupiedByBuildingFast(world, 5 + dx, 7 + dy), true);
+    }
+  }
+  // Adjacent tiles must remain free.
+  assert.equal(tileOccupiedByBuildingFast(world, 4, 7), false);
+  assert.equal(tileOccupiedByBuildingFast(world, 7, 7), false);
+  assert.equal(tileOccupiedByBuildingFast(world, 5, 9), false);
+});
+
+test('S13: tileOccupiedByBuildingFast agrees with linear scan for many placements', () => {
+  const world = makeWorld(20, 20);
+  const buildings = [
+    makeBuilding('hut', 1, 1, 1),
+    makeBuilding('storage', 8, 4, 2),
+    makeBuilding('well', 12, 12, 3),
+    makeBuilding('farmplot', 3, 14, 4),
+    makeBuilding('campfire', 17, 17, 5),
+  ];
+  for (const b of buildings) paintBuildingFootprint(world, b);
+  for (let y = 0; y < 20; y++) {
+    for (let x = 0; x < 20; x++) {
+      const fast = tileOccupiedByBuildingFast(world, x, y);
+      const slow = tileOccupiedByBuildingIn(buildings, x, y);
+      assert.equal(fast, slow, `mismatch at ${x},${y}`);
+    }
+  }
+});
+
+test('S13: clearBuildingFootprint removes the building from the bitmap', () => {
+  const world = makeWorld();
+  const hut = makeBuilding('hut', 3, 3, 1);
+  paintBuildingFootprint(world, hut);
+  clearBuildingFootprint(world, hut);
+  for (let dy = 0; dy < 2; dy++) {
+    for (let dx = 0; dx < 2; dx++) {
+      assert.equal(tileOccupiedByBuildingFast(world, 3 + dx, 3 + dy), false);
+    }
+  }
+});
+
+test('S13: rebuildBuildingOccupancy reconstructs from buildings array', () => {
+  const world = makeWorld();
+  // Stale data already in the bitmap should be wiped first.
+  world.buildingOccupancy[0] = 1;
+  world.buildingOccupancy[5] = 1;
+  const buildings = [makeBuilding('hut', 8, 8, 1), makeBuilding('storage', 12, 12, 2)];
+  rebuildBuildingOccupancy(world, buildings);
+  assert.equal(tileOccupiedByBuildingFast(world, 0, 0), false, 'stale data must be cleared');
+  assert.equal(tileOccupiedByBuildingFast(world, 8, 8), true);
+  assert.equal(tileOccupiedByBuildingFast(world, 12, 12), true);
+});
+
+test('S13: build completion (built 0 → 1) does not change footprint', () => {
+  // Buildings under construction also block movement; the bitmap is set on
+  // addBuilding regardless of `built`. Toggling `built` later must not need
+  // a bitmap update.
+  const world = makeWorld();
+  const b = makeBuilding('hut', 4, 4, 1, 0);
+  paintBuildingFootprint(world, b);
+  const before = Array.from(world.buildingOccupancy);
+  b.built = 1;
+  // Without any bitmap call, occupancy is still correct.
+  const after = Array.from(world.buildingOccupancy);
+  assert.deepEqual(after, before);
+});
+
+test('S13: out-of-bounds paint does not crash', () => {
+  const world = makeWorld(8, 8);
+  // Building partially off the grid.
+  paintBuildingFootprint(world, makeBuilding('hut', 7, 7, 1));
+  assert.equal(tileOccupiedByBuildingFast(world, 7, 7), true);
+  assert.equal(tileOccupiedByBuildingFast(world, 8, 7), false);
+  assert.equal(tileOccupiedByBuildingFast(world, 7, 8), false);
+});


### PR DESCRIPTION
- S13: per-tile building-occupancy bitmap on world.buildingOccupancy.
  passable() now reads it in O(1) instead of scanning all buildings on
  every neighbor expansion. Painted in addBuilding, rebuilt in
  reindexAllBuildings (loadGame), reset in resetVolatileState. Validation
  paths that need ignoreId keep the linear scan.
- S12: pathfind switched from BFS to A* with Manhattan heuristic and a
  binary min-heap on Int32Array. Touched-cell tracking avoids per-call
  GRID_SIZE fills.
- B23: findHuntApproachPath replaced its 9×9 pathfind-per-cell loop with
  a single A*-to-region search. New pathfindToRegion supports an
  optional admissible heuristic; hunt approach passes
  max(0, manhattan(node, animal) - range).
- B25: agricultureBonusesAt split into agricultureMoodAt /
  agricultureGrowthAt / agricultureHarvestAt, each scanning only the
  contributing kinds via the existing buildingsByKind index. The
  per-tick villager mood path drops from O(B) to O(huts+wells).
- DebugKit: tick.js now records EMA per-subsystem ms (jobs, season,
  blackboard, planners, animals, villagerTick, ...). Surfaced via
  debugKitGetPerf in the diag dump so before/after numbers are visible
  from the running game.

Tests:
- new: world.occupancyBitmap.phase12, pathfinding.aStar.phase12,
  animals.huntApproach.phase12, world.agricultureSplit.phase12,
  pathfinding.bench.phase12.
- updated mock deps in build.laborResume / movement.{speed,fatigue} /
  work.fatigue tests for the new agriculture accessor names.

198/198 tests pass; lint clean (preserves one pre-existing planner
warning).

https://claude.ai/code/session_01LYrNQFYzWBbRQS9ggigaJH