### PR TITLE
Make hunger gentler at night and add a peckish snack cue

### DIFF
--- a/src/app/population.js
+++ b/src/app/population.js
@@ -51,7 +51,7 @@ export function createPopulation(opts) {
       id: uid(),
       x, y,
       path: [],
-      hunger: rnd(0.2, 0.5),
+      hunger: rnd(0.05, 0.25),
       energy: rnd(0.5, 0.9),
       happy: rnd(0.4, 0.8),
       hydration: 0.7,
@@ -93,7 +93,7 @@ export function createPopulation(opts) {
     const v = newVillager(x, y);
     v.role = 'child';
     v.speed = 1.6 + rnd(-0.1, 0.1);
-    v.hunger = rnd(0.1, 0.3);
+    v.hunger = rnd(0.05, 0.15);
     v.energy = rnd(0.55, 0.85);
     v.happy = rnd(0.45, 0.85);
     v.lifeStage = 'child';

--- a/src/app/villagerAI.js
+++ b/src/app/villagerAI.js
@@ -15,7 +15,10 @@ import { score as scoreJob, computeFamineSeverity } from '../ai/scoring.js';
 
 // Single source of truth for villager-tuning constants. villagerTick.js,
 // onArrive.js, and this module all read from here.
-export const STARVE_THRESH = { hungry: 0.82, starving: 1.08, sick: 1.18 };
+// `peckish` is a soft pre-stage-1 cue: villagers carrying food snack from
+// their pack once hunger crosses this so they don't slide into stage 1's
+// energy/mood drain. It deliberately does not trigger camp-storage runs.
+export const STARVE_THRESH = { peckish: 0.60, hungry: 0.82, starving: 1.08, sick: 1.18 };
 export const STARVE_COLLAPSE_TICKS = 140;
 export const STARVE_RECOVERY_TICKS = 280;
 export const STARVE_TOAST_COOLDOWN = 420;

--- a/src/app/villagerTick.js
+++ b/src/app/villagerTick.js
@@ -9,7 +9,7 @@ import {
   moodThought,
   seasonalHungerMultiplier
 } from './simulation.js';
-import { DAY_LENGTH, HUNT_RANGE, HUNT_RETRY_COOLDOWN } from './constants.js';
+import { DAY_LENGTH, HUNT_RANGE, HUNT_RETRY_COOLDOWN, ITEM } from './constants.js';
 import { BUILDINGS } from './world.js';
 import { CHILDHOOD_TICKS } from './population.js';
 import {
@@ -34,6 +34,12 @@ const REST_ENERGY_RECOVERY = 0.0024;
 const REST_MOOD_TICK = 0.0009;
 const REST_FINISH_MOOD = 0.05;
 const REST_HUNGER_MULT = 0.42;
+// Metabolism slows overnight regardless of whether the villager is asleep —
+// a campfire socializer or a midnight forager still burns less than at noon.
+// Stacks multiplicatively with REST_HUNGER_MULT so deep sleep at night
+// (~0.27x) is the cheapest state, and an awake daytime worker (1.0x) the
+// most expensive. Tick-rate only; not persisted, not read by scoring.
+const NIGHT_HUNGER_MULT = 0.65;
 
 // Phase 10 (S10): tightened decay + dehydrated threshold so dry stretches
 // matter. The pre-Phase-10 0.00018/tick reached the visit threshold (0.46)
@@ -149,7 +155,12 @@ export function createVillagerTick(opts) {
     const dehydrated = v.hydration < HYDRATION_LOW;
     // Phase 9 (B4/S7): winter raises drain ~15%, summer dips slightly.
     const seasonalHungerMult = seasonalHungerMultiplier(state?.world?.season ?? 0);
-    const hungerRate = (resting ? HUNGER_RATE * REST_HUNGER_MULT : HUNGER_RATE) * (hydratedBuff ? HYDRATION_HUNGER_MULT : (dehydrated ? HYDRATION_DEHYDRATED_PENALTY : 1)) * seasonalHungerMult;
+    const restMult = resting ? REST_HUNGER_MULT : 1;
+    const nightMult = nightNow ? NIGHT_HUNGER_MULT : 1;
+    const hydrationMult = hydratedBuff
+      ? HYDRATION_HUNGER_MULT
+      : (dehydrated ? HYDRATION_DEHYDRATED_PENALTY : 1);
+    const hungerRate = HUNGER_RATE * restMult * nightMult * hydrationMult * seasonalHungerMult;
     v.hunger += hungerRate;
 
     const tileX = v.x | 0;
@@ -403,6 +414,15 @@ export function createVillagerTick(opts) {
           }
         }
       }
+    }
+
+    // Proactive snack: once hunger crosses the peckish threshold but before
+    // stage 1's energy/mood drain kicks in, eat from our pack only. We do
+    // NOT raid camp storage at this stage — that's reserved for needsFood
+    // below — to avoid storage thrashing on a soft cue.
+    if (stage === 0 && v.hunger > STARVE_THRESH.peckish
+        && v.inv && v.inv.type === ITEM.FOOD) {
+      if (consumeFood(v)) { v.thought = moodThought(v, 'Snacking'); return; }
     }
 
     if (urgentFood) {

--- a/tests/villager.hungerNight.test.js
+++ b/tests/villager.hungerNight.test.js
@@ -1,0 +1,205 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// villagerAI → simulation → environment asserts on AIV_TERRAIN / AIV_CONFIG
+// at module-load time; world.js → canvas.js touches `document` / `window`.
+// Mirror movement.speed.test.js's load-time stubs.
+function ensureBrowserStubs() {
+  if (!globalThis.document) {
+    globalThis.document = {
+      getElementById: () => ({
+        getContext: () => ({ imageSmoothingEnabled: true }),
+        getBoundingClientRect: () => ({ width: 800, height: 600 }),
+        style: {},
+        width: 0,
+        height: 0,
+      }),
+    };
+  }
+  if (!globalThis.window) {
+    globalThis.window = { devicePixelRatio: 1, addEventListener: () => {} };
+  }
+  if (!globalThis.AIV_TERRAIN) {
+    globalThis.AIV_TERRAIN = {
+      generateTerrain: () => ({}),
+      makeHillshade: () => new Uint8ClampedArray(0),
+    };
+  }
+  if (!globalThis.AIV_CONFIG) {
+    globalThis.AIV_CONFIG = {
+      WORLDGEN_DEFAULTS: {},
+      SHADING_DEFAULTS: { ambient: 0.5, intensity: 0.5, slopeScale: 1 },
+    };
+  }
+}
+ensureBrowserStubs();
+
+const {
+  createVillagerAI,
+  STARVE_THRESH,
+  FOOD_HUNGER_RECOVERY,
+} = await import('../src/app/villagerAI.js');
+const { ITEM } = await import('../src/app/constants.js');
+
+// Mirror of the rate calc at src/app/villagerTick.js:158-163. Tick-only
+// constants don't leave that module (project convention), so we replicate
+// the formula here to assert behavior without spinning up the 30-dep tick
+// state machine. Numeric constants must stay in sync with villagerTick.js.
+const HUNGER_RATE = 0.00095;
+const REST_HUNGER_MULT = 0.42;
+const NIGHT_HUNGER_MULT = 0.65;
+
+function computeHungerRate({ resting = false, nightNow = false } = {}) {
+  const restMult = resting ? REST_HUNGER_MULT : 1;
+  const nightMult = nightNow ? NIGHT_HUNGER_MULT : 1;
+  // hydration / season factors hold at 1 for these tests so we isolate the
+  // night and rest dimensions.
+  return HUNGER_RATE * restMult * nightMult;
+}
+
+// Mirror of the peckish gate at src/app/villagerTick.js:423-426. Pack-only
+// by design: storage runs are reserved for needsFood (stage>=1).
+function shouldSnackFromPack(v, stage) {
+  return stage === 0
+    && v.hunger > STARVE_THRESH.peckish
+    && !!v.inv
+    && v.inv.type === ITEM.FOOD;
+}
+
+function makeAI({ storageFood = 0 } = {}) {
+  const storageTotals = { food: storageFood, wood: 0, stone: 0 };
+  const state = {
+    units: { buildings: [], jobs: [], villagers: [], itemsOnGround: [] },
+    stocks: { totals: storageTotals, reserved: {} },
+    time: { tick: 100, dayTime: 1000 },
+    world: {},
+  };
+  const noop = () => {};
+  const ai = createVillagerAI({
+    state,
+    policy: { style: { jobScoring: {}, hunger: {}, jobCreation: {} }, sliders: {} },
+    pathfind: () => null,
+    passable: () => true,
+    Toast: { show: noop },
+    addJob: noop,
+    finishJob: (v) => { v.targetJob = null; },
+    noteJobAssignmentChanged: noop,
+    availableToReserve: () => 0,
+    reserveMaterials: () => true,
+    releaseReservedMaterials: noop,
+    findAnimalById: () => null,
+    findEntryTileNear: () => ({ x: 0, y: 0 }),
+    getBuildingById: () => null,
+    buildingsByKind: new Map(),
+    idx: () => 0,
+    ambientAt: () => 'day',
+    isNightTime: () => false,
+  });
+  return { ai, state, storageTotals };
+}
+
+function makeVillager(overrides = {}) {
+  return {
+    x: 0,
+    y: 0,
+    inv: null,
+    hunger: 0.5,
+    energy: 0.8,
+    happy: 0.7,
+    condition: 'normal',
+    starveStage: 0,
+    sickTimer: 0,
+    recoveryTimer: 0,
+    state: 'idle',
+    path: null,
+    targetJob: null,
+    nextStarveWarning: 0,
+    thought: '',
+    ...overrides,
+  };
+}
+
+test('night reduces hunger rate when awake', () => {
+  const day = computeHungerRate({ resting: false, nightNow: false });
+  const night = computeHungerRate({ resting: false, nightNow: true });
+  assert.ok(night < day, `night rate ${night} must be < day rate ${day}`);
+  assert.ok(night > 0, 'night rate must remain positive — villagers still get hungry');
+  assert.ok(
+    Math.abs(night - HUNGER_RATE * NIGHT_HUNGER_MULT) < 1e-12,
+    'night-awake rate must equal HUNGER_RATE * NIGHT_HUNGER_MULT'
+  );
+});
+
+test('night and rest stack to a deeper slowdown than rest alone', () => {
+  const restDay = computeHungerRate({ resting: true, nightNow: false });
+  const restNight = computeHungerRate({ resting: true, nightNow: true });
+  assert.ok(restNight < restDay, `rest+night ${restNight} must be < rest-only ${restDay}`);
+  assert.ok(restNight > 0, 'deep-sleep rate must remain positive');
+  assert.ok(
+    Math.abs(restNight - HUNGER_RATE * REST_HUNGER_MULT * NIGHT_HUNGER_MULT) < 1e-12,
+    'rest+night rate must equal product of all three factors'
+  );
+});
+
+test('peckish threshold sits between healthy and stage-1 hungry', () => {
+  assert.ok(
+    STARVE_THRESH.peckish < STARVE_THRESH.hungry,
+    `peckish ${STARVE_THRESH.peckish} must be strictly below hungry ${STARVE_THRESH.hungry}`
+  );
+  assert.ok(STARVE_THRESH.peckish > 0, 'peckish must be a real positive trigger');
+  // Margin big enough that a typical foraging round-trip can't blow through
+  // the proactive-snack window in one tick.
+  assert.ok(
+    STARVE_THRESH.hungry - STARVE_THRESH.peckish >= 0.15,
+    'peckish must leave room before stage 1'
+  );
+});
+
+test('snack predicate fires for stage-0 villager carrying food past peckish', () => {
+  const v = makeVillager({ hunger: 0.65, inv: { type: ITEM.FOOD, qty: 1 } });
+  assert.equal(shouldSnackFromPack(v, 0), true);
+});
+
+test('snack predicate does NOT fire when pack is empty (storage thrash guard)', () => {
+  const v = makeVillager({ hunger: 0.65, inv: null });
+  assert.equal(
+    shouldSnackFromPack(v, 0),
+    false,
+    'empty pack at peckish must not snack — storage runs are reserved for stage>=1'
+  );
+});
+
+test('snack predicate does NOT fire below the peckish threshold', () => {
+  const v = makeVillager({ hunger: STARVE_THRESH.peckish - 0.001, inv: { type: ITEM.FOOD } });
+  assert.equal(shouldSnackFromPack(v, 0), false);
+});
+
+test('snack predicate does NOT fire once already at stage 1', () => {
+  // Once stage>=1 the existing needsFood branch handles eating (incl.
+  // storage). The peckish gate exists only to act *before* stage 1.
+  const v = makeVillager({ hunger: 0.85, inv: { type: ITEM.FOOD } });
+  assert.equal(shouldSnackFromPack(v, 1), false);
+});
+
+test('stage-0 peckish snack from pack: eats from inv, leaves storage alone, no recovery armed', () => {
+  // This locks down the B7 invariant for the new branch: a healthy
+  // peckish snack must NOT arm recoveryTimer (which would be wrong — the
+  // villager isn't recovering from anything).
+  const { ai, storageTotals } = makeAI({ storageFood: 5 });
+  const v = makeVillager({
+    hunger: 0.65,
+    starveStage: 0,
+    condition: 'normal',
+    inv: { type: ITEM.FOOD, qty: 1 },
+  });
+  const ate = ai.consumeFood(v);
+  assert.equal(ate, true, 'consumeFood must succeed when pack has food');
+  assert.equal(v.inv, null, 'pack food must be consumed');
+  assert.equal(storageTotals.food, 5, 'storage must be untouched (pack-priority)');
+  assert.equal(v.condition, 'normal', 'stage-0 meal must not change condition');
+  assert.equal(v.recoveryTimer, 0, 'stage-0 meal must NOT arm the recovery timer');
+  assert.ok(
+    Math.abs(v.hunger - Math.max(0, 0.65 - FOOD_HUNGER_RECOVERY)) < 1e-9,
+    `hunger should drop by FOOD_HUNGER_RECOVERY (clamped at 0); got ${v.hunger}`
+  );
+});


### PR DESCRIPTION
Villagers were starving very early in fresh worlds: spawn hunger averaged
0.35, the slowdown only kicked in while resting, and eating only triggered
at stage 1 — exactly when the energy-drain penalty begins.

- Add NIGHT_HUNGER_MULT (0.65) so metabolism slows after dark even while
  awake; stacks multiplicatively with REST_HUNGER_MULT for deep-sleep
  conservation (~0.27x).
- Add STARVE_THRESH.peckish (0.60): once stage-0 hunger crosses this,
  villagers carrying food snack from their pack (no storage runs) so they
  don't slide into the stage-1 energy/mood penalty.
- Lower spawn hunger: adults rnd(0.05, 0.25), children rnd(0.05, 0.15) —
  villagers wake up well-fed.

No save schema change. New tests cover the night rate, night×rest stacking,
peckish threshold ordering, the snack predicate gating, and the B7 invariant
(stage-0 meals must not arm recoveryTimer).

https://claude.ai/code/session_019wvuP8n2gB62JMLgqZYqZL