### PR TITLE
Enhance day/night visuals with phase-aware color grading

### DIFF
--- a/src/app/lighting.js
+++ b/src/app/lighting.js
@@ -1,3 +1,4 @@
+import { DAY_LENGTH } from './constants.js';
 import { SHADING_DEFAULTS } from './environment.js';
 
 const LIGHTING = {
@@ -5,9 +6,9 @@ const LIGHTING = {
   useMultiplyComposite: true,
   lightmapScale: 0.25,
   uiMinLight: 0.94,
-  exposure: 1.0,
-  nightFloor: 0.32,
-  lightCap: 1.40,
+  exposure: 1.08,
+  nightFloor: 0.38,
+  lightCap: 1.45,
   softLights: true,
   debugShowLightmap: false
 };
@@ -22,10 +23,14 @@ const clamp01 = (value) => {
 // Lightmap color grading. The lightmap composites with 'multiply', so these
 // tints are channel scalars in [0, 1] applied to the greyscale brightness.
 // A value below 1 attenuates that channel (cools when r/g drop, warms when
-// b drops). Picked to read as cozy-sim atmosphere rather than a colored
-// filter — every tint stays close to neutral.
-const NIGHT_TINT = Object.freeze({ r: 0.66, g: 0.78, b: 1.00 });
-const DAWN_DUSK_TINT = Object.freeze({ r: 1.00, g: 0.92, b: 0.78 });
+// b drops). Dawn and dusk are split so morning reads as pale gold and
+// evening reads as deeper amber; deep night pushes further blue than the
+// dawn/dusk shoulders.
+const NIGHT_TINT = Object.freeze({ r: 0.58, g: 0.70, b: 1.00 });
+const DEEP_NIGHT_TINT = Object.freeze({ r: 0.48, g: 0.62, b: 1.00 });
+const DAWN_TINT = Object.freeze({ r: 1.00, g: 0.86, b: 0.66 });
+const DUSK_TINT = Object.freeze({ r: 1.00, g: 0.76, b: 0.54 });
+const DAY_TINT = Object.freeze({ r: 1.00, g: 0.99, b: 0.94 });
 const NEUTRAL_TINT = Object.freeze({ r: 1.00, g: 1.00, b: 1.00 });
 
 function lerp(a, b, t) { return a + (b - a) * t; }
@@ -38,21 +43,44 @@ function lerpTint(a, b, t) {
   };
 }
 
-// gradeLightmap maps the scalar ambient into a per-channel multiplier:
-//   ambient < 0.40  : night → neutral
-//   0.40 ≤ a < 0.55 : neutral → dawn/dusk warm
-//   0.55 ≤ a < 0.85 : warm → neutral
-//   ambient ≥ 0.85  : neutral daylight
-function gradeLightmap(ambient) {
+// timePhase wraps dayTime into [0, 1) so we can split the warm shoulder
+// into morning (dawn) vs. evening (dusk). The first half of the cycle is
+// morning; the second half is evening.
+function timePhase(dayTime) {
+  if (!Number.isFinite(dayTime)) return null;
+  return ((dayTime % DAY_LENGTH) + DAY_LENGTH) % DAY_LENGTH / DAY_LENGTH;
+}
+
+function isMorningPhase(phase) {
+  return phase < 0.5;
+}
+
+// gradeLightmap maps ambient → per-channel multiplier with five bands:
+//   ambient < 0.28  : deep blue night → cooler night
+//   0.28 ≤ a < 0.42 : night → warm shoulder (dawn or dusk)
+//   0.42 ≤ a < 0.62 : warm shoulder → soft daylight
+//   0.62 ≤ a < 0.92 : soft daylight → neutral
+//   ambient ≥ 0.92  : neutral daylight
+// dayTime selects DAWN_TINT before midday and DUSK_TINT after.
+function gradeLightmap(ambient, dayTime = null) {
   const a = clamp01(ambient);
-  if (a < 0.40) {
-    return lerpTint(NIGHT_TINT, NEUTRAL_TINT, a / 0.40);
+  const phase = timePhase(dayTime);
+  const warmTint = phase == null || isMorningPhase(phase) ? DAWN_TINT : DUSK_TINT;
+  // Deep blue night.
+  if (a < 0.28) {
+    return lerpTint(DEEP_NIGHT_TINT, NIGHT_TINT, a / 0.28);
   }
-  if (a < 0.55) {
-    return lerpTint(NEUTRAL_TINT, DAWN_DUSK_TINT, (a - 0.40) / 0.15);
+  // Night fading into dawn/dusk.
+  if (a < 0.42) {
+    return lerpTint(NIGHT_TINT, warmTint, (a - 0.28) / 0.14);
   }
-  if (a < 0.85) {
-    return lerpTint(DAWN_DUSK_TINT, NEUTRAL_TINT, (a - 0.55) / 0.30);
+  // Warm dawn/dusk.
+  if (a < 0.62) {
+    return lerpTint(warmTint, DAY_TINT, (a - 0.42) / 0.20);
+  }
+  // Long readable daylight.
+  if (a < 0.92) {
+    return lerpTint(DAY_TINT, NEUTRAL_TINT, (a - 0.62) / 0.30);
   }
   return { ...NEUTRAL_TINT };
 }
@@ -107,7 +135,10 @@ function makeAltitudeShade(height, w, h, cfg = SHADING_DEFAULTS) {
 
 export {
   clamp01,
-  DAWN_DUSK_TINT,
+  DAWN_TINT,
+  DAY_TINT,
+  DEEP_NIGHT_TINT,
+  DUSK_TINT,
   gradeLightmap,
   LIGHTING,
   makeAltitudeShade,

--- a/src/app/render.js
+++ b/src/app/render.js
@@ -427,7 +427,7 @@ export function createRenderSystem(deps) {
     // Per-channel tint shifts the lightmap's neutral grey toward warm at
     // dawn/dusk and cool blue at night. The multiply composite carries the
     // tint across the whole scene, so this is the cheapest place to grade.
-    const tint = gradeLightmap(ambient);
+    const tint = gradeLightmap(ambient, targetWorld.dayTime);
     const data = img.data;
     for (let i = 0, p = 0; i < length; i++, p += 4) {
       const v = Math.max(0, Math.min(1, Lq[i]));

--- a/src/app/simulation.js
+++ b/src/app/simulation.js
@@ -3,8 +3,8 @@ import { DAYTIME_PORTION, NIGHTTIME_PORTION } from './environment.js';
 import { LIGHTING, clamp01 } from './lighting.js';
 import { clamp } from './rng.js';
 
-export const NIGHT_AMBIENT_THRESHOLD = 0.6;
-export const DAWN_AMBIENT_THRESHOLD = 0.68;
+export const NIGHT_AMBIENT_THRESHOLD = 0.42;
+export const DAWN_AMBIENT_THRESHOLD = 0.58;
 
 export const JOB_EXPERIENCE_MAP = Object.freeze({
   sow: 'farming',

--- a/tests/lighting.grading.test.js
+++ b/tests/lighting.grading.test.js
@@ -21,17 +21,31 @@ function ensureBrowserStubs() {
 ensureBrowserStubs();
 
 const {
-  DAWN_DUSK_TINT,
+  DAWN_TINT,
+  DAY_TINT,
+  DEEP_NIGHT_TINT,
+  DUSK_TINT,
   NEUTRAL_TINT,
   NIGHT_TINT,
   gradeLightmap
 } = await import('../src/app/lighting.js');
+const { DAY_LENGTH } = await import('../src/app/constants.js');
 
-test('gradeLightmap returns night tint at deep night', () => {
+const morningTime = DAY_LENGTH * 0.25;
+const eveningTime = DAY_LENGTH * 0.75;
+
+test('gradeLightmap returns deep night tint at ambient 0', () => {
   const t = gradeLightmap(0);
-  assert.equal(t.r, NIGHT_TINT.r);
-  assert.equal(t.g, NIGHT_TINT.g);
-  assert.equal(t.b, NIGHT_TINT.b);
+  assert.equal(t.r, DEEP_NIGHT_TINT.r);
+  assert.equal(t.g, DEEP_NIGHT_TINT.g);
+  assert.equal(t.b, DEEP_NIGHT_TINT.b);
+});
+
+test('gradeLightmap returns night tint at the deep-night/night seam', () => {
+  const t = gradeLightmap(0.28);
+  assert.ok(Math.abs(t.r - NIGHT_TINT.r) < 1e-6);
+  assert.ok(Math.abs(t.g - NIGHT_TINT.g) < 1e-6);
+  assert.ok(Math.abs(t.b - NIGHT_TINT.b) < 1e-6);
 });
 
 test('gradeLightmap returns neutral at full daylight', () => {
@@ -41,32 +55,55 @@ test('gradeLightmap returns neutral at full daylight', () => {
   assert.equal(t.b, NEUTRAL_TINT.b);
 });
 
-test('gradeLightmap reaches dawn/dusk warm tint near ambient 0.55', () => {
-  const t = gradeLightmap(0.55);
-  assert.equal(t.r, DAWN_DUSK_TINT.r);
-  assert.equal(t.g, DAWN_DUSK_TINT.g);
-  assert.equal(t.b, DAWN_DUSK_TINT.b);
+test('gradeLightmap reaches dawn warm tint at ambient 0.42 in morning', () => {
+  const t = gradeLightmap(0.42, morningTime);
+  assert.ok(Math.abs(t.r - DAWN_TINT.r) < 1e-6, `r ${t.r}`);
+  assert.ok(Math.abs(t.g - DAWN_TINT.g) < 1e-6, `g ${t.g}`);
+  assert.ok(Math.abs(t.b - DAWN_TINT.b) < 1e-6, `b ${t.b}`);
 });
 
-test('gradeLightmap blends night → neutral around ambient 0.4', () => {
-  const t = gradeLightmap(0.4);
-  // At ambient = 0.4 the night→neutral lerp lands on neutral.
-  assert.ok(Math.abs(t.r - NEUTRAL_TINT.r) < 1e-6, `r ${t.r}`);
-  assert.ok(Math.abs(t.g - NEUTRAL_TINT.g) < 1e-6, `g ${t.g}`);
-  assert.ok(Math.abs(t.b - NEUTRAL_TINT.b) < 1e-6, `b ${t.b}`);
+test('gradeLightmap reaches dusk warm tint at ambient 0.42 in evening', () => {
+  const t = gradeLightmap(0.42, eveningTime);
+  assert.ok(Math.abs(t.r - DUSK_TINT.r) < 1e-6, `r ${t.r}`);
+  assert.ok(Math.abs(t.g - DUSK_TINT.g) < 1e-6, `g ${t.g}`);
+  assert.ok(Math.abs(t.b - DUSK_TINT.b) < 1e-6, `b ${t.b}`);
 });
 
-test('gradeLightmap warm tint pulls red above blue', () => {
-  // Sanity check on the dawn/dusk tint shape: red dominates, blue attenuates.
-  const t = gradeLightmap(0.55);
-  assert.ok(t.r > t.b, `expected r=${t.r} > b=${t.b}`);
-  assert.ok(t.r > t.g, `expected r=${t.r} > g=${t.g}`);
+test('gradeLightmap reaches day tint at ambient 0.62', () => {
+  const t = gradeLightmap(0.62, morningTime);
+  assert.ok(Math.abs(t.r - DAY_TINT.r) < 1e-6, `r ${t.r}`);
+  assert.ok(Math.abs(t.g - DAY_TINT.g) < 1e-6, `g ${t.g}`);
+  assert.ok(Math.abs(t.b - DAY_TINT.b) < 1e-6, `b ${t.b}`);
+});
+
+test('gradeLightmap warm tint pulls red above blue at the warm shoulder', () => {
+  const morn = gradeLightmap(0.5, morningTime);
+  const eve = gradeLightmap(0.5, eveningTime);
+  for (const t of [morn, eve]) {
+    assert.ok(t.r > t.b, `expected r=${t.r} > b=${t.b}`);
+    assert.ok(t.r > t.g, `expected r=${t.r} > g=${t.g}`);
+  }
+});
+
+test('dusk reads warmer/redder than dawn', () => {
+  const dawn = gradeLightmap(0.42, morningTime);
+  const dusk = gradeLightmap(0.42, eveningTime);
+  // Dusk drops green and blue further than dawn, so r/g and r/b ratios are higher.
+  assert.ok(dusk.b < dawn.b, `dusk b=${dusk.b} should be < dawn b=${dawn.b}`);
+  assert.ok(dusk.g < dawn.g, `dusk g=${dusk.g} should be < dawn g=${dawn.g}`);
 });
 
 test('gradeLightmap night tint pulls blue above red', () => {
   const t = gradeLightmap(0);
   assert.ok(t.b > t.r, `expected b=${t.b} > r=${t.r}`);
   assert.ok(t.b > t.g, `expected b=${t.b} > g=${t.g}`);
+});
+
+test('deep night is bluer than the night shoulder', () => {
+  const deep = gradeLightmap(0);
+  const night = gradeLightmap(0.28);
+  assert.ok(deep.r < night.r, `deep r=${deep.r} should be < night r=${night.r}`);
+  assert.ok(deep.g < night.g, `deep g=${deep.g} should be < night g=${night.g}`);
 });
 
 test('gradeLightmap clamps invalid input', () => {
@@ -82,9 +119,18 @@ test('gradeLightmap clamps invalid input', () => {
 
 test('gradeLightmap returns a tint per channel in [0, 1]', () => {
   for (let a = 0; a <= 1; a += 0.05) {
-    const t = gradeLightmap(a);
-    for (const ch of ['r', 'g', 'b']) {
-      assert.ok(t[ch] >= 0 && t[ch] <= 1, `${ch} at a=${a} = ${t[ch]} out of [0,1]`);
+    for (const dt of [null, morningTime, eveningTime]) {
+      const t = gradeLightmap(a, dt);
+      for (const ch of ['r', 'g', 'b']) {
+        assert.ok(t[ch] >= 0 && t[ch] <= 1, `${ch} at a=${a} dt=${dt} = ${t[ch]} out of [0,1]`);
+      }
     }
   }
+});
+
+test('gradeLightmap defaults to dawn tint when dayTime is missing', () => {
+  const noTime = gradeLightmap(0.42);
+  assert.ok(Math.abs(noTime.r - DAWN_TINT.r) < 1e-6);
+  assert.ok(Math.abs(noTime.g - DAWN_TINT.g) < 1e-6);
+  assert.ok(Math.abs(noTime.b - DAWN_TINT.b) < 1e-6);
 });


### PR DESCRIPTION
Decouple villager night-behavior thresholds from the visual dusk/dawn
shoulders so dawn and dusk feel atmospheric without the simulation
treating them as full night. Split the warm shoulder into morning/dawn
(pale gold) and evening/dusk (deeper amber), add a deeper-blue night
floor, and lengthen the readable daylight band.

- NIGHT_AMBIENT_THRESHOLD: 0.6 -> 0.42, DAWN_AMBIENT_THRESHOLD: 0.68 -> 0.58
- LIGHTING: brighter exposure (1.08), softer night floor (0.38), higher
  light cap (1.45)
- New tints: DEEP_NIGHT, NIGHT (cooler), DAWN, DUSK, DAY (warmer)
- gradeLightmap takes dayTime to pick DAWN vs DUSK in the warm band