### PR TITLE
Overhaul UI for vertical-phone form factor

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
-<title>AI Village — Pixel Edition v3 (Mobile)</title>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"/>
+<meta name="theme-color" content="#0b0d12"/>
+<title>AI Village</title>
 <link rel="stylesheet" href="styles.css">
 <!-- Enable the DebugKit overlay by visiting the page with ?debug=1 or setting localStorage.debug to true. -->
 <script src="bootstrap.js" defer></script>
@@ -13,52 +14,61 @@
 </head>
 <body>
 <canvas id="game"></canvas>
-<div id="version">
-  AI Village v3.1 (diag)
+
+<div class="hud-top" id="hud-top">
+  <div class="resources" id="stats" role="status" aria-live="polite">
+    <span class="res res--food"><span class="res__icon" aria-hidden="true">🍞</span><span id="food">0</span></span>
+    <span class="res res--wood"><span class="res__icon" aria-hidden="true">🪵</span><span id="wood">0</span></span>
+    <span class="res res--stone"><span class="res__icon" aria-hidden="true">🪨</span><span id="stone">0</span></span>
+    <span class="res res--pelt"><span class="res__icon" aria-hidden="true">🦊</span><span id="pelt">0</span></span>
+    <span class="res res--pop"><span class="res__icon" aria-hidden="true">👥</span><span id="pop">0</span></span>
+  </div>
 </div>
 
-  <div class="hud-top">
-    <div class="pill pill-stats" id="stats">
-      <div class="stat">🍞 <span id="food">0</span><small>food</small></div>
-      <div class="stat">🪵 <span id="wood">0</span><small>wood</small></div>
-      <div class="stat">🪨 <span id="stone">0</span><small>stone</small></div>
-      <div class="stat">🦊 <span id="pelt">0</span><small>pelts</small></div>
-      <div class="stat">👥 <span id="pop">0</span><small>pop</small></div>
-    </div>
-    <div class="pill pill-controls">
-      <button class="btn" id="btnPause">⏸</button>
-      <button class="btn" id="btnSpeed">1×</button>
-      <button class="btn" id="btnPrior">Priorities</button>
-      <button class="btn" id="btnSave">💾</button>
-      <button class="btn" id="btnNew">🗺️ New</button>
-    </div>
-  </div>
+<nav class="hud-dock" id="hud-dock" aria-label="Controls">
+  <button class="dock-btn" id="btnPause" aria-label="Pause">⏸</button>
+  <button class="dock-btn" id="btnSpeed" aria-label="Speed">1×</button>
+  <button class="dock-btn dock-btn--primary" id="btnMenu" aria-label="Menu">☰</button>
+</nav>
 
-<div class="sheet" id="sheetPrior">
+<div class="sheet" id="sheetMenu" role="dialog" aria-labelledby="sheetMenuTitle" aria-hidden="true">
   <div class="sheet-handle" aria-hidden="true"></div>
-  <h3>Village Priorities <button class="sheet-close" aria-label="Close">✕</button></h3>
-  <div class="priorities-columns">
-    <div class="priorities-column">
-      <div class="priorities-label">Food</div>
-      <input type="range" id="prioFood" class="slider" min="0" max="100" value="70">
-    </div>
-    <div class="priorities-column">
-      <div class="priorities-label">Build</div>
-      <input type="range" id="prioBuild" class="slider" min="0" max="100" value="50">
-    </div>
-    <div class="priorities-column">
-      <div class="priorities-label">Explore</div>
-      <input type="range" id="prioExplore" class="slider" min="0" max="100" value="30">
-    </div>
+  <h3 id="sheetMenuTitle">Menu <button class="sheet-close" aria-label="Close">✕</button></h3>
+  <div class="menu-grid">
+    <button class="menu-item" id="btnPrior"><span class="menu-item__icon" aria-hidden="true">⚖️</span><span class="menu-item__label">Priorities</span></button>
+    <button class="menu-item" id="btnSave"><span class="menu-item__icon" aria-hidden="true">💾</span><span class="menu-item__label">Save</span></button>
+    <button class="menu-item" id="btnNew"><span class="menu-item__icon" aria-hidden="true">🗺️</span><span class="menu-item__label">New world</span></button>
+    <button class="menu-item" id="btnHelp"><span class="menu-item__icon" aria-hidden="true">❓</span><span class="menu-item__label">Help</span></button>
   </div>
 </div>
 
-<div id="help">
-  <div class="help-title">Pixel Edition v3 — Quickstart</div>
-  - Pinch to <b>zoom</b>, drag with one finger to <b>pan</b>.<br/>
-  - Villagers now decide which buildings and zones to add; focus on priorities.<br/>
-  - If you saw a blank screen previously, this build fixes camera scaling.<br/>
-  <button class="btn" id="btnHelpClose">Got it</button>
+<div class="sheet" id="sheetPrior" role="dialog" aria-labelledby="sheetPriorTitle" aria-hidden="true">
+  <div class="sheet-handle" aria-hidden="true"></div>
+  <h3 id="sheetPriorTitle">Priorities <button class="sheet-close" aria-label="Close">✕</button></h3>
+  <div class="priorities">
+    <label class="prio">
+      <span class="prio__label">🍞 Food</span>
+      <input type="range" id="prioFood" class="slider" min="0" max="100" value="70">
+    </label>
+    <label class="prio">
+      <span class="prio__label">🛠️ Build</span>
+      <input type="range" id="prioBuild" class="slider" min="0" max="100" value="50">
+    </label>
+    <label class="prio">
+      <span class="prio__label">🧭 Explore</span>
+      <input type="range" id="prioExplore" class="slider" min="0" max="100" value="30">
+    </label>
+  </div>
+</div>
+
+<div class="help-card" id="help" hidden>
+  <div class="help-card__title">Welcome to AI Village</div>
+  <ul class="help-card__list">
+    <li>Pinch to zoom, drag with one finger to pan.</li>
+    <li>Tap <b>☰</b> to save, start a new world, or tune Priorities.</li>
+    <li>Villagers decide where to build — guide them with priorities, not direct orders.</li>
+  </ul>
+  <button class="btn btn--primary" id="btnHelpClose">Got it</button>
 </div>
 
 <script type="module" src="./src/main.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -1148,7 +1148,7 @@ function boot(){
     openMode('inspect');            // UI init
     if(!Storage.get('aiv_help_px3')){
       const helpEl = el('help');
-      if (helpEl) helpEl.style.display='block';
+      if (helpEl) helpEl.removeAttribute('hidden');
     }
   } catch (e){
     reportFatal(e);

--- a/src/app/ui.js
+++ b/src/app/ui.js
@@ -23,10 +23,7 @@ export function createUISystem(deps) {
 
   const host = document.createElement('div');
   host.id = 'toastHost';
-  host.style.cssText = `
-    position:fixed; top:72px; left:50%; transform:translateX(-50%);
-    display:flex; flex-direction:column; gap:8px; z-index:5000; pointer-events:none;
-  `;
+  host.className = 'toast-host';
   document.body.appendChild(host);
 
   const Toast = (() => {
@@ -44,12 +41,6 @@ export function createUISystem(deps) {
       const node = document.createElement('div');
       node.className = 'toast';
       node.textContent = text;
-      node.style.cssText = `
-        background: rgba(20,24,33,0.96);
-        border:1px solid rgba(255,255,255,0.12);
-        color:#e9f1ff; font-weight:700; font-size:14px;
-        border-radius:12px; padding:10px 14px; box-shadow:0 6px 18px rgba(0,0,0,.35);
-      `;
       host.appendChild(node);
       setTimeout(() => {
         node.style.transition = 'opacity .2s ease, transform .2s ease';
@@ -74,13 +65,6 @@ export function createUISystem(deps) {
       if (root) {
         root.setAttribute('data-mode', nextMode);
       }
-
-      const modeButtons = document.querySelectorAll('[data-mode]');
-      modeButtons.forEach((btn) => {
-        const active = btn.dataset.mode === nextMode;
-        btn.classList.toggle('active', active);
-        btn.setAttribute('aria-pressed', active ? 'true' : 'false');
-      });
     }
 
     if (typeof canvas !== 'undefined' && canvas && canvas.style) {
@@ -94,16 +78,25 @@ export function createUISystem(deps) {
     const node = document.getElementById(id);
     if (!node) return;
     node.setAttribute('data-open', open ? 'true' : 'false');
+    node.setAttribute('aria-hidden', open ? 'false' : 'true');
+  }
+
+  function closeAllSheets() {
+    toggleSheet('sheetMenu', false);
+    toggleSheet('sheetPrior', false);
   }
 
   const uiRefs = {
     btnPause: el('btnPause'),
     btnSpeed: el('btnSpeed'),
+    btnMenu: el('btnMenu'),
     btnPrior: el('btnPrior'),
     btnSave: el('btnSave'),
     btnNew: el('btnNew'),
+    btnHelp: el('btnHelp'),
     btnHelpClose: el('btnHelpClose'),
     help: el('help'),
+    sheetMenu: el('sheetMenu'),
     sheetPrior: el('sheetPrior'),
     prioFood: el('prioFood'),
     prioBuild: el('prioBuild'),
@@ -127,8 +120,15 @@ export function createUISystem(deps) {
     time.speedIdx = (time.speedIdx + 1) % SPEEDS.length;
     syncTimeButtons();
   }
+  function onMenuClick() {
+    if (!uiRefs.sheetMenu) return;
+    const open = uiRefs.sheetMenu.getAttribute('data-open') === 'true';
+    if (!open) toggleSheet('sheetPrior', false);
+    toggleSheet('sheetMenu', !open);
+  }
   function onPriorClick() {
     if (!uiRefs.sheetPrior) return;
+    toggleSheet('sheetMenu', false);
     const open = uiRefs.sheetPrior.getAttribute('data-open') === 'true';
     toggleSheet('sheetPrior', !open);
   }
@@ -136,21 +136,31 @@ export function createUISystem(deps) {
     if (!Storage.available) { Toast.show('Saving disabled in this context'); return; }
     saveGame();
     Toast.show('Saved.');
+    toggleSheet('sheetMenu', false);
   }
-  function onNewClick() { newWorld(); }
+  function onNewClick() {
+    newWorld();
+    toggleSheet('sheetMenu', false);
+  }
+  function onHelpOpenClick() {
+    toggleSheet('sheetMenu', false);
+    if (!uiRefs.help) return;
+    uiRefs.help.removeAttribute('hidden');
+  }
   function onHelpCloseClick() {
     if (!uiRefs.help) return;
-    uiRefs.help.style.display = 'none';
+    uiRefs.help.setAttribute('hidden', '');
     Storage.set('aiv_help_px3', '1');
+  }
+  function onSheetMenuClick(e) {
+    if (e.target.closest('.sheet-close')) toggleSheet('sheetMenu', false);
   }
   function onSheetPriorClick(e) {
     if (e.target.closest('.sheet-close')) toggleSheet('sheetPrior', false);
   }
   function onDocumentClick(e) {
-    const modeBtn = e.target.closest('[data-mode]');
-    if (modeBtn) { openMode(modeBtn.dataset.mode || 'inspect'); return; }
-    if (e.target.closest('.sheet') || e.target.closest('.pill-controls')) return;
-    toggleSheet('sheetPrior', false);
+    if (e.target.closest('.sheet') || e.target.closest('.hud-dock') || e.target.closest('.help-card')) return;
+    closeAllSheets();
   }
   function onKeyDown(e) {
     if ((e.key === 'l' || e.key === 'L') && e.altKey) {
@@ -167,10 +177,13 @@ export function createUISystem(deps) {
     if (uiListenersBound) return;
     safeOn(uiRefs.btnPause, 'click', onPauseClick);
     safeOn(uiRefs.btnSpeed, 'click', onSpeedClick);
+    safeOn(uiRefs.btnMenu, 'click', onMenuClick);
     safeOn(uiRefs.btnPrior, 'click', onPriorClick);
     safeOn(uiRefs.btnSave, 'click', onSaveClick);
     safeOn(uiRefs.btnNew, 'click', onNewClick);
+    safeOn(uiRefs.btnHelp, 'click', onHelpOpenClick);
     safeOn(uiRefs.btnHelpClose, 'click', onHelpCloseClick);
+    safeOn(uiRefs.sheetMenu, 'click', onSheetMenuClick);
     safeOn(uiRefs.sheetPrior, 'click', onSheetPriorClick);
     document.addEventListener('click', onDocumentClick);
     window.addEventListener('keydown', onKeyDown);
@@ -183,10 +196,13 @@ export function createUISystem(deps) {
     if (!uiListenersBound) return;
     safeOff(uiRefs.btnPause, 'click', onPauseClick);
     safeOff(uiRefs.btnSpeed, 'click', onSpeedClick);
+    safeOff(uiRefs.btnMenu, 'click', onMenuClick);
     safeOff(uiRefs.btnPrior, 'click', onPriorClick);
     safeOff(uiRefs.btnSave, 'click', onSaveClick);
     safeOff(uiRefs.btnNew, 'click', onNewClick);
+    safeOff(uiRefs.btnHelp, 'click', onHelpOpenClick);
     safeOff(uiRefs.btnHelpClose, 'click', onHelpCloseClick);
+    safeOff(uiRefs.sheetMenu, 'click', onSheetMenuClick);
     safeOff(uiRefs.sheetPrior, 'click', onSheetPriorClick);
     document.removeEventListener('click', onDocumentClick);
     window.removeEventListener('keydown', onKeyDown);
@@ -200,11 +216,6 @@ export function createUISystem(deps) {
   const activePointers = new Map();
   let primaryPointer = null;
   let pinch = null;
-
-  const dbg = document.createElement('div');
-  dbg.style.cssText = 'position:fixed;left:8px;bottom:8px;z-index:5000;color:#9cb2cc;font:12px system-ui;pointer-events:none';
-  document.body.appendChild(dbg);
-  const setDbg = (s) => dbg.textContent = s;
 
   function pointerScale() {
     const r = canvas.getBoundingClientRect();
@@ -224,7 +235,6 @@ export function createUISystem(deps) {
   function toTile(v) { return Math.floor(v); }
 
   function onPointerDown(e) {
-    setDbg(`down ${e.pointerType} mode=${ui.mode}`);
     activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY, type: e.pointerType });
     canvas.setPointerCapture(e.pointerId);
     if (e.pointerType === 'touch' && activePointers.size === 2) {

--- a/styles.css
+++ b/styles.css
@@ -9,10 +9,24 @@
   --accent-2: #9c7cff;
   --accent-soft: rgba(124, 196, 255, 0.16);
   --glow: 0 10px 40px rgba(124, 196, 255, 0.15);
+
+  --tap: 48px;
+  --gap: 10px;
+  --radius: 14px;
+  --radius-sm: 10px;
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-bot: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+
+  --hud-edge: 8px;
+  --pill-bg: rgba(20, 24, 33, 0.92);
+  --pill-border: rgba(255, 255, 255, 0.12);
 }
 
-html,
-body {
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
   margin: 0;
   padding: 0;
   height: 100%;
@@ -23,9 +37,20 @@ body {
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial;
   overflow: hidden;
   -webkit-tap-highlight-color: transparent;
+  overscroll-behavior: none;
 }
 
-/* canvas always clickable */
+button {
+  font-family: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 #game {
   position: fixed;
   inset: 0;
@@ -39,140 +64,173 @@ body {
   z-index: 0;
 }
 
-/* HUD containers ignore taps by default; only their children accept them */
-.hud-top {
-  pointer-events: none;
-}
-
-.hud-top > * {
-  pointer-events: auto;
-}
+/* Top resource strip */
 
 .hud-top {
   position: fixed;
-  left: 10px;
-  right: 10px;
-  top: max(10px, env(safe-area-inset-top));
+  top: calc(var(--hud-edge) + var(--safe-top));
+  left: calc(var(--hud-edge) + var(--safe-left));
+  right: calc(var(--hud-edge) + var(--safe-right));
   display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
+  justify-content: center;
+  pointer-events: none;
   z-index: 3000;
 }
 
-.hud-top .pill {
-  max-width: 100%;
-  overflow: hidden;
-}
-
-.pill {
+.resources {
   pointer-events: auto;
-  background: rgba(20, 24, 33, 0.9);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 14px;
-  padding: 10px 12px;
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
+  width: 100%;
+  max-width: 600px;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 4px;
+  padding: 6px;
+  background: var(--pill-bg);
+  border: 1px solid var(--pill-border);
+  border-radius: var(--radius);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
   backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   background-image: linear-gradient(145deg, rgba(124, 196, 255, 0.08), transparent 35%);
 }
 
-.stat {
-  display: flex;
+.res {
+  display: inline-flex;
   align-items: center;
-  gap: 6px;
+  justify-content: center;
+  gap: 4px;
+  min-width: 0;
+  padding: 6px 4px;
+  font-size: 13px;
   font-weight: 700;
-  font-size: 14px;
+  border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  padding: 8px 10px;
-  border-radius: 12px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.stat small {
-  color: var(--muted);
-  font-weight: 600;
-  margin-left: 4px;
+.res__icon {
+  font-size: 14px;
+  line-height: 1;
+  flex-shrink: 0;
 }
 
-#stats {
-  width: min(560px, 100%);
+.res--food { border-color: rgba(124, 196, 255, 0.40); background: rgba(124, 196, 255, 0.10); }
+.res--wood { border-color: rgba(148, 255, 214, 0.32); background: rgba(148, 255, 214, 0.10); }
+.res--stone { border-color: rgba(255, 196, 124, 0.32); background: rgba(255, 196, 124, 0.10); }
+.res--pelt { border-color: rgba(156, 124, 255, 0.40); background: rgba(156, 124, 255, 0.12); }
+.res--pop { border-color: rgba(255, 255, 255, 0.16); background: rgba(255, 255, 255, 0.06); }
+
+/* Bottom action dock */
+
+.hud-dock {
+  position: fixed;
+  left: calc(var(--hud-edge) + var(--safe-left));
+  right: calc(var(--hud-edge) + var(--safe-right));
+  bottom: calc(var(--hud-edge) + var(--safe-bot));
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  z-index: 3000;
+  pointer-events: none;
 }
 
-.pill-stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 10px;
+.hud-dock > * {
+  pointer-events: auto;
 }
 
-.pill-stats .stat:nth-child(1) {
-  border-color: rgba(124, 196, 255, 0.45);
-  background: rgba(124, 196, 255, 0.10);
+.dock-btn {
+  flex: 1 1 0;
+  min-width: var(--tap);
+  max-width: 140px;
+  height: var(--tap);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--fg);
+  border: 1px solid var(--pill-border);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02)), var(--pill-bg);
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transition: transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
-.pill-stats .stat:nth-child(2) {
-  border-color: rgba(148, 255, 214, 0.35);
-  background: rgba(148, 255, 214, 0.10);
+.dock-btn--primary {
+  border-color: rgba(124, 196, 255, 0.55);
+  background: linear-gradient(180deg, rgba(124, 196, 255, 0.18), rgba(124, 196, 255, 0.04)), var(--pill-bg);
 }
 
-.pill-stats .stat:nth-child(3) {
-  border-color: rgba(255, 196, 124, 0.35);
-  background: rgba(255, 196, 124, 0.10);
+.dock-btn:hover,
+.dock-btn:focus-visible {
+  border-color: rgba(124, 196, 255, 0.6);
+  outline: none;
 }
 
-.pill-stats .stat:nth-child(4) {
-  border-color: rgba(156, 124, 255, 0.45);
-  background: rgba(156, 124, 255, 0.12);
+.dock-btn:active {
+  transform: translateY(1px) scale(0.98);
+  border-color: rgba(124, 196, 255, 0.85);
 }
 
-.pill-controls {
-  gap: 10px;
-  padding: 10px 12px;
-}
+/* Generic button */
 
 .btn {
-  pointer-events: auto;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02)), rgba(27, 35, 48, 0.95);
-  color: var(--fg);
-  border-radius: 12px;
-  padding: 9px 12px;
-  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 40px;
+  padding: 9px 14px;
+  font-weight: 700;
   font-size: 14px;
+  color: var(--fg);
+  border: 1px solid var(--pill-border);
+  border-radius: var(--radius-sm);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02)), rgba(27, 35, 48, 0.95);
   box-shadow: var(--glow);
-  transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
+  transition: transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+}
+
+.btn--primary {
+  background: linear-gradient(180deg, rgba(124, 196, 255, 0.22), rgba(124, 196, 255, 0.06)), rgba(27, 35, 48, 0.95);
+  border-color: rgba(124, 196, 255, 0.55);
 }
 
 .btn:hover,
 .btn:focus-visible {
   border-color: rgba(124, 196, 255, 0.6);
-  box-shadow: 0 6px 20px rgba(124, 196, 255, 0.2);
+  outline: none;
 }
 
 .btn:active {
   transform: translateY(1px) scale(0.99);
 }
 
-/* Sheets only accept taps when open */
+/* Bottom sheet */
+
 .sheet {
-  pointer-events: none;
   position: fixed;
   left: 0;
   right: 0;
   bottom: 0;
+  pointer-events: none;
   transform: translateY(100%);
-  transition: transform 0.2s ease;
-  background: linear-gradient(180deg, rgba(20, 24, 33, 0.96), var(--panel-3));
+  transition: transform 0.22s ease;
+  background: linear-gradient(180deg, rgba(20, 24, 33, 0.98), var(--panel-3));
   border-top: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 16px 16px 0 0;
-  padding: 12px 12px calc(env(safe-area-inset-bottom) + 12px);
-  max-height: 65vh;
+  border-radius: 18px 18px 0 0;
+  padding: 10px calc(16px + var(--safe-right)) calc(env(safe-area-inset-bottom) + 18px) calc(16px + var(--safe-left));
+  max-height: min(72vh, 620px);
   overflow: auto;
-  box-shadow: 0 -14px 40px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 -14px 40px rgba(0, 0, 0, 0.65);
   z-index: 0;
 }
 
@@ -183,155 +241,261 @@ body {
 }
 
 .sheet h3 {
-  margin: 6px 2px 10px;
+  margin: 4px 2px 14px;
   font-size: 16px;
+  font-weight: 700;
   color: var(--muted);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-bottom: 8px;
+  padding-bottom: 10px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.sheet-close {
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--fg);
-  border-radius: 8px;
-  padding: 4px 8px;
-  font-weight: 700;
-}
-
-.grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 10px;
-}
-
-.tile {
-  text-align: center;
-  font-size: 12px;
-  padding: 12px 10px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.10);
-  border-radius: 12px;
-  user-select: none;
-  transition: transform 0.12s ease, border-color 0.12s ease, background 0.12s ease, box-shadow 0.12s ease;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
-}
-.tile:hover,
-.tile:focus-visible {
-  border-color: rgba(124, 196, 255, 0.6);
-  background: rgba(124, 196, 255, 0.12);
-  box-shadow: 0 6px 22px rgba(124, 196, 255, 0.15);
-}
-
-.tile:active {
-  transform: translateY(1px);
-}
-.tile small {
-  display: block;
-  margin-top: 6px;
-  color: var(--muted);
-  font-weight: 600;
-  font-size: 11px;
-  line-height: 1.3;
-}
-
-.slider {
-  appearance: none;
-  width: 100%;
-  height: 8px;
-  border-radius: 999px;
-  background: #2b3544;
-  outline: none;
-}
-
-.slider::-webkit-slider-thumb {
-  appearance: none;
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  background: var(--accent);
-  border: 2px solid rgba(255, 255, 255, 0.35);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
 }
 
 .sheet-handle {
   width: 56px;
-  height: 6px;
+  height: 5px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.18);
-  margin: 0 auto 10px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.22);
+  margin: 4px auto 10px;
 }
 
-/* Any helper/guide panel should not block the map unless explicitly open */
-#help {
-  position: fixed;
-  left: 12px;
-  right: 12px;
-  top: 12px;
-  background: rgba(20, 24, 33, 0.95);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 14px;
-  padding: 14px;
-  font-size: 14px;
-  line-height: 1.5;
-  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.65), var(--glow);
-  display: none;
-  pointer-events: none;
-}
-
-#help button {
-  margin-top: 8px;
-}
-
-#version {
-  position: fixed;
-  left: 8px;
-  top: 8px;
-  z-index: 1;
-  pointer-events: none;
-  color: #9cb2cc;
-  font: 12px system-ui;
-  background: rgba(12, 17, 26, 0.7);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  padding: 6px 8px;
+.sheet-close {
+  min-width: 36px;
+  min-height: 36px;
+  border: 1px solid var(--pill-border);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg);
   border-radius: 10px;
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.55);
+  padding: 6px 10px;
+  font-size: 14px;
+  font-weight: 700;
 }
 
-.priorities-columns {
-  display: flex;
+.sheet-close:active {
+  transform: scale(0.96);
+}
+
+/* Menu grid */
+
+.menu-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   gap: 10px;
 }
 
-.priorities-column {
-  flex: 1;
+.menu-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 76px;
+  padding: 12px 10px;
+  border: 1px solid var(--pill-border);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02)), rgba(27, 35, 48, 0.7);
+  color: var(--fg);
+  font-size: 14px;
+  font-weight: 700;
+  transition: transform 0.12s ease, border-color 0.12s ease, background 0.12s ease;
 }
 
-.priorities-label {
+.menu-item__icon {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.menu-item__label {
+  font-size: 13px;
+  color: var(--fg);
+}
+
+.menu-item:hover,
+.menu-item:focus-visible {
+  border-color: rgba(124, 196, 255, 0.5);
+  background: linear-gradient(180deg, rgba(124, 196, 255, 0.10), rgba(124, 196, 255, 0.02)), rgba(27, 35, 48, 0.85);
+  outline: none;
+}
+
+.menu-item:active {
+  transform: translateY(1px) scale(0.98);
+}
+
+.menu-item:disabled {
+  opacity: 0.55;
+}
+
+/* Priorities sliders */
+
+.priorities {
+  display: grid;
+  gap: 16px;
+  padding: 4px 2px 8px;
+}
+
+.prio {
+  display: grid;
+  grid-template-columns: 92px 1fr;
+  align-items: center;
+  gap: 14px;
+}
+
+.prio__label {
   font-weight: 700;
-  margin-bottom: 4px;
+  font-size: 14px;
   color: var(--muted);
 }
 
-.help-title {
-  font-weight: 700;
-  margin-bottom: 6px;
+.slider {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent-soft), #2b3544);
+  outline: none;
+  border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-@media (max-width: 480px) {
-  .hud-top {
-    gap: 8px;
+.slider::-webkit-slider-thumb {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+  cursor: pointer;
+}
+
+.slider::-moz-range-thumb {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+  cursor: pointer;
+}
+
+/* Help card (first-run + on-demand) */
+
+.help-card {
+  position: fixed;
+  left: 50%;
+  top: calc(var(--safe-top) + 80px);
+  transform: translateX(-50%);
+  width: min(360px, calc(100vw - 24px));
+  background: rgba(20, 24, 33, 0.98);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: var(--radius);
+  padding: 16px;
+  font-size: 14px;
+  line-height: 1.5;
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.65), var(--glow);
+  z-index: 4000;
+}
+
+.help-card[hidden] {
+  display: none;
+}
+
+.help-card__title {
+  font-weight: 800;
+  font-size: 16px;
+  margin-bottom: 8px;
+  color: var(--fg);
+}
+
+.help-card__list {
+  margin: 0 0 14px;
+  padding-left: 18px;
+  color: var(--fg);
+}
+
+.help-card__list li + li {
+  margin-top: 6px;
+}
+
+.help-card .btn {
+  width: 100%;
+  min-height: 44px;
+}
+
+/* Toast host + toasts */
+
+.toast-host {
+  position: fixed;
+  top: calc(var(--safe-top) + 72px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 5000;
+  pointer-events: none;
+  width: min(360px, calc(100vw - 24px));
+  align-items: center;
+}
+
+.toast {
+  background: rgba(20, 24, 33, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--fg);
+  font-weight: 700;
+  font-size: 14px;
+  border-radius: 12px;
+  padding: 10px 14px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+  max-width: 100%;
+  text-align: center;
+}
+
+/* Wider screens: tablets & landscape phones */
+
+@media (min-width: 600px) {
+  :root {
+    --hud-edge: 12px;
   }
 
-  .pill {
-    padding: 6px 8px;
+  .resources {
+    gap: 6px;
+    padding: 8px;
   }
 
-  .hud-top .pill:nth-child(2) {
-    margin-left: auto;
+  .res {
+    font-size: 14px;
+    padding: 8px 6px;
   }
+
+  .res__icon {
+    font-size: 16px;
+  }
+
+  .dock-btn {
+    max-width: 160px;
+    font-size: 18px;
+  }
+}
+
+@media (min-width: 900px) {
+  .hud-dock {
+    justify-content: flex-end;
+  }
+
+  .dock-btn {
+    flex: 0 0 auto;
+    min-width: 64px;
+  }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  .sheet { transition: none; }
+  .dock-btn,
+  .btn,
+  .menu-item { transition: none; }
 }


### PR DESCRIPTION
Replace the wide-screen pill layout with a mobile-first HUD: a single-row
resource strip pinned to the top and a thumb-reachable bottom dock with
pause / speed / menu. Save, New world, Priorities, and Help live in a new
bottom sheet (#sheetMenu) reached via the dock.

Other fixes rolled in:
- Larger 48px touch targets throughout, honoring safe-area insets on all
  four edges so the dock clears the iOS home indicator.
- Replace the always-visible pointer-debug node and dead [data-mode]
  selector code in ui.js (left over from a removed mode picker).
- Move toast styling out of inline cssText into .toast-host / .toast CSS.
- Switch the first-run help card to the `hidden` attribute (CSS rule
  drives visibility) and add a Help entry in the menu so it can be
  re-opened after dismissal. Refresh the stale "blank screen" copy.
- Drop the "v3.1 (diag)" #version badge from the canvas overlay.

All existing IDs (#food/#wood/#stone/#pelt/#pop, #btnPause/#btnSpeed/
#btnPrior/#btnSave/#btnNew/#btnHelpClose, #sheetPrior, #prioFood/Build/
Explore) are preserved, so render.js and the Phase 7 UI tests work
unchanged.

https://claude.ai/code/session_01E3wNJNa3tRjjXo9xnqC7as