### PR TITLE
Phase 1: settlement layout templates

### DIFF
--- a/public/debugkit.js
+++ b/public/debugkit.js
@@ -735,6 +735,49 @@
   const filterSection = createSection('dbgFilterSection', 'Network & Filters', narrowLayout);
   filterSection.body.append(netLabel, filterSelect, searchInput);
 
+  // Phase 1 — Settlement Layout section. Toggles the slot/anchor overlay in
+  // the main render pass via window.AIV_DEBUG_SLOTS, and exposes a snapshot of
+  // the active archetype + slot occupancy.
+  const layoutSlotsInput = el('input', { type: 'checkbox' });
+  const layoutSlotsLabel = el('label', { className: 'dbg-shade-label' }, [
+    layoutSlotsInput,
+    el('span', { text: ' Show slots' })
+  ]);
+  const layoutRefreshBtn = el('button', null, 'Refresh');
+  const layoutStateLabel = el('span', { className: 'dbg-shade-state', text: 'Layout: (press Refresh)' });
+  const layoutSection = createSection('dbgLayoutSection', 'Settlement Layout', narrowLayout);
+  layoutSection.body.append(layoutSlotsLabel, layoutRefreshBtn, layoutStateLabel);
+
+  layoutSlotsInput.addEventListener('change', () => {
+    win.AIV_DEBUG_SLOTS = !!layoutSlotsInput.checked;
+  });
+
+  function refreshLayoutState() {
+    if (typeof stateProvider !== 'function') {
+      layoutStateLabel.textContent = 'Layout: stateProvider not configured';
+      return;
+    }
+    try {
+      const snap = stateProvider();
+      const layout = snap && snap.layout ? snap.layout : null;
+      if (!layout) {
+        layoutStateLabel.textContent = 'Layout: not initialized';
+        return;
+      }
+      const slotCount = Array.isArray(layout.slots) ? layout.slots.length : 0;
+      const occ = layout.occupancy || {};
+      const occTotal = Object.keys(occ).reduce((sum, k) => sum + (Number(occ[k]) || 0), 0);
+      const features = layout.features || {};
+      layoutStateLabel.textContent = `Layout: ${layout.archetype || '?'} · slots=${slotCount} (occ=${occTotal})`
+        + ` · water=${features.dominantWaterSide || '-'} slope=${features.slope ?? 0}`;
+    } catch (err) {
+      layoutStateLabel.textContent = 'Layout: refresh failed';
+      add('ERROR', 'Layout refresh failed', fmt(err));
+    }
+  }
+
+  layoutRefreshBtn.addEventListener('click', refreshLayoutState);
+
   copyBtn.classList.add('dbg-aux');
   exportBtn.classList.add('dbg-aux');
   shareBtn.classList.add('dbg-aux');
@@ -759,6 +802,7 @@
     stateBtn,
     shadingSection.section,
     filterSection.section,
+    layoutSection.section,
     fpsLabel
   );
 

--- a/src/app.js
+++ b/src/app.js
@@ -31,6 +31,7 @@ import { createJobsSystem } from './app/jobs.js';
 import { createAnimalsSystem } from './app/animals.js';
 import { createNocturnalSystem } from './app/nocturnal.js';
 import { createDebugKitBridge } from './app/debugkit.js';
+import { buildLayout, findSlotForKind } from './app/layout.js';
 import { createMaterials } from './app/materials.js';
 import { CHILDHOOD_TICKS, createPopulation } from './app/population.js';
 import { STARVE_THRESH, createVillagerAI } from './app/villagerAI.js';
@@ -364,6 +365,10 @@ function generateWorldBase(seed){
     emitters: []
   };
   buildHillshadeQ(nextWorld);
+  // Phase 1: stamp settlement archetype + named slots before any building is
+  // placed. Layout is a pure function of seed+terrain (no Math.random) and is
+  // recomputed on load rather than persisted, so save migration is a no-op.
+  nextWorld.layout = buildLayout(seed, nextWorld, policy.layout);
   world = nextWorld;
   gameState.world = nextWorld;
   resetLightmapCache();
@@ -435,8 +440,17 @@ function newWorld(seed=Date.now()|0, opts={}){
   const campFp=getFootprint('campfire');
   const campMaxX=Math.max(0, GRID_W-campFp.w);
   const campMaxY=Math.max(0, GRID_H-campFp.h);
-  const campStartX=clamp(Math.round(GRID_W*0.5 - campFp.w*0.5), 0, campMaxX);
-  const campStartY=clamp(Math.round(GRID_H*0.5 - campFp.h*0.5), 0, campMaxY);
+  // Phase 1: seed the campfire from the hearth slot when a layout exists, so
+  // the settlement origin honors the chosen archetype. Fall back to the
+  // map-center heuristic only if the layout is missing (e.g., minimal test
+  // worlds that bypass generateWorldBase()).
+  const hearthSlot = findSlotForKind(world.layout, 'campfire');
+  const campStartX = hearthSlot
+    ? clamp(hearthSlot.footprint.x, 0, campMaxX)
+    : clamp(Math.round(GRID_W*0.5 - campFp.w*0.5), 0, campMaxX);
+  const campStartY = hearthSlot
+    ? clamp(hearthSlot.footprint.y, 0, campMaxY)
+    : clamp(Math.round(GRID_H*0.5 - campFp.h*0.5), 0, campMaxY);
   const campPos=findNearestStartSpot('campfire', campStartX, campStartY) || {x:campStartX, y:campStartY};
   const campfire=addBuilding('campfire',campPos.x,campPos.y,{built:1});
 

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -62,7 +62,7 @@ const GRID_W = coords.GRID_W;
 const GRID_H = coords.GRID_H;
 const GRID_SIZE = GRID_W * GRID_H;
 const SAVE_KEY = 'aiv_px_v3_save';
-const SAVE_VERSION = 7;
+const SAVE_VERSION = 8;
 const COARSE_SAVE_SIZE = 96;
 
 // Sequential save-format migrations: when loading a save with version `v`,
@@ -83,8 +83,18 @@ const SAVE_MIGRATIONS = new Map([
   // v6 -> v7: Phase 8 adds per-villager `restStartedAtNight` (saved as `rsn`).
   // Absent fields coerce to false at load time, matching pre-Phase-8 wake
   // behavior on the first post-load sleep — no-op migration.
-  [6, (data) => data]
+  [6, (data) => data],
+  // v7 -> v8: Phase 1 adds world.layout (archetype + slots + anchors). Layout
+  // is a pure function of seed+terrain and is recomputed at world-gen, so it
+  // is not serialized — the migration body is intentionally a no-op.
+  [7, (data) => data]
 ]);
+const LAYOUT_ARCHETYPES = Object.freeze({
+  RADIAL: 'radial',
+  RIBBON: 'ribbon',
+  TERRACE: 'terrace',
+  COURTYARD: 'courtyard'
+});
 const TILES = { GRASS:0, FOREST:1, ROCK:2, WATER:3, FERTILE:4, FARMLAND:5, SAND:6, SNOW:7, MEADOW:8, MARSH:9 };
 const ZONES = { NONE:0, FARM:1, CUT:2, MINE:4 };
 const WALKABLE = new Set([
@@ -198,6 +208,7 @@ export {
   HUNT_RETRY_COOLDOWN,
   ITEM,
   ITEM_COLORS,
+  LAYOUT_ARCHETYPES,
   LIGHT_VECTOR,
   LIGHT_VECTOR_LENGTH,
   LAYER_ORDER,

--- a/src/app/debugkit.js
+++ b/src/app/debugkit.js
@@ -158,6 +158,30 @@ export function createDebugKitBridge(opts) {
     } else if (Number.isFinite(getDayTime())) {
       snapshotTime = getDayTime();
     }
+    // Phase 1: shallow-copy layout for the slot overlay. The Map is converted
+    // to a plain object so the debug payload is JSON-serializable.
+    let layout = null;
+    if (world?.layout) {
+      const occ = world.layout.occupancy;
+      const occupancy = {};
+      if (occ && typeof occ.forEach === 'function') {
+        occ.forEach((value, key) => { occupancy[key] = value; });
+      }
+      layout = {
+        archetype: world.layout.archetype,
+        origin: world.layout.origin,
+        anchors: world.layout.anchors,
+        slots: world.layout.slots.map((s) => ({
+          id: s.id,
+          family: s.family,
+          footprint: s.footprint,
+          capacity: s.capacity,
+          kindAffinity: s.kindAffinity
+        })),
+        occupancy,
+        features: world.layout.features
+      };
+    }
     const villagerDetails = Array.isArray(villagers)
       ? villagers.map((v) => ({
           id: v.id,
@@ -185,6 +209,7 @@ export function createDebugKitBridge(opts) {
       villagers: villagerCount,
       lightingMode: LIGHTING?.mode ?? 'unknown',
       multiplyComposite: LIGHTING?.useMultiplyComposite === true,
+      layout,
       villagerDetails,
     };
   }

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,0 +1,449 @@
+// Phase 1 — Settlement layout templates.
+//
+// Replaces the implicit "campfire-at-center, score-within-18-tiles" layout with
+// an explicit archetype + named-slot table. `buildLayout(seed, world)` analyzes
+// terrain features (water orientation, tree density, slope from aux.height),
+// picks one of {radial, ribbon, terrace, courtyard} deterministically, and
+// stamps a parametric set of anchor slots. The planner then routes each
+// building kind into the matching slot; the legacy per-tile scoring becomes
+// the within-slot tie-breaker.
+//
+// All randomness threads through mulberry32(seed) — no Math.random().
+
+import { GRID_H, GRID_W, TILES } from './constants.js';
+import { mulberry32 } from './rng.js';
+
+export const LAYOUT_ARCHETYPES = Object.freeze({
+  RADIAL: 'radial',
+  RIBBON: 'ribbon',
+  TERRACE: 'terrace',
+  COURTYARD: 'courtyard'
+});
+
+const ARCHETYPE_LIST = ['radial', 'ribbon', 'terrace', 'courtyard'];
+
+const DEFAULT_KIND_TO_FAMILY = Object.freeze({
+  campfire: ['hearth'],
+  storage: ['storage'],
+  hut: ['housing'],
+  hunterLodge: ['craft'],
+  farmplot: ['fields'],
+  well: ['wells', 'fields']
+});
+
+// Quadrant ids used by terrain analysis. N is the top half of the map (y < cy),
+// S is the bottom half, etc.
+const QUADRANTS = ['N', 'E', 'S', 'W'];
+
+function isBuildableTile(tile) {
+  return tile === TILES.GRASS
+    || tile === TILES.FERTILE
+    || tile === TILES.MEADOW
+    || tile === TILES.SAND
+    || tile === TILES.FARMLAND
+    || tile === TILES.SNOW;
+}
+
+function clampInt(v, lo, hi) {
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return v | 0;
+}
+
+function clampFootprint(fp) {
+  const x = clampInt(fp.x, 0, Math.max(0, GRID_W - 1));
+  const y = clampInt(fp.y, 0, Math.max(0, GRID_H - 1));
+  const w = clampInt(Math.max(1, fp.w), 1, GRID_W - x);
+  const h = clampInt(Math.max(1, fp.h), 1, GRID_H - y);
+  return { x, y, w, h };
+}
+
+function rectsOverlap(a, b) {
+  return !(a.x + a.w <= b.x || b.x + b.w <= a.x || a.y + a.h <= b.y || b.y + b.h <= a.y);
+}
+
+// Walk an outward spiral from (cx, cy) until a tile satisfies `predicate`.
+function spiralFind(cx, cy, predicate, maxRadius = Math.max(GRID_W, GRID_H)) {
+  if (predicate(cx, cy)) return { x: cx, y: cy };
+  for (let r = 1; r <= maxRadius; r++) {
+    for (let dy = -r; dy <= r; dy++) {
+      for (let dx = -r; dx <= r; dx++) {
+        if (Math.abs(dx) !== r && Math.abs(dy) !== r) continue;
+        const x = cx + dx;
+        const y = cy + dy;
+        if (x < 0 || y < 0 || x >= GRID_W || y >= GRID_H) continue;
+        if (predicate(x, y)) return { x, y };
+      }
+    }
+  }
+  return { x: cx, y: cy };
+}
+
+export function analyzeTerrain(world) {
+  const tiles = world?.tiles;
+  const trees = world?.trees;
+  const height = world?.aux?.height || null;
+  const cx = (GRID_W / 2) | 0;
+  const cy = (GRID_H / 2) | 0;
+
+  const waterByQuad = { N: 0, E: 0, S: 0, W: 0 };
+  const treeByQuad = { N: 0, E: 0, S: 0, W: 0 };
+  let totalWater = 0;
+  let totalTrees = 0;
+  let centerTrees = 0;
+  let centerSamples = 0;
+  // Slope estimate: height range across the grid normalized to [0, 1].
+  let hMin = Infinity;
+  let hMax = -Infinity;
+  let hSamples = 0;
+
+  if (tiles && tiles.length === GRID_W * GRID_H) {
+    for (let y = 0; y < GRID_H; y++) {
+      const dy = y - cy;
+      for (let x = 0; x < GRID_W; x++) {
+        const i = y * GRID_W + x;
+        const dx = x - cx;
+        // Quadrant assignment: N if dy<=dx-... use the dominant axis.
+        // Use sign of dx,dy and which has larger magnitude.
+        let quad;
+        if (Math.abs(dy) >= Math.abs(dx)) {
+          quad = dy < 0 ? 'N' : 'S';
+        } else {
+          quad = dx < 0 ? 'W' : 'E';
+        }
+        if (tiles[i] === TILES.WATER) {
+          waterByQuad[quad]++;
+          totalWater++;
+        }
+        if (trees && trees[i] > 0) {
+          treeByQuad[quad]++;
+          totalTrees++;
+          if (Math.abs(dx) <= 6 && Math.abs(dy) <= 6) {
+            centerTrees++;
+          }
+        }
+        if (Math.abs(dx) <= 6 && Math.abs(dy) <= 6) {
+          centerSamples++;
+        }
+        if (height && height.length === tiles.length) {
+          const h = height[i];
+          if (h < hMin) hMin = h;
+          if (h > hMax) hMax = h;
+          hSamples++;
+        }
+      }
+    }
+  }
+
+  const totalCells = GRID_W * GRID_H;
+  let dominantWaterSide = null;
+  if (totalWater > totalCells * 0.02) {
+    let bestQuad = 'N';
+    let bestCount = waterByQuad.N;
+    for (const q of QUADRANTS) {
+      if (waterByQuad[q] > bestCount) { bestCount = waterByQuad[q]; bestQuad = q; }
+    }
+    // Require dominant quadrant to hold ≥40% of all water tiles before we
+    // call it directional — diffuse water shouldn't push us to ribbon.
+    if (bestCount >= totalWater * 0.4) dominantWaterSide = bestQuad;
+  }
+
+  const slope = (hSamples > 0 && hMax > hMin)
+    ? Math.min(1, (hMax - hMin) / 255)
+    : 0;
+  const treeDensityCenter = centerSamples > 0 ? centerTrees / centerSamples : 0;
+  const treeDensityTotal = totalCells > 0 ? totalTrees / totalCells : 0;
+
+  return {
+    waterByQuad,
+    treeByQuad,
+    totalWater,
+    totalTrees,
+    treeDensityCenter,
+    treeDensityTotal,
+    slope,
+    dominantWaterSide,
+    center: { x: cx, y: cy }
+  };
+}
+
+// Deterministic archetype pick. Terrain features dominate; mulberry32(seed)
+// adds a small jitter so seeds with similar terrain still resolve consistently.
+export function chooseArchetype(seed, features, opts = {}) {
+  const jitterAmplitude = Number.isFinite(opts.jitterAmplitude) ? opts.jitterAmplitude : 0.15;
+  const weights = opts.archetypeWeights || { radial: 1, ribbon: 1, terrace: 1, courtyard: 1 };
+  const bias = opts.terrainBias || { waterToRibbon: 2, slopeToTerrace: 2, openToCourtyard: 1.5 };
+
+  const score = {
+    radial: (weights.radial || 1) * (1 + (features.dominantWaterSide ? 0 : 1)),
+    ribbon: (weights.ribbon || 1) * (1 + (features.dominantWaterSide ? bias.waterToRibbon : 0)),
+    terrace: (weights.terrace || 1) * (1 + Math.min(2, features.slope * bias.slopeToTerrace * 2)),
+    courtyard: (weights.courtyard || 1) * (1 + (features.treeDensityCenter < 0.1 ? bias.openToCourtyard : 0))
+  };
+
+  const rng = mulberry32((seed >>> 0) || 1);
+  let best = ARCHETYPE_LIST[0];
+  let bestScore = -Infinity;
+  for (const id of ARCHETYPE_LIST) {
+    const s = score[id] + (rng() * 2 - 1) * jitterAmplitude;
+    if (s > bestScore) { bestScore = s; best = id; }
+  }
+  return best;
+}
+
+function pickSettlementOrigin(world, features) {
+  const cx = features.center.x;
+  const cy = features.center.y;
+  let originX = cx;
+  let originY = cy;
+
+  // Shift inland from the dominant water side so settlements anchored next to
+  // a coast still sit on usable land.
+  if (features.dominantWaterSide === 'N') originY = cy + 10;
+  else if (features.dominantWaterSide === 'S') originY = cy - 10;
+  else if (features.dominantWaterSide === 'E') originX = cx - 10;
+  else if (features.dominantWaterSide === 'W') originX = cx + 10;
+
+  const tiles = world?.tiles;
+  if (!tiles) return { x: originX, y: originY };
+
+  const snapped = spiralFind(
+    clampInt(originX, 4, GRID_W - 5),
+    clampInt(originY, 4, GRID_H - 5),
+    (x, y) => {
+      // Require a 4x4 buildable area around the origin so the hearth and
+      // storage slots have somewhere to sit even without obstacle clearing.
+      for (let yy = -2; yy <= 1; yy++) {
+        for (let xx = -2; xx <= 1; xx++) {
+          const tx = x + xx;
+          const ty = y + yy;
+          if (tx < 0 || ty < 0 || tx >= GRID_W || ty >= GRID_H) return false;
+          if (!isBuildableTile(tiles[ty * GRID_W + tx])) return false;
+        }
+      }
+      return true;
+    },
+    24
+  );
+  return snapped;
+}
+
+// Each archetype emits the same slot families (hearth, storage, housing×N,
+// craft, fields, wells) but with different geometry, so the planner's slot
+// lookup stays archetype-agnostic.
+function radialSlots(origin, _features) {
+  const { x, y } = origin;
+  const slots = [
+    { id: 'hearth', family: 'hearth', footprint: { x: x - 1, y: y - 1, w: 4, h: 4 }, capacity: 1, kindAffinity: ['campfire'] },
+    { id: 'storage-main', family: 'storage', footprint: { x: x + 4, y: y - 1, w: 4, h: 4 }, capacity: 1, kindAffinity: ['storage'] },
+    { id: 'housing-ring-N', family: 'housing', footprint: { x: x - 8, y: y - 12, w: 16, h: 5 }, capacity: 3, kindAffinity: ['hut'] },
+    { id: 'housing-ring-E', family: 'housing', footprint: { x: x + 9, y: y - 6, w: 5, h: 14 }, capacity: 3, kindAffinity: ['hut'] },
+    { id: 'housing-ring-S', family: 'housing', footprint: { x: x - 8, y: y + 8, w: 16, h: 5 }, capacity: 3, kindAffinity: ['hut'] },
+    { id: 'housing-ring-W', family: 'housing', footprint: { x: x - 13, y: y - 6, w: 5, h: 14 }, capacity: 3, kindAffinity: ['hut'] },
+    { id: 'craft', family: 'craft', footprint: { x: x + 9, y: y - 13, w: 6, h: 6 }, capacity: 2, kindAffinity: ['hunterLodge'] },
+    { id: 'fields-1', family: 'fields', footprint: { x: x - 16, y: y + 4, w: 10, h: 10 }, capacity: 4, kindAffinity: ['farmplot', 'well'] },
+    { id: 'wells', family: 'wells', footprint: { x: x - 14, y: y + 4, w: 4, h: 6 }, capacity: 1, kindAffinity: ['well'] }
+  ];
+  const anchors = {};
+  for (const s of slots) {
+    anchors[s.id] = { x: s.footprint.x + s.footprint.w / 2, y: s.footprint.y + s.footprint.h / 2 };
+  }
+  return { slots, anchors };
+}
+
+function ribbonSlots(origin, features) {
+  const { x, y } = origin;
+  // Ribbon runs along the water edge axis. If water is N or S, ribbon spans
+  // east-west; otherwise it spans north-south.
+  const horizontal = features.dominantWaterSide === 'N' || features.dominantWaterSide === 'S' || !features.dominantWaterSide;
+  let slots;
+  if (horizontal) {
+    slots = [
+      { id: 'hearth', family: 'hearth', footprint: { x: x - 1, y: y - 1, w: 4, h: 4 }, capacity: 1, kindAffinity: ['campfire'] },
+      { id: 'storage-main', family: 'storage', footprint: { x: x + 4, y: y - 1, w: 4, h: 4 }, capacity: 1, kindAffinity: ['storage'] },
+      { id: 'housing-band-A', family: 'housing', footprint: { x: x - 18, y: y - 6, w: 18, h: 4 }, capacity: 3, kindAffinity: ['hut'] },
+      { id: 'housing-band-B', family: 'housing', footprint: { x: x + 9, y: y - 6, w: 18, h: 4 }, capacity: 3, kindAffinity: ['hut'] },
+      { id: 'housing-band-C', family: 'housing', footprint: { x: x - 18, y: y + 5, w: 18, h: 4 }, capacity: 3, kindAffinity: ['hut'] },
+      { id: 'craft', family: 'craft', footprint: { x: x - 24, y: y - 1, w: 5, h: 5 }, capacity: 2, kindAffinity: ['hunterLodge'] },
+      { id: 'fields-1', family: 'fields', footprint: { x: x - 6, y: y + 11, w: 14, h: 14 }, capacity: 4, kindAffinity: ['farmplot', 'well'] },
+      { id: 'wells', family: 'wells', footprint: { x: x + 8, y: y + 11, w: 4, h: 6 }, capacity: 1, kindAffinity: ['well'] }
+    ];
+  } else {
+    slots = [
+      { id: 'hearth', family: 'hearth', footprint: { x: x - 1, y: y - 1, w: 4, h: 4 }, capacity: 1, kindAffinity: ['campfire'] },
+      { id: 'storage-main', family: 'storage', footprint: { x: x - 1, y: y + 4, w: 4, h: 4 }, capacity: 1, kindAffinity: ['storage'] },
+      { id: 'housing-band-A', family: 'housing', footprint: { x: x - 6, y: y - 18, w: 4, h: 18 }, capacity: 3, kindAffinity: ['hut'] },
+      { id: 'housing-band-B', family: 'housing', footprint: { x: x - 6, y: y + 9, w: 4, h: 18 }, capacity: 3, kindAffinity: ['hut'] },
+      { id: 'housing-band-C', family: 'housing', footprint: { x: x + 5, y: y - 18, w: 4, h: 18 }, capacity: 3, kindAffinity: ['hut'] },
+      { id: 'craft', family: 'craft', footprint: { x: x - 1, y: y - 24, w: 5, h: 5 }, capacity: 2, kindAffinity: ['hunterLodge'] },
+      { id: 'fields-1', family: 'fields', footprint: { x: x + 11, y: y - 6, w: 14, h: 14 }, capacity: 4, kindAffinity: ['farmplot', 'well'] },
+      { id: 'wells', family: 'wells', footprint: { x: x + 11, y: y + 8, w: 6, h: 4 }, capacity: 1, kindAffinity: ['well'] }
+    ];
+  }
+  const anchors = {};
+  for (const s of slots) {
+    anchors[s.id] = { x: s.footprint.x + s.footprint.w / 2, y: s.footprint.y + s.footprint.h / 2 };
+  }
+  return { slots, anchors };
+}
+
+function terraceSlots(origin, _features) {
+  const { x, y } = origin;
+  // Three stacked rows climbing the slope. Hearth on the lowest row, fields on
+  // the flattest band (the lowest one), housing rows above.
+  const slots = [
+    { id: 'hearth', family: 'hearth', footprint: { x: x - 1, y: y + 5, w: 4, h: 4 }, capacity: 1, kindAffinity: ['campfire'] },
+    { id: 'storage-main', family: 'storage', footprint: { x: x + 4, y: y - 1, w: 4, h: 4 }, capacity: 1, kindAffinity: ['storage'] },
+    { id: 'housing-row-1', family: 'housing', footprint: { x: x - 12, y: y - 13, w: 24, h: 4 }, capacity: 3, kindAffinity: ['hut'] },
+    { id: 'housing-row-2', family: 'housing', footprint: { x: x - 12, y: y - 7, w: 24, h: 4 }, capacity: 3, kindAffinity: ['hut'] },
+    { id: 'housing-row-3', family: 'housing', footprint: { x: x - 12, y: y - 1, w: 24, h: 4 }, capacity: 3, kindAffinity: ['hut'] },
+    { id: 'craft', family: 'craft', footprint: { x: x + 13, y: y - 7, w: 6, h: 6 }, capacity: 2, kindAffinity: ['hunterLodge'] },
+    { id: 'fields-1', family: 'fields', footprint: { x: x - 12, y: y + 11, w: 24, h: 10 }, capacity: 4, kindAffinity: ['farmplot', 'well'] },
+    { id: 'wells', family: 'wells', footprint: { x: x - 4, y: y + 11, w: 4, h: 6 }, capacity: 1, kindAffinity: ['well'] }
+  ];
+  const anchors = {};
+  for (const s of slots) {
+    anchors[s.id] = { x: s.footprint.x + s.footprint.w / 2, y: s.footprint.y + s.footprint.h / 2 };
+  }
+  return { slots, anchors };
+}
+
+function courtyardSlots(origin, _features) {
+  const { x, y } = origin;
+  // Storage and craft form a U around an empty central plaza; hearth at the
+  // plaza center; housing slots on the outer N/E/S/W; fields outside the U.
+  const slots = [
+    { id: 'hearth', family: 'hearth', footprint: { x: x - 1, y: y - 1, w: 4, h: 4 }, capacity: 1, kindAffinity: ['campfire'] },
+    { id: 'storage-main', family: 'storage', footprint: { x: x - 7, y: y - 2, w: 4, h: 5 }, capacity: 1, kindAffinity: ['storage'] },
+    { id: 'craft', family: 'craft', footprint: { x: x + 5, y: y - 2, w: 5, h: 5 }, capacity: 2, kindAffinity: ['hunterLodge'] },
+    { id: 'housing-ring-N', family: 'housing', footprint: { x: x - 8, y: y - 11, w: 18, h: 5 }, capacity: 3, kindAffinity: ['hut'] },
+    { id: 'housing-ring-E', family: 'housing', footprint: { x: x + 12, y: y - 6, w: 5, h: 14 }, capacity: 3, kindAffinity: ['hut'] },
+    { id: 'housing-ring-S', family: 'housing', footprint: { x: x - 8, y: y + 8, w: 18, h: 5 }, capacity: 3, kindAffinity: ['hut'] },
+    { id: 'housing-ring-W', family: 'housing', footprint: { x: x - 16, y: y - 6, w: 5, h: 14 }, capacity: 3, kindAffinity: ['hut'] },
+    { id: 'fields-1', family: 'fields', footprint: { x: x - 8, y: y + 15, w: 18, h: 10 }, capacity: 4, kindAffinity: ['farmplot', 'well'] },
+    { id: 'wells', family: 'wells', footprint: { x: x + 1, y: y + 15, w: 4, h: 6 }, capacity: 1, kindAffinity: ['well'] }
+  ];
+  const anchors = {};
+  for (const s of slots) {
+    anchors[s.id] = { x: s.footprint.x + s.footprint.w / 2, y: s.footprint.y + s.footprint.h / 2 };
+  }
+  return { slots, anchors };
+}
+
+const ARCHETYPE_BUILDERS = {
+  radial: radialSlots,
+  ribbon: ribbonSlots,
+  terrace: terraceSlots,
+  courtyard: courtyardSlots
+};
+
+export const ARCHETYPES = Object.freeze({
+  radial: { id: 'radial', label: 'Radial', build: radialSlots },
+  ribbon: { id: 'ribbon', label: 'Ribbon', build: ribbonSlots },
+  terrace: { id: 'terrace', label: 'Terrace', build: terraceSlots },
+  courtyard: { id: 'courtyard', label: 'Courtyard', build: courtyardSlots }
+});
+
+export function buildLayout(seed, world, opts = {}) {
+  const features = analyzeTerrain(world);
+  const archetype = chooseArchetype(seed, features, opts);
+  const origin = pickSettlementOrigin(world, features);
+  const builder = ARCHETYPE_BUILDERS[archetype] || radialSlots;
+  const { slots: rawSlots, anchors: rawAnchors } = builder(origin, features);
+
+  const slots = rawSlots.map((s) => ({
+    id: s.id,
+    family: s.family,
+    footprint: clampFootprint(s.footprint),
+    capacity: s.capacity,
+    kindAffinity: Array.isArray(s.kindAffinity) ? s.kindAffinity.slice() : []
+  }));
+
+  const anchors = {};
+  for (const key of Object.keys(rawAnchors)) {
+    const a = rawAnchors[key];
+    anchors[key] = {
+      x: clampInt(Math.round(a.x), 0, GRID_W - 1),
+      y: clampInt(Math.round(a.y), 0, GRID_H - 1)
+    };
+  }
+
+  return {
+    archetype,
+    origin: { x: origin.x | 0, y: origin.y | 0 },
+    anchors,
+    slots,
+    occupancy: new Map(),
+    features: {
+      dominantWaterSide: features.dominantWaterSide,
+      slope: +features.slope.toFixed(3),
+      treeDensityCenter: +features.treeDensityCenter.toFixed(3)
+    }
+  };
+}
+
+export function findSlotForKind(layout, kind, opts = {}) {
+  if (!layout || !Array.isArray(layout.slots)) return null;
+  const kindToFamily = opts.kindToSlotFamily || DEFAULT_KIND_TO_FAMILY;
+  const families = kindToFamily[kind] || [];
+  // Prefer slots whose primary family matches the kind, then fall back to any
+  // slot that lists the kind in its kindAffinity array.
+  for (const family of families) {
+    for (const slot of layout.slots) {
+      if (slot.family !== family) continue;
+      const used = layout.occupancy.get(slot.id) || 0;
+      if (used < slot.capacity && slot.kindAffinity.includes(kind)) return slot;
+    }
+  }
+  for (const slot of layout.slots) {
+    if (!slot.kindAffinity.includes(kind)) continue;
+    const used = layout.occupancy.get(slot.id) || 0;
+    if (used < slot.capacity) return slot;
+  }
+  return null;
+}
+
+export function tileInsideSlot(slot, x, y) {
+  if (!slot || !slot.footprint) return false;
+  const fp = slot.footprint;
+  return x >= fp.x && x < fp.x + fp.w && y >= fp.y && y < fp.y + fp.h;
+}
+
+// Walk the live buildings list and rebuild layout.occupancy from scratch.
+// Called once per planBuildings cycle so claims survive saves/loads (the
+// layout itself is recomputed at world-gen, not persisted).
+export function recomputeOccupancy(layout, buildings, opts = {}) {
+  if (!layout || !Array.isArray(layout.slots)) return;
+  layout.occupancy.clear();
+  if (!Array.isArray(buildings) || buildings.length === 0) return;
+  const kindToFamily = opts.kindToSlotFamily || DEFAULT_KIND_TO_FAMILY;
+  for (const b of buildings) {
+    if (!b || typeof b.x !== 'number' || typeof b.y !== 'number') continue;
+    const families = kindToFamily[b.kind];
+    if (!families) continue;
+    // Match the building footprint against slot footprints. We accept a slot
+    // as the owner of this building if the building's bounding box intersects
+    // the slot AND the slot allows this kind.
+    let owner = null;
+    const fpW = 2;
+    const fpH = 2; // current 6 building kinds all share 2x2; planner footprint is authoritative.
+    const bRect = { x: b.x, y: b.y, w: fpW, h: fpH };
+    for (const slot of layout.slots) {
+      if (!slot.kindAffinity.includes(b.kind)) continue;
+      if (rectsOverlap(bRect, slot.footprint)) { owner = slot; break; }
+    }
+    if (!owner) continue;
+    const cur = layout.occupancy.get(owner.id) || 0;
+    layout.occupancy.set(owner.id, cur + 1);
+  }
+}
+
+export const __test = {
+  isBuildableTile,
+  clampFootprint,
+  rectsOverlap,
+  spiralFind,
+  pickSettlementOrigin,
+  ARCHETYPE_BUILDERS,
+  DEFAULT_KIND_TO_FAMILY
+};

--- a/src/app/planner.js
+++ b/src/app/planner.js
@@ -17,6 +17,7 @@ import {
   tileOccupiedByBuildingIn,
   validateFootprintPlacementIn
 } from './world.js';
+import { findSlotForKind, recomputeOccupancy } from './layout.js';
 import { clamp } from './rng.js';
 import { computeFamineSeverity } from '../ai/scoring.js';
 
@@ -132,68 +133,106 @@ export function createPlanner(opts) {
     return best;
   }
 
-  function findPlacementNear(kind, anchorX, anchorY, maxRadius = 18, context = {}) {
-    const world = state.world;
+  // Per-kind tile-scoring helpers, shared between the slot-aware fast path and
+  // the legacy radius search. Pulled out of findPlacementNear so both paths
+  // tie-break with the exact same weights — preserves the progression-tier
+  // order acceptance criterion in Phase 1.
+  function wildlifeDensity(x, y, radius = 6) {
     const animals = state.units.animals;
+    if (!Array.isArray(animals) || animals.length === 0) return 0;
+    let score = 0;
+    for (const a of animals) {
+      if (!a || a.state === 'dead') continue;
+      const dist = Math.abs(a.x - x) + Math.abs(a.y - y);
+      if (dist > radius) continue;
+      score += Math.max(0, radius - dist + 1);
+    }
+    return score;
+  }
+
+  function nearbyZoneScore(zone, x, y, radius = 3) {
+    const world = state.world;
+    if (!world?.zone) return 0;
+    let count = 0;
+    for (let yy = y - radius; yy <= y + radius; yy++) {
+      for (let xx = x - radius; xx <= x + radius; xx++) {
+        if (xx < 0 || yy < 0 || xx >= GRID_W || yy >= GRID_H) continue;
+        const i = yy * GRID_W + xx;
+        if (world.zone[i] === zone) count++;
+      }
+    }
+    return count;
+  }
+
+  function resourceDensity(resource, x, y, radius = 2) {
+    const world = state.world;
+    if (!world) return 0;
+    const source = resource === 'wood' ? world.trees : world.rocks;
+    if (!source) return 0;
+    let score = 0;
+    for (let yy = y - radius; yy <= y + radius; yy++) {
+      for (let xx = x - radius; xx <= x + radius; xx++) {
+        if (xx < 0 || yy < 0 || xx >= GRID_W || yy >= GRID_H) continue;
+        const i = yy * GRID_W + xx;
+        score += Math.max(0, source[i] || 0);
+      }
+    }
+    return score;
+  }
+
+  function fertileScore(x, y, radius = 1) {
+    const world = state.world;
+    if (!world?.tiles) return 0;
+    let score = 0;
+    for (let yy = y - radius; yy <= y + radius; yy++) {
+      for (let xx = x - radius; xx <= x + radius; xx++) {
+        if (xx < 0 || yy < 0 || xx >= GRID_W || yy >= GRID_H) continue;
+        const tile = world.tiles[yy * GRID_W + xx];
+        if (tile === TILES.FERTILE || tile === TILES.MEADOW) score += 2;
+        else if (tile === TILES.GRASS) score += 1;
+      }
+    }
+    return score;
+  }
+
+  function perKindBonus(kind, cx, cy) {
+    let score = 0;
+    if (kind === 'hut') {
+      score += nearbyZoneScore(ZONES.FARM, cx, cy, 4) * -0.3;
+      score += nearbyZoneScore(ZONES.CUT, cx, cy, 3) * -0.1;
+    } else if (kind === 'farmplot') {
+      score += nearbyZoneScore(ZONES.FARM, cx, cy, 3) * 1.8;
+      score += fertileScore(cx, cy, 2) * 0.6;
+    } else if (kind === 'well') {
+      score += nearbyZoneScore(ZONES.FARM, cx, cy, 4) * 2.2;
+      score += fertileScore(cx, cy, 1) * 0.2;
+    } else if (kind === 'storage') {
+      score += nearbyZoneScore(ZONES.CUT, cx, cy, 4) * 1.1;
+      score += nearbyZoneScore(ZONES.MINE, cx, cy, 4) * 1.1;
+      score += resourceDensity('wood', cx, cy, 2) * 0.05;
+      score += resourceDensity('stone', cx, cy, 2) * 0.06;
+    } else if (kind === 'hunterLodge') {
+      score += wildlifeDensity(cx, cy, 6) * 0.45;
+      score += resourceDensity('wood', cx, cy, 2) * 0.08;
+      score += nearbyZoneScore(ZONES.FARM, cx, cy, 4) * -0.2;
+    }
+    return score;
+  }
+
+  // Phase 1 — slot-aware placement.
+  //
+  // When world.layout exists, route the placement into the slot family the
+  // kind belongs to (campfire→hearth, hut→housing-*, farmplot→fields-*, etc).
+  // Tiles inside the slot footprint are scored with the same per-kind bonuses
+  // as before, plus a slot-center distance term. If the slot is full or no
+  // tile inside it is buildable+reachable, fall back to the legacy radius
+  // search so progression isn't blocked on edge cases.
+  function legacyFindPlacementNear(kind, anchorX, anchorY, maxRadius = 18, context = {}) {
     const fp = getFootprint(kind);
     let best = null, bestScore = -Infinity;
     const anchorTx = Math.round(anchorX);
     const anchorTy = Math.round(anchorY);
     let reachableFound = false;
-
-    const wildlifeDensity = (x, y, radius = 6) => {
-      if (!Array.isArray(animals) || animals.length === 0) return 0;
-      let score = 0;
-      for (const a of animals) {
-        if (!a || a.state === 'dead') continue;
-        const dist = Math.abs(a.x - x) + Math.abs(a.y - y);
-        if (dist > radius) continue;
-        score += Math.max(0, radius - dist + 1);
-      }
-      return score;
-    };
-
-    const nearbyZoneScore = (zone, x, y, radius = 3) => {
-      if (!world?.zone) return 0;
-      let count = 0;
-      for (let yy = y - radius; yy <= y + radius; yy++) {
-        for (let xx = x - radius; xx <= x + radius; xx++) {
-          if (xx < 0 || yy < 0 || xx >= GRID_W || yy >= GRID_H) continue;
-          const i = yy * GRID_W + xx;
-          if (world.zone[i] === zone) count++;
-        }
-      }
-      return count;
-    };
-
-    const resourceDensity = (resource, x, y, radius = 2) => {
-      if (!world) return 0;
-      const source = resource === 'wood' ? world.trees : world.rocks;
-      if (!source) return 0;
-      let score = 0;
-      for (let yy = y - radius; yy <= y + radius; yy++) {
-        for (let xx = x - radius; xx <= x + radius; xx++) {
-          if (xx < 0 || yy < 0 || xx >= GRID_W || yy >= GRID_H) continue;
-          const i = yy * GRID_W + xx;
-          score += Math.max(0, source[i] || 0);
-        }
-      }
-      return score;
-    };
-
-    const fertileScore = (x, y, radius = 1) => {
-      if (!world?.tiles) return 0;
-      let score = 0;
-      for (let yy = y - radius; yy <= y + radius; yy++) {
-        for (let xx = x - radius; xx <= x + radius; xx++) {
-          if (xx < 0 || yy < 0 || xx >= GRID_W || yy >= GRID_H) continue;
-          const tile = world.tiles[yy * GRID_W + xx];
-          if (tile === TILES.FERTILE || tile === TILES.MEADOW) score += 2;
-          else if (tile === TILES.GRASS) score += 1;
-        }
-      }
-      return score;
-    };
 
     for (let r = 0; r <= maxRadius; r++) {
       const minX = Math.max(0, Math.floor(anchorX - r));
@@ -206,31 +245,7 @@ export function createPlanner(opts) {
           const cx = x + (fp.w - 1) / 2;
           const cy = y + (fp.h - 1) / 2;
           const baseDist = Math.abs(cx - anchorX) + Math.abs(cy - anchorY);
-          let score = -baseDist;
-
-          if (kind === 'hut') {
-            score += nearbyZoneScore(ZONES.FARM, cx, cy, 4) * -0.3;
-            score += nearbyZoneScore(ZONES.CUT, cx, cy, 3) * -0.1;
-          }
-          if (kind === 'farmplot') {
-            score += nearbyZoneScore(ZONES.FARM, cx, cy, 3) * 1.8;
-            score += fertileScore(cx, cy, 2) * 0.6;
-          }
-          if (kind === 'well') {
-            score += nearbyZoneScore(ZONES.FARM, cx, cy, 4) * 2.2;
-            score += fertileScore(cx, cy, 1) * 0.2;
-          }
-          if (kind === 'storage') {
-            score += nearbyZoneScore(ZONES.CUT, cx, cy, 4) * 1.1;
-            score += nearbyZoneScore(ZONES.MINE, cx, cy, 4) * 1.1;
-            score += resourceDensity('wood', cx, cy, 2) * 0.05;
-            score += resourceDensity('stone', cx, cy, 2) * 0.06;
-          }
-          if (kind === 'hunterLodge') {
-            score += wildlifeDensity(cx, cy, 6) * 0.45;
-            score += resourceDensity('wood', cx, cy, 2) * 0.08;
-            score += nearbyZoneScore(ZONES.FARM, cx, cy, 4) * -0.2;
-          }
+          let score = -baseDist + perKindBonus(kind, cx, cy);
 
           if (score > bestScore - 4) {
             const path = pathfind(anchorTx, anchorTy, Math.round(cx), Math.round(cy), Math.max(140, maxRadius * 8));
@@ -252,10 +267,61 @@ export function createPlanner(opts) {
     if (!reachableFound && maxRadius < Math.max(GRID_W, GRID_H)) {
       const nextRadius = Math.min(Math.max(GRID_W, GRID_H), maxRadius + 8);
       if (nextRadius > maxRadius) {
-        return findPlacementNear(kind, anchorX, anchorY, nextRadius, { ...context, expanded: true });
+        return legacyFindPlacementNear(kind, anchorX, anchorY, nextRadius, { ...context, expanded: true });
       }
     }
     return reachableFound ? best : null;
+  }
+
+  function placeInSlot(kind, slot, anchorX, anchorY) {
+    const fp = getFootprint(kind);
+    const sx = slot.footprint.x;
+    const sy = slot.footprint.y;
+    const sw = slot.footprint.w;
+    const sh = slot.footprint.h;
+    const minX = Math.max(0, sx);
+    const maxX = Math.min(GRID_W - fp.w, sx + sw - fp.w);
+    const minY = Math.max(0, sy);
+    const maxY = Math.min(GRID_H - fp.h, sy + sh - fp.h);
+    if (minX > maxX || minY > maxY) return null;
+    const slotCx = sx + sw / 2;
+    const slotCy = sy + sh / 2;
+    const anchorTx = Math.round(anchorX);
+    const anchorTy = Math.round(anchorY);
+
+    let best = null, bestScore = -Infinity;
+    let reachable = false;
+    for (let y = minY; y <= maxY; y++) {
+      for (let x = minX; x <= maxX; x++) {
+        if (validateFootprintPlacement(kind, x, y) !== null) continue;
+        const cx = x + (fp.w - 1) / 2;
+        const cy = y + (fp.h - 1) / 2;
+        const slotDist = Math.abs(cx - slotCx) + Math.abs(cy - slotCy);
+        let score = -slotDist + perKindBonus(kind, cx, cy);
+        const path = pathfind(anchorTx, anchorTy, Math.round(cx), Math.round(cy), 200);
+        if (!path) continue;
+        reachable = true;
+        score -= path.length * 0.35;
+        if (score > bestScore) { bestScore = score; best = { x, y }; }
+      }
+    }
+    return reachable ? best : null;
+  }
+
+  function findPlacementNear(kind, anchorX, anchorY, maxRadius = 18, context = {}) {
+    const layout = state.world?.layout;
+    if (layout) {
+      const slot = findSlotForKind(layout, kind);
+      if (slot) {
+        const placed = placeInSlot(kind, slot, anchorX, anchorY);
+        if (placed) {
+          const used = layout.occupancy.get(slot.id) || 0;
+          layout.occupancy.set(slot.id, used + 1);
+          return placed;
+        }
+      }
+    }
+    return legacyFindPlacementNear(kind, anchorX, anchorY, maxRadius, context);
   }
 
   function ensureZoneCoverage(zone, targetTiles, anchor, radius = 0) {
@@ -605,6 +671,12 @@ export function createPlanner(opts) {
     const villagers = state.units.villagers;
     const animals = state.units.animals;
     if (!world) return false;
+    // Phase 1: rebuild slot occupancy from the live buildings list before
+    // running placement logic, so claims survive across save/load and stay in
+    // sync if a building is destroyed elsewhere.
+    if (world.layout) {
+      recomputeOccupancy(world.layout, state.units.buildings, policy?.layout);
+    }
     const anchor = findPrimaryAnchor();
     const villagerCount = Math.max(1, villagers.length || 0);
     let placed = false;
@@ -1061,5 +1133,7 @@ export function createPlanner(opts) {
     // Phase 11 (B13): exposed for targeted resource-bookkeeping tests.
     _applyProgressionPlanner: applyProgressionPlanner,
     _progressionMemory: progressionMemory,
+    // Phase 1: exposed so tests can validate slot-aware placement directly.
+    _findPlacementNear: findPlacementNear,
   };
 }

--- a/src/app/render.js
+++ b/src/app/render.js
@@ -676,6 +676,59 @@ export function createRenderSystem(deps) {
     ctx.drawImage(canvas, 0, 0, canvas.width, canvas.height, baseDx, baseDy, destW, destH);
   }
 
+  // Phase 1 — debug-only overlay. Each slot family gets a distinct hue so the
+  // archetype is readable at a glance; anchor markers reuse the slot color so
+  // a slot and its anchor read as a pair.
+  const SLOT_FAMILY_COLORS = {
+    hearth: 'rgba(255, 130, 70, 0.5)',
+    storage: 'rgba(180, 140, 80, 0.5)',
+    housing: 'rgba(120, 200, 255, 0.45)',
+    craft: 'rgba(220, 100, 200, 0.45)',
+    fields: 'rgba(150, 220, 120, 0.45)',
+    wells: 'rgba(80, 160, 220, 0.5)'
+  };
+
+  function drawLayoutOverlay(layout, camState) {
+    const ctx = getCtx();
+    if (!ctx || !layout || !Array.isArray(layout.slots)) return;
+    const occ = layout.occupancy;
+    ctx.save();
+    ctx.lineWidth = Math.max(1, camState.z);
+    for (const slot of layout.slots) {
+      if (!slot || !slot.footprint) continue;
+      const fp = slot.footprint;
+      const x = tileToPxX(fp.x, camState);
+      const y = tileToPxY(fp.y, camState);
+      const w = fp.w * TILE * camState.z;
+      const h = fp.h * TILE * camState.z;
+      const color = SLOT_FAMILY_COLORS[slot.family] || 'rgba(220, 220, 220, 0.4)';
+      ctx.strokeStyle = color;
+      ctx.fillStyle = color.replace(/, [\d.]+\)$/, ', 0.10)');
+      ctx.fillRect(x, y, w, h);
+      ctx.strokeRect(x, y, w, h);
+      const usedRaw = occ instanceof Map ? (occ.get(slot.id) || 0) : (occ?.[slot.id] || 0);
+      ctx.fillStyle = '#0a0c10';
+      ctx.font = `${Math.max(8, Math.round(8 * camState.z))}px system-ui, sans-serif`;
+      ctx.fillText(`${slot.id} ${usedRaw}/${slot.capacity}`, x + 2, y + Math.max(10, 10 * camState.z));
+    }
+    if (layout.anchors) {
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.85)';
+      ctx.lineWidth = Math.max(1, camState.z * 0.6);
+      for (const name of Object.keys(layout.anchors)) {
+        const a = layout.anchors[name];
+        if (!a) continue;
+        const ax = tileToPxX(a.x + 0.5, camState);
+        const ay = tileToPxY(a.y + 0.5, camState);
+        const r = Math.max(2, 3 * camState.z);
+        ctx.beginPath();
+        ctx.moveTo(ax - r, ay); ctx.lineTo(ax + r, ay);
+        ctx.moveTo(ax, ay - r); ctx.lineTo(ax, ay + r);
+        ctx.stroke();
+      }
+    }
+    ctx.restore();
+  }
+
   function ensureWaterOverlayCanvas() {
     const W = getViewportW();
     const H = getViewportH();
@@ -1608,6 +1661,13 @@ export function createRenderSystem(deps) {
       }
 
       drawFireflies(season, tick, vis, ambient);
+      // Phase 1: optional slot/anchor overlay. Toggled via the DebugKit tray's
+      // "Show slots" checkbox, which sets window.AIV_DEBUG_SLOTS. Draws each
+      // slot footprint as a translucent rectangle and each named anchor as a
+      // small cross — purely additive, no impact when the flag is off.
+      if (typeof window !== 'undefined' && window.AIV_DEBUG_SLOTS && world.layout) {
+        drawLayoutOverlay(world.layout, cam);
+      }
       drawPostFx();
       drawQueuedVillagerLabels(ambient);
 

--- a/src/policy/policy.js
+++ b/src/policy/policy.js
@@ -136,6 +136,33 @@ const DEFAULT_PROGRESSION = Object.freeze({
   tiers: DEFAULT_PROGRESS_TIERS
 });
 
+// Phase 1 — settlement layout templates. `archetypeWeights` and `terrainBias`
+// feed `chooseArchetype` in src/app/layout.js; `kindToSlotFamily` and
+// `slotCapacities` are the contract `findSlotForKind` consults to route a
+// building kind into a slot. Verbose archetype geometry (per-archetype slot
+// footprints) lives in layout.js — this block holds tuning knobs only.
+const DEFAULT_LAYOUT = Object.freeze({
+  archetypeWeights: { radial: 1, ribbon: 1, terrace: 1, courtyard: 1 },
+  terrainBias: { waterToRibbon: 2, slopeToTerrace: 2, openToCourtyard: 1.5 },
+  jitterAmplitude: 0.15,
+  kindToSlotFamily: {
+    campfire: ['hearth'],
+    storage: ['storage'],
+    hut: ['housing'],
+    hunterLodge: ['craft'],
+    farmplot: ['fields'],
+    well: ['wells', 'fields']
+  },
+  slotCapacities: {
+    hearth: 1,
+    storage: 1,
+    housing: 3,
+    craft: 2,
+    fields: 4,
+    wells: 1
+  }
+});
+
 export const policy = {
   state: null,
   sliders: { ...DEFAULT_SLIDERS },
@@ -168,5 +195,6 @@ export const policy = {
     hunger: { ...DEFAULT_HUNGER_THRESHOLDS },
     jobCreation: { ...DEFAULT_JOB_CREATION }
   },
-  progression: { ...DEFAULT_PROGRESSION }
+  progression: { ...DEFAULT_PROGRESSION },
+  layout: { ...DEFAULT_LAYOUT }
 };

--- a/tests/planner.layoutArchetype.phase1.test.js
+++ b/tests/planner.layoutArchetype.phase1.test.js
@@ -1,0 +1,241 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// Phase 1 — Settlement layout templates.
+//
+// These tests lock in the contract from AI_VILLAGE_PLAN.md Phase 1:
+//   1. Same seed + same terrain → identical archetype + slot table.
+//   2. Different terrain shapes → different archetypes (radial / ribbon /
+//      terrace / courtyard) AND visibly different anchor positions.
+//   3. The planner's findPlacementNear routes each of the 6 building kinds
+//      into its slot's footprint (the within-slot scoring is the tie-breaker,
+//      not the layout selector).
+//   4. SAVE_VERSION bumped to 8 with a no-op v7 migration entry.
+
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = { getElementById: () => ({ getContext: () => ({ imageSmoothingEnabled: true }), getBoundingClientRect: () => ({ width: 800, height: 600 }), style: {}, width: 0, height: 0 }) };
+  }
+  if (!globalThis.window) globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  if (!globalThis.AIV_TERRAIN) globalThis.AIV_TERRAIN = { generateTerrain: () => ({}), makeHillshade: () => new Uint8ClampedArray(0) };
+  if (!globalThis.AIV_CONFIG) globalThis.AIV_CONFIG = { WORLDGEN_DEFAULTS: {}, SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 } };
+}
+ensureBrowserStubs();
+
+const { buildLayout, chooseArchetype, analyzeTerrain, findSlotForKind, recomputeOccupancy } = await import('../src/app/layout.js');
+const { GRID_W, GRID_H, TILES, SAVE_VERSION, SAVE_MIGRATIONS } = await import('../src/app/constants.js');
+const { createPlanner } = await import('../src/app/planner.js');
+const { policy } = await import('../src/policy/policy.js');
+
+const N = GRID_W * GRID_H;
+
+function blankWorld() {
+  return {
+    seed: 0,
+    tiles: new Uint8Array(N).fill(TILES.GRASS),
+    trees: new Uint8Array(N),
+    rocks: new Uint8Array(N),
+    berries: new Uint8Array(N),
+    growth: new Uint8Array(N),
+    zone: new Uint8Array(N),
+    width: GRID_W,
+    height: GRID_H,
+    aux: {}
+  };
+}
+
+function withWaterNorth() {
+  const w = blankWorld();
+  // Lay a water band across the north sixth of the map. dominantWaterSide
+  // requires ≥2% of the map to be water and ≥40% of those tiles in the
+  // dominant quadrant — a single-band stripe in the north satisfies both.
+  for (let y = 0; y < Math.floor(GRID_H / 6); y++) {
+    for (let x = 0; x < GRID_W; x++) {
+      w.tiles[y * GRID_W + x] = TILES.WATER;
+    }
+  }
+  return w;
+}
+
+function withDenseCenterTrees() {
+  const w = blankWorld();
+  const cx = (GRID_W / 2) | 0;
+  const cy = (GRID_H / 2) | 0;
+  for (let y = cy - 6; y <= cy + 6; y++) {
+    for (let x = cx - 6; x <= cx + 6; x++) {
+      w.trees[y * GRID_W + x] = 1;
+    }
+  }
+  return w;
+}
+
+function withSlope() {
+  const w = blankWorld();
+  // Linear height ramp 0 → 250 across the map. analyzeTerrain reads
+  // (max - min) / 255 as the slope strength, so this lands at ~0.98.
+  const h = new Uint8Array(N);
+  for (let y = 0; y < GRID_H; y++) {
+    for (let x = 0; x < GRID_W; x++) {
+      h[y * GRID_W + x] = Math.min(255, Math.floor((y / GRID_H) * 250));
+    }
+  }
+  w.aux = { height: h };
+  return w;
+}
+
+test('Phase 1: chooseArchetype is deterministic for the same seed and features', () => {
+  const w = blankWorld();
+  const features = analyzeTerrain(w);
+  const a = chooseArchetype(12345, features);
+  const b = chooseArchetype(12345, features);
+  assert.equal(a, b, 'same seed must yield same archetype');
+});
+
+test('Phase 1: buildLayout is byte-equal across runs with the same seed and world', () => {
+  const w1 = blankWorld();
+  const w2 = blankWorld();
+  const l1 = buildLayout(424242, w1);
+  const l2 = buildLayout(424242, w2);
+  // occupancy is a Map (not JSON-serializable in a stable way); compare the
+  // rest of the structure.
+  const stripped = (layout) => ({
+    archetype: layout.archetype,
+    origin: layout.origin,
+    anchors: layout.anchors,
+    slots: layout.slots,
+    features: layout.features
+  });
+  assert.equal(JSON.stringify(stripped(l1)), JSON.stringify(stripped(l2)));
+  assert.ok(l1.occupancy instanceof Map && l1.occupancy.size === 0);
+});
+
+test('Phase 1: terrain shape drives archetype — water→ribbon, dense center trees→radial, slope→terrace, open→courtyard', () => {
+  const ribbon = buildLayout(1, withWaterNorth());
+  const radial = buildLayout(2, withDenseCenterTrees());
+  const terrace = buildLayout(3, withSlope());
+  const courtyard = buildLayout(4, blankWorld());
+
+  assert.equal(ribbon.archetype, 'ribbon', `expected ribbon, got ${ribbon.archetype}`);
+  assert.equal(radial.archetype, 'radial', `expected radial, got ${radial.archetype}`);
+  assert.equal(terrace.archetype, 'terrace', `expected terrace, got ${terrace.archetype}`);
+  assert.equal(courtyard.archetype, 'courtyard', `expected courtyard, got ${courtyard.archetype}`);
+
+  // Anchor-position divergence: at least three of the four archetypes must
+  // differ from one another in the hearth + storage + craft anchors. This is
+  // the "slot-position diff > threshold" check from the acceptance criteria.
+  const all = [ribbon, radial, terrace, courtyard];
+  const anchorSig = (l) => {
+    const keys = ['hearth', 'storage-main', 'craft', 'fields-1'];
+    return keys.map((k) => `${k}:${l.anchors[k].x},${l.anchors[k].y}`).join('|');
+  };
+  const sigs = new Set(all.map(anchorSig));
+  assert.ok(sigs.size >= 3, `expected >=3 distinct anchor signatures, got ${sigs.size}`);
+});
+
+test('Phase 1: every archetype emits the full slot family set used by all 6 building kinds', () => {
+  const layouts = [
+    buildLayout(1, withWaterNorth()),
+    buildLayout(2, withDenseCenterTrees()),
+    buildLayout(3, withSlope()),
+    buildLayout(4, blankWorld())
+  ];
+  const requiredFamilies = ['hearth', 'storage', 'housing', 'craft', 'fields', 'wells'];
+  for (const layout of layouts) {
+    const families = new Set(layout.slots.map((s) => s.family));
+    for (const family of requiredFamilies) {
+      assert.ok(families.has(family), `${layout.archetype} missing family ${family}`);
+    }
+  }
+});
+
+test('Phase 1: findSlotForKind routes each of the 6 building kinds into a slot whose kindAffinity matches', () => {
+  const layout = buildLayout(2, withDenseCenterTrees());
+  const kinds = ['campfire', 'storage', 'hut', 'hunterLodge', 'farmplot', 'well'];
+  for (const kind of kinds) {
+    const slot = findSlotForKind(layout, kind);
+    assert.ok(slot, `findSlotForKind(${kind}) returned null`);
+    assert.ok(slot.kindAffinity.includes(kind),
+      `slot ${slot.id} (${slot.family}) does not list ${kind} in kindAffinity`);
+  }
+});
+
+test('Phase 1: planner._findPlacementNear places each kind inside its slot footprint', () => {
+  const world = blankWorld();
+  const layout = buildLayout(99, world);
+  world.layout = layout;
+
+  const buildings = [];
+  const state = {
+    units: { buildings, jobs: [], villagers: [{ id: 1, x: layout.origin.x, y: layout.origin.y }], animals: [] },
+    stocks: { totals: { food: 0, wood: 100, stone: 50 }, reserved: {} },
+    time: { tick: 1 },
+    world,
+    bb: { villagers: 1, availableFood: 10, availableWood: 100, availableStone: 50 }
+  };
+  const noop = () => {};
+  const planner = createPlanner({
+    state,
+    policy,
+    pathfind: () => [{ x: 0, y: 0 }],
+    addJob: noop,
+    hasSimilarJob: () => false,
+    noteJobRemoved: noop,
+    requestBuildHauls: noop,
+    countBuildingsByKind: (k) => ({ total: buildings.filter((b) => b.kind === k).length, built: 0 }),
+    ensureBlackboardSnapshot: () => state.bb,
+    getJobCreationConfig: () => ({}),
+    violatesSpacing: () => false,
+    zoneCanEverWork: () => true,
+    zoneHasWorkNow: () => false,
+    updateZoneRow: noop,
+    markZoneOverlayDirty: noop,
+    markStaticDirty: noop,
+    availableToReserve: (r) => state.stocks.totals[r] || 0,
+    reserveMaterials: () => true,
+    releaseReservedMaterials: noop,
+    addBuilding: noop,
+    Toast: { show: noop },
+    toTile: (n) => n | 0
+  });
+
+  const kinds = ['campfire', 'storage', 'hut', 'hunterLodge', 'farmplot', 'well'];
+  for (const kind of kinds) {
+    // Reset occupancy for each kind so we always probe the first eligible
+    // slot. Capture the expected slot BEFORE the placement call, since the
+    // call increments occupancy and may exhaust capacity-1 slots like
+    // hearth/storage.
+    layout.occupancy.clear();
+    const slot = findSlotForKind(layout, kind);
+    assert.ok(slot, `no slot for ${kind}`);
+    const fp = slot.footprint;
+    const pos = planner._findPlacementNear(kind, layout.origin.x, layout.origin.y, 18);
+    assert.ok(pos, `findPlacementNear(${kind}) returned null`);
+    assert.ok(
+      pos.x >= fp.x && pos.x < fp.x + fp.w && pos.y >= fp.y && pos.y < fp.y + fp.h,
+      `${kind} placed at (${pos.x},${pos.y}) is outside slot ${slot.id} fp=(${fp.x},${fp.y},${fp.w}x${fp.h})`
+    );
+  }
+});
+
+test('Phase 1: recomputeOccupancy rebuilds the occupancy map from a live buildings list', () => {
+  const world = blankWorld();
+  const layout = buildLayout(7, world);
+  const housingSlot = layout.slots.find((s) => s.family === 'housing');
+  assert.ok(housingSlot, 'expected at least one housing slot');
+  // Drop two huts inside the housing slot — their footprint must overlap it.
+  const buildings = [
+    { kind: 'hut', x: housingSlot.footprint.x, y: housingSlot.footprint.y },
+    { kind: 'hut', x: housingSlot.footprint.x + 2, y: housingSlot.footprint.y }
+  ];
+  recomputeOccupancy(layout, buildings, policy.layout);
+  assert.equal(layout.occupancy.get(housingSlot.id), 2,
+    `housing slot ${housingSlot.id} should report occupancy=2, got ${layout.occupancy.get(housingSlot.id)}`);
+});
+
+test('Phase 1: SAVE_VERSION is 8 and SAVE_MIGRATIONS exposes a no-op entry for v7→v8', () => {
+  assert.equal(SAVE_VERSION, 8, 'SAVE_VERSION must be bumped to 8 for the layout addition');
+  const migrate7 = SAVE_MIGRATIONS.get(7);
+  assert.equal(typeof migrate7, 'function', 'v7→v8 migration entry must exist');
+  const probe = { foo: 'bar' };
+  assert.deepEqual(migrate7(probe), probe, 'v7→v8 migration must be a pure no-op');
+});

--- a/tests/save.layoutMigration.phase1.test.js
+++ b/tests/save.layoutMigration.phase1.test.js
@@ -1,0 +1,165 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// Phase 1 — settlement layout templates. Layout is a pure function of seed +
+// terrain and is recomputed at world-gen time, so SAVE_VERSION bumps to 8
+// without persisting any new fields. The migration entry for v7→v8 is a
+// no-op; the loader's job is just to not crash on older saves and let
+// generateWorldBase rebuild the layout from the restored seed.
+
+const mem = new Map();
+globalThis.localStorage = {
+  getItem: (k) => (mem.has(k) ? mem.get(k) : null),
+  setItem: (k, v) => { mem.set(k, String(v)); },
+  removeItem: (k) => { mem.delete(k); },
+  clear: () => { mem.clear(); }
+};
+
+const { createSaveSystem } = await import('../src/app/save.js');
+const { GRID_W, GRID_H, SAVE_KEY, SAVE_VERSION, SAVE_MIGRATIONS, TILES } = await import('../src/app/constants.js');
+const { buildLayout } = await import('../src/app/layout.js');
+
+function makeWorld() {
+  const n = GRID_W * GRID_H;
+  return {
+    seed: 1,
+    season: 0,
+    tSeason: 0,
+    tiles: new Uint8Array(n).fill(TILES.GRASS),
+    zone: new Uint8Array(n),
+    trees: new Uint8Array(n),
+    rocks: new Uint8Array(n),
+    berries: new Uint8Array(n),
+    growth: new Uint16Array(n),
+    width: GRID_W,
+    height: GRID_H,
+    aux: {}
+  };
+}
+
+function makeSystem() {
+  let tick = 0;
+  let dayTime = 0;
+  const world = makeWorld();
+  const buildings = [];
+  const villagers = [];
+  const animals = [];
+  const storageTotals = {};
+  const storageReserved = {};
+  let regenCount = 0;
+
+  const deps = {
+    getWorld: () => world,
+    getBuildings: () => buildings,
+    getVillagers: () => villagers,
+    getAnimals: () => animals,
+    getStorageTotals: () => storageTotals,
+    getStorageReserved: () => storageReserved,
+    getTick: () => tick,
+    getDayTime: () => dayTime,
+    setTick: (v) => { tick = Number.isFinite(v) ? v | 0 : 0; },
+    setDayTime: (v) => { dayTime = Number.isFinite(v) ? v | 0 : 0; },
+    starveThresh: { hungry: 0.4, starving: 0.8, sick: 1.18 },
+    childhoodTicks: 1000,
+    ensureVillagerNumber: (v, num) => {
+      if (Number.isFinite(num)) v.num = num;
+      else if (!Number.isFinite(v.num)) v.num = 1;
+      return v.num;
+    },
+    normalizeExperienceLedger: (xp) => xp || null,
+    normalizeArraySource: (src) => {
+      if (!src) return [];
+      if (Array.isArray(src)) return src;
+      if (typeof src.length === 'number') return Array.from(src);
+      return [];
+    },
+    applyArrayScaled: (dest, src, _factor, fill) => {
+      if (!dest || typeof dest.length !== 'number') return;
+      const fillVal = Number.isFinite(fill) ? fill : 0;
+      for (let i = 0; i < dest.length; i++) {
+        dest[i] = i < src.length ? src[i] : fillVal;
+      }
+    },
+    generateWorldBase: (seed) => {
+      regenCount++;
+      // Mirror the production wiring: stamp a layout on the live world after
+      // terrain is restored, so loadGame leaves world.layout populated.
+      world.seed = Number.isFinite(seed) ? seed : world.seed;
+      world.layout = buildLayout(world.seed, world);
+    },
+    resetVolatileState: () => {},
+    syncTimeButtons: () => {},
+    getFootprint: () => ({ w: 1, h: 1 }),
+    ensureBuildingData: () => {},
+    reindexAllBuildings: () => {},
+    markEmittersDirty: () => {},
+    refreshWaterRowMaskFromTiles: () => {},
+    refreshZoneRowMask: () => {},
+    markZoneOverlayDirty: () => {},
+    markStaticDirty: () => {},
+    toast: { show: () => {} }
+  };
+
+  const sys = createSaveSystem(deps);
+  return { sys, world, getRegenCount: () => regenCount };
+}
+
+test('Phase 1: SAVE_VERSION is 8 and the v7 migration is a no-op', () => {
+  assert.equal(SAVE_VERSION, 8);
+  const m = SAVE_MIGRATIONS.get(7);
+  assert.equal(typeof m, 'function');
+  const probe = { saveVersion: 7, seed: 5 };
+  const out = m(probe);
+  assert.deepEqual(out, probe, 'v7→v8 migration must not mutate the save object');
+});
+
+test('Phase 1: loadGame applies migrations from older versions without crashing', () => {
+  mem.clear();
+  // Hand-craft a v6 save (post-Phase-8). Migrations 6→7 and 7→8 are both
+  // no-ops, so loadGame should walk them, regenerate the world (and its
+  // layout), and report success.
+  const fakeV6 = {
+    saveVersion: 6,
+    seed: 4242,
+    tick: 0,
+    dayTime: 0,
+    tiles: Array.from(new Uint8Array(GRID_W * GRID_H).fill(TILES.GRASS)),
+    zone: Array.from(new Uint8Array(GRID_W * GRID_H)),
+    trees: Array.from(new Uint8Array(GRID_W * GRID_H)),
+    rocks: Array.from(new Uint8Array(GRID_W * GRID_H)),
+    berries: Array.from(new Uint8Array(GRID_W * GRID_H)),
+    growth: Array.from(new Uint8Array(GRID_W * GRID_H)),
+    season: 0,
+    tSeason: 0,
+    buildings: [],
+    storageTotals: { food: 12, wood: 0, stone: 0, bow: 0, pelt: 0 },
+    storageReserved: {},
+    villagers: [],
+    animals: []
+  };
+  globalThis.localStorage.setItem(SAVE_KEY, JSON.stringify(fakeV6));
+
+  const ctx = makeSystem();
+  const ok = ctx.sys.loadGame();
+  assert.equal(ok, true, 'loadGame must return true on a migratable older save');
+  assert.equal(ctx.getRegenCount(), 1, 'generateWorldBase must run exactly once on load');
+  assert.ok(ctx.world.layout, 'world.layout must be populated after load');
+  assert.ok(ctx.world.layout.archetype, 'layout.archetype must be set');
+});
+
+test('Phase 1: a v8 save round-trips with a freshly-rebuilt layout matching the seed', () => {
+  mem.clear();
+  const ctx1 = makeSystem();
+  // Seed the world directly so the save reflects a known archetype.
+  ctx1.world.seed = 91234;
+  ctx1.world.layout = buildLayout(91234, ctx1.world);
+  const archetypeBefore = ctx1.world.layout.archetype;
+  ctx1.sys.saveGame();
+
+  const ctx2 = makeSystem();
+  const ok = ctx2.sys.loadGame();
+  assert.equal(ok, true, 'loadGame must succeed on a v8 save');
+  assert.ok(ctx2.world.layout, 'layout must be rebuilt at load time');
+  assert.equal(ctx2.world.layout.archetype, archetypeBefore,
+    'rebuilt layout must select the same archetype for the same seed');
+});


### PR DESCRIPTION
Replace the implicit center-blob placement with an explicit archetype +
named-slot system. Each world now picks one of {radial, ribbon, terrace,
courtyard} from terrain features (water orientation, slope, tree density)
and stamps a parametric set of slot footprints. The planner's per-tile
scoring is preserved as the within-slot tie-breaker, so progression-tier
order is unchanged.

- src/app/layout.js: terrain analysis, deterministic archetype selection
  via mulberry32(seed) + terrain bias, slot tables for each archetype.
- src/app/planner.js: findPlacementNear delegates to a slot-aware path
  first, with the legacy radius search retained as a defensive fallback.
- src/app.js: generateWorldBase stamps world.layout; the campfire seeds
  from the hearth slot when a layout is present.
- src/app/constants.js: bump SAVE_VERSION 7→8 with a no-op v7 migration
  (layout is recomputed at world-gen, not persisted).
- src/policy/policy.js: DEFAULT_LAYOUT block (archetype weights, terrain
  bias, kind→slot family map, slot capacities).
- public/debugkit.js + src/app/debugkit.js + src/app/render.js: optional
  Settlement Layout debug section with a "Show slots" toggle that draws
  slot footprints and anchor crosses over the main render pass.
- tests/planner.layoutArchetype.phase1.test.js: determinism, terrain-
  driven archetype selection, slot routing for all 6 building kinds, and
  occupancy rebuild from a live buildings list.
- tests/save.layoutMigration.phase1.test.js: SAVE_VERSION bump, v7→v8
  no-op migration, v6 save loads cleanly, v8 round-trip rebuilds layout.

https://claude.ai/code/session_01AS68B8bwSjFh4VGwsWWX58